### PR TITLE
Export enableThreadPinning

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -159,6 +159,7 @@ cdef extern from "daal4py_cpp.h":
     cdef size_t c_num_threads() except +
     cdef size_t c_num_procs() except +
     cdef size_t c_my_procid() except +
+    cdef void c_enable_thread_pinning(bool enabled) except +
 
 
 def daalinit(nthreads = -1):
@@ -176,6 +177,8 @@ def num_procs():
 def my_procid():
     return c_my_procid()
 
+def enable_thread_pinning(enabled=True):
+    c_enable_thread_pinning(enabled)
 
 def get_data(x):
     if isinstance(x, pdDataFrame):

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -824,6 +824,11 @@ extern "C"
         return 0;
 #endif
     }
+
+    void c_enable_thread_pinning(bool enabled)
+    {
+        daal::services::Environment::getInstance()->enableThreadPinning(enabled);
+    }
 } // extern "C"
 
 bool c_assert_all_finite(const data_or_file & t, bool allowNaN, char dtype)

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -63,6 +63,7 @@ void c_daalfini();
 size_t c_num_threads();
 size_t c_num_procs();
 size_t c_my_procid();
+void c_enable_thread_pinning(bool enabled=true);
 }
 
 using daal::data_management::NumericTablePtr;


### PR DESCRIPTION
# Description

Some application may get performance improvement by binding threads.And there is a way for `daal` to enable it which is not export to `daal4py`.

Changes proposed in this pull request:
- export `daal::services::Environment::getInstance()->enableThreadPinning` to daal4py.

 
