### PR TITLE
to_daal_nt: shared pointer changed to raw pointer

### DIFF
--- a/src/oneapi/oneapi_backend.cpp
+++ b/src/oneapi/oneapi_backend.cpp
@@ -160,7 +160,7 @@ daal::data_management::NumericTablePtr * to_daal_nt(void * ptr, int * shape)
 #if INTEL_DAAL_VERSION >= 20210200
         auto * usm_ptr = reinterpret_cast<daal::services::SharedPtr<T> *>(ptr);
         // we need to return a pointer to safely cross language boundaries
-        return new daal::data_management::NumericTablePtr(TBL_T::create(*usm_ptr, shape[1], shape[0], get_current_queue()));
+        return new daal::data_management::NumericTablePtr(TBL_T::create(usm_ptr->get(), shape[1], shape[0], get_current_queue()));
 #else
         auto * buffer = reinterpret_cast<sycl::buffer<T> *>(ptr);
         return new daal::data_management::NumericTablePtr(TBL_T::create(*buffer, shape[1], shape[0]));


### PR DESCRIPTION
Changed the logic of creating SyclNumericTables from `sycl_buffer`: now it is created from raw USM pointer not to hold the reference to the data. 
This is needed for https://github.com/oneapi-src/oneDAL/pull/1603 to properly free the SYCL RT resources on Windows. 

 
