### PR TITLE
Fix "_y" attribute behavior for Nearest Neighbors

### DIFF
--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -415,7 +415,7 @@ class KNeighborsMixin(BaseKNeighborsMixin):
             if daal_model is not None or getattr(self, '_tree', 0) is None and \
                     self._fit_method == 'kd_tree':
                 if sklearn_check_version("0.24"):
-                    BaseNeighborsBase._fit(self, self._fit_X, self._y)
+                    BaseNeighborsBase._fit(self, self._fit_X, getattr(self, '_y', None))
                 else:
                     BaseNeighborsBase._fit(self, self._fit_X)
             result = super(KNeighborsMixin, self).kneighbors(
@@ -432,7 +432,7 @@ class RadiusNeighborsMixin(BaseRadiusNeighborsMixin):
         if daal_model is not None or getattr(self, '_tree', 0) is None and \
                 self._fit_method == 'kd_tree':
             if sklearn_check_version("0.24"):
-                BaseNeighborsBase._fit(self, self._fit_X, self._y)
+                BaseNeighborsBase._fit(self, self._fit_X, getattr(self, '_y', None))
             else:
                 BaseNeighborsBase._fit(self, self._fit_X)
         if sklearn_check_version("0.22"):

--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -93,12 +93,15 @@ def daal4py_fit(estimator, X, fptype):
         'k': estimator.n_neighbors,
         'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
         'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
-        'resultsToEvaluate': 'none' if estimator._y is None else 'computeClassLabels'
+        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None else 'computeClassLabels'
     }
     if hasattr(estimator, 'classes_'):
         params['nClasses'] = len(estimator.classes_)
 
-    labels = None if estimator._y is None else estimator._y.reshape(-1, 1)
+    if getattr(estimator, '_y', None) is None:
+        labels = None
+    else:
+        labels = estimator._y.reshape(-1, 1)
 
     method = parse_auto_method(
         estimator, estimator.algorithm,
@@ -167,7 +170,7 @@ def daal4py_kneighbors(estimator, X=None, n_neighbors=None,
         'k': n_neighbors,
         'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
         'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
-        'resultsToEvaluate': 'none' if estimator._y is None else 'computeClassLabels'
+        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None else 'computeClassLabels'
     }
     if hasattr(estimator, 'classes_'):
         params['nClasses'] = len(estimator.classes_)
@@ -323,7 +326,6 @@ class NeighborsBase(BaseNeighborsBase):
             if not X_incorrect_type:
                 X, _ = validate_data(
                     self, X, accept_sparse='csr', dtype=[np.float64, np.float32])
-            self._y = None
 
         if not X_incorrect_type:
             self.n_samples_fit_ = X.shape[0]

--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -93,7 +93,8 @@ def daal4py_fit(estimator, X, fptype):
         'k': estimator.n_neighbors,
         'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
         'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
-        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None else 'computeClassLabels'
+        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None
+        else 'computeClassLabels'
     }
     if hasattr(estimator, 'classes_'):
         params['nClasses'] = len(estimator.classes_)
@@ -170,7 +171,8 @@ def daal4py_kneighbors(estimator, X=None, n_neighbors=None,
         'k': n_neighbors,
         'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
         'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
-        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None else 'computeClassLabels'
+        'resultsToEvaluate': 'none' if getattr(estimator, '_y', None) is None
+        else 'computeClassLabels'
     }
     if hasattr(estimator, 'classes_'):
         params['nClasses'] = len(estimator.classes_)


### PR DESCRIPTION
# Description
Different "_y" attribute behavior of Nearest Neighbors estimator between daal4py and sklearn caused error in [skl2onnx](https://github.com/onnx/sklearn-onnx) while converting model:
```
  File "skl2onnx/convert.py", line 160, in convert_sklearn
    onnx_model = convert_topology(topology, name, doc_string, target_opset,
  File "skl2onnx/common/_topology.py", line 1087, in convert_topology
    conv(scope, operator, container)
  File "skl2onnx/common/_registration.py", line 29, in __call__
    return self._fct(*args)
  File "skl2onnx/operator_converters/nearest_neighbours.py", line 520, in convert_nearest_neighbors_transform
    many = _convert_nearest_neighbors(operator, container)
  File "skl2onnx/operator_converters/nearest_neighbours.py", line 213, in _convert_nearest_neighbors
    single_reg = (not hasattr(op, '_y') or len(op._y.shape) == 1 or
AttributeError: 'NoneType' object has no attribute 'shape'
```

While '_y' doesn't exist in sklearn NearestNeighbors, daal4py has _y = None.
Code to check it:
```python
from daal4py.sklearn.neighbors import NearestNeighbors as NND4P
from sklearn.neighbors import NearestNeighbors as NNSKL
import numpy as np


def check_y(nn_class, train_data, test_data):
    def print_y(e, msg):
        print(msg)
        if hasattr(e, '_y'):
            print('\t\thas attribute _y:', e._y)
        else:
            print('\t\thasn\'t attribute _y')

    estimator = nn_class()
    print(f'{estimator.__class__}:')
    print_y(estimator, '\tafter init:')
    estimator.fit(train_data)
    print_y(estimator, '\tafter fit:')
    estimator.kneighbors(test_data)
    print_y(estimator, '\tafter kneighbors:')


data = np.random.uniform(size=(20, 2))
train_data, test_data = data[:10], data[10:]
check_y(NND4P, train_data, test_data)
check_y(NNSKL, train_data, test_data)
```
It's output:
```
<class 'daal4py.sklearn.neighbors._unsupervised.NearestNeighbors'>:
        after init:
                hasn't attribute _y
        after fit:
                has attribute _y: None
        after kneighbors:
                has attribute _y: None
<class 'sklearn.neighbors._unsupervised.NearestNeighbors'>:
        after init:
                hasn't attribute _y
        after fit:
                hasn't attribute _y
        after kneighbors:
                hasn't attribute _y
```