### PR TITLE
Fix of oneapi module import for python 3.8, 3.9

### DIFF
--- a/daal4py/oneapi/__init__.py
+++ b/daal4py/oneapi/__init__.py
@@ -28,7 +28,8 @@ if "Windows" in platform.system():
 
     if sys.version_info.minor >= 8:
         os.add_dll_directory(current_path)
-        os.add_dll_directory(installed_package_path)
+        if os.path.exists(installed_package_path):
+            os.add_dll_directory(installed_package_path)
     os.environ['PATH'] = current_path + os.pathsep + os.environ['PATH']
     os.environ['PATH'] = installed_package_path + os.pathsep + os.environ['PATH']
 


### PR DESCRIPTION
Before adding new dll path of the module probably installed in site-packages, first, we ensure that the path exists 

 
