### PR TITLE
New python interfaces: policy support

### DIFF
--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -14,4 +14,6 @@
 # limitations under the License.
 #===============================================================================
 
-__all__ = ['svm', 'prims']
+from ._config import get_config
+
+__all__ = ['svm', 'prims', 'get_config']

--- a/onedal/_config.py
+++ b/onedal/_config.py
@@ -14,17 +14,24 @@
 # limitations under the License.
 #===============================================================================
 
-try:
-    from _onedal4py_dpc import (
-        PyPolicy
-    )
-except ImportError:
-    from _onedal4py_host import (
-        PyPolicy
-    )
+def get_config():
+    """Retrieve current values of global configuration
+    Returns
+    -------
+    config : dict
+        Keys are parameter names
+    """
+    import sys
+    if 'daal4py.oneapi' in sys.modules:
+        import daal4py.oneapi as d4p_oneapi
+        devname = d4p_oneapi._get_device_name_sycl_ctxt()
+        params = d4p_oneapi._get_sycl_ctxt_params()
 
-from onedal import get_config
-
-def _get_current_policy():
-    config = get_config()
-    return PyPolicy(config.get('target_offload', 'host'))
+        return {
+            'target_offload': 'host' if devname == 'cpu' else devname,
+            'allow_fallback_to_host': params.get('host_offload_on_fail', False)
+        }
+    return {
+        'target_offload': None,
+        'allow_fallback_to_host': False
+    }

--- a/onedal/common/__init__.py
+++ b/onedal/common/__init__.py
@@ -29,7 +29,11 @@ from .validation import (
     _num_features
 )
 
+from .policy import (
+    _get_current_policy
+)
+
 __all__ = ['_column_or_1d', '_validate_targets', '_check_X_y',
            '_check_array', '_get_sample_weight', '_check_is_fitted',
            '_check_classification_targets', '_type_of_target', '_is_integral_float',
-           '_is_multilabel', '_check_n_features', '_num_features']
+           '_is_multilabel', '_check_n_features', '_num_features', '_get_current_policy']

--- a/onedal/common/backend/compute.h
+++ b/onedal/common/backend/compute.h
@@ -16,33 +16,14 @@
 
 #pragma once
 
-#ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
-#endif
-
-#ifdef DPCTL_ENABLE
-#include "dpctl_sycl_types.h"
-#include "dpctl_sycl_queue_manager.h"
-#endif
+#include "common/backend/policy.h"
 
 namespace oneapi::dal::python {
+
 template <typename... Args>
-auto compute(Args &&... args) {
-#if defined(DPCTL_ENABLE)
-    auto dpctl_queue = DPCTLQueueMgr_GetCurrentQueue();
-    if (dpctl_queue != NULL) {
-        cl::sycl::queue &sycl_queue = *reinterpret_cast<cl::sycl::queue *>(dpctl_queue);
-        return dal::compute(sycl_queue, std::forward<Args>(args)...);
-    }
-    else {
-        throw std::runtime_error("Cannot set daal context: Pointer to queue object is NULL");
-    }
-#elif defined(ONEDAL_DATA_PARALLEL)
-    cl::sycl::queue sycl_queue(sycl::host_selector{});
-    return dal::compute(sycl_queue, std::forward<Args>(args)...);
-#else
-    return dal::compute(std::forward<Args>(args)...);
-#endif
+auto compute(const policy* policy, Args &&... args) {
+    ONEDAL_ASSERT(policy, "policy object is null");
+    return policy->compute(std::forward<Args>(args)...);
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/common/backend/infer.h
+++ b/onedal/common/backend/infer.h
@@ -16,35 +16,14 @@
 
 #pragma once
 
-#include <numpy/arrayobject.h>
-
-#ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
-#endif
-
-#ifdef DPCTL_ENABLE
-#include "dpctl_sycl_types.h"
-#include "dpctl_sycl_queue_manager.h"
-#endif
+#include "common/backend/policy.h"
 
 namespace oneapi::dal::python {
+
 template <typename... Args>
-auto infer(Args &&... args) {
-#if defined(DPCTL_ENABLE)
-    auto dpctl_queue = DPCTLQueueMgr_GetCurrentQueue();
-    if (dpctl_queue != NULL) {
-        cl::sycl::queue &sycl_queue = *reinterpret_cast<cl::sycl::queue *>(dpctl_queue);
-        return dal::infer(sycl_queue, std::forward<Args>(args)...);
-    }
-    else {
-        throw std::runtime_error("Cannot set daal context: Pointer to queue object is NULL");
-    }
-#elif defined(ONEDAL_DATA_PARALLEL)
-    cl::sycl::queue sycl_queue(sycl::host_selector{});
-    return dal::infer(sycl_queue, std::forward<Args>(args)...);
-#else
-    return dal::infer(std::forward<Args>(args)...);
-#endif
+auto infer(const policy* policy, Args &&... args) {
+    ONEDAL_ASSERT(policy, "policy object is null");
+    return policy->infer(std::forward<Args>(args)...);
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/common/backend/policy.cpp
+++ b/onedal/common/backend/policy.cpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/backend/policy.h"
+
+namespace oneapi::dal::python {
+
+policy::policy(const std::string& device_name) {
+    if (device_name == "host") {
+        impl_ = std::shared_ptr<policy_impl>(new host_policy_impl());
+    }
+#ifdef ONEDAL_DATA_PARALLEL
+    else if (device_name == "gpu") {
+        sycl::queue queue { sycl::gpu_selector() };
+        impl_ = std::shared_ptr<policy_impl>(new data_parallel_policy_impl(queue));
+    }
+#endif
+    else {
+        throw std::runtime_error("Unexpected device_name");
+    }
+}
+
+} // namespace oneapi::dal::python

--- a/onedal/common/backend/policy.h
+++ b/onedal/common/backend/policy.h
@@ -1,0 +1,74 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#ifdef ONEDAL_DATA_PARALLEL
+#include <CL/sycl.hpp>
+#endif
+
+#include "oneapi/dal/train.hpp"
+#include "oneapi/dal/infer.hpp"
+#include "oneapi/dal/compute.hpp"
+
+#include "common/backend/policy_impl.h"
+
+namespace oneapi::dal::python {
+
+#define FuncCaller(func_name) [](auto&&... args) { return func_name(std::forward<decltype(args)>(args)...); }
+
+class policy {
+public:
+    policy(const std::string& device_name);
+
+    template <typename... Args>
+    auto train(Args &&... args) const {
+        return dispatch_and_run(FuncCaller(dal::train), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    auto infer(Args &&... args) const {
+        return dispatch_and_run(FuncCaller(dal::infer), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    auto compute(Args &&... args) const {
+        return dispatch_and_run(FuncCaller(dal::compute), std::forward<Args>(args)...);
+    }
+
+private:
+    template <typename Func, typename... Args>
+    auto dispatch_and_run(Func func, Args&&... args) const {
+
+        if (impl_->get_kind() == host_policy_impl::kind()) {
+            return func(std::forward<Args>(args)...);
+        }
+#ifdef ONEDAL_DATA_PARALLEL
+        else if (impl_->get_kind() == data_parallel_policy_impl::kind()) {
+            auto* impl_ptr = static_cast<data_parallel_policy_impl*>(impl_.get());
+            sycl::queue queue = impl_ptr->get_queue();
+            return func(queue, std::forward<Args>(args)...);
+        }
+#endif
+        else {
+            throw std::runtime_error("Unknown policy type");
+        }
+    }
+
+    std::shared_ptr<policy_impl> impl_;
+};
+
+} // namespace oneapi::dal::python

--- a/onedal/common/backend/policy.h
+++ b/onedal/common/backend/policy.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#define NO_IMPORT_ARRAY
+
 #ifdef ONEDAL_DATA_PARALLEL
 #include <CL/sycl.hpp>
 #endif
@@ -24,13 +26,14 @@
 #include "oneapi/dal/infer.hpp"
 #include "oneapi/dal/compute.hpp"
 
+#include "common/backend/utils.h"
 #include "common/backend/policy_impl.h"
 
 namespace oneapi::dal::python {
 
 #define FuncCaller(func_name) [](auto&&... args) { return func_name(std::forward<decltype(args)>(args)...); }
 
-class policy {
+class ONEDAL_BACKEND_EXPORT policy {
 public:
     policy(const std::string& device_name);
 

--- a/onedal/common/backend/policy_impl.cpp
+++ b/onedal/common/backend/policy_impl.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/backend/policy.h"
+
+namespace oneapi::dal::python {
+
+static const std::int64_t host_policy_kind = 1;
+static const std::int64_t data_parallel_policy_kind = 2;
+
+std::int64_t host_policy_impl::kind() {
+    return host_policy_kind;
+}
+
+#ifdef ONEDAL_DATA_PARALLEL
+std::int64_t data_parallel_policy_impl::kind() {
+    return data_parallel_policy_kind;
+}
+
+data_parallel_policy_impl::data_parallel_policy_impl(const sycl::queue& queue)
+    : queue_(queue) {}
+
+sycl::queue data_parallel_policy_impl::get_queue() const {
+    return queue_;
+}
+#endif
+
+} // namespace oneapi::dal::python

--- a/onedal/common/backend/policy_impl.h
+++ b/onedal/common/backend/policy_impl.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#ifdef ONEDAL_DATA_PARALLEL
+#include <CL/sycl.hpp>
+#endif
+
+namespace oneapi::dal::python {
+
+class policy_impl {
+public:
+    virtual ~policy_impl() = default;
+    virtual std::int64_t get_kind() const = 0;
+};
+
+class host_policy_impl : public policy_impl {
+public:
+    static std::int64_t kind();
+    std::int64_t get_kind() const override { return kind(); }
+};
+
+#ifdef ONEDAL_DATA_PARALLEL
+
+class data_parallel_policy_impl : public policy_impl {
+public:
+    static std::int64_t kind();
+
+    data_parallel_policy_impl(const sycl::queue& queue);
+
+    std::int64_t get_kind() const override { return kind(); }
+    sycl::queue get_queue() const;
+
+private:
+    sycl::queue queue_;
+};
+
+#endif
+
+} // namespace oneapi::dal::python

--- a/onedal/common/backend/train.h
+++ b/onedal/common/backend/train.h
@@ -16,35 +16,14 @@
 
 #pragma once
 
-#include <numpy/arrayobject.h>
-
-#ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
-#endif
-
-#ifdef DPCTL_ENABLE
-#include "dpctl_sycl_types.h"
-#include "dpctl_sycl_queue_manager.h"
-#endif
+#include "common/backend/policy.h"
 
 namespace oneapi::dal::python {
+
 template <typename... Args>
-auto train(Args &&... args) {
-#if defined(DPCTL_ENABLE)
-    auto dpctl_queue = DPCTLQueueMgr_GetCurrentQueue();
-    if (dpctl_queue != NULL) {
-        cl::sycl::queue &sycl_queue = *reinterpret_cast<cl::sycl::queue *>(dpctl_queue);
-        return dal::train(sycl_queue, std::forward<Args>(args)...);
-    }
-    else {
-        throw std::runtime_error("Cannot set daal context: Pointer to queue object is NULL");
-    }
-#elif defined(ONEDAL_DATA_PARALLEL)
-    cl::sycl::queue sycl_queue(sycl::host_selector{});
-    return dal::train(sycl_queue, std::forward<Args>(args)...);
-#else
-    return dal::train(std::forward<Args>(args)...);
-#endif
+auto train(const policy* policy, Args &&... args) {
+    ONEDAL_ASSERT(policy, "policy object is null");
+    return policy->train(std::forward<Args>(args)...);
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/common/policy.pxi
+++ b/onedal/common/policy.pxi
@@ -1,0 +1,24 @@
+#===============================================================================
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+from libcpp.string cimport string as std_string
+
+cdef extern from "common/backend/policy.h" namespace "oneapi::dal::python":
+    cdef cppclass policy:
+        policy(const std_string& device_name) except +
+
+cdef extern from "common/backend/utils.h" namespace "oneapi::dal::python":
+    cdef std_string to_std_string(PyObject * o) except +

--- a/onedal/common/policy.py
+++ b/onedal/common/policy.py
@@ -23,6 +23,7 @@ except ImportError:
         PyPolicy
     )
 
+
 def _get_current_policy():
     import sys
     if 'daal4py.oneapi' in sys.modules:

--- a/onedal/common/policy.py
+++ b/onedal/common/policy.py
@@ -1,0 +1,37 @@
+#===============================================================================
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+try:
+    from _onedal4py_dpc import (
+        PyPolicy
+    )
+except ImportError:
+    from _onedal4py_host import (
+        PyPolicy
+    )
+
+def _get_current_policy():
+    import sys
+    if 'daal4py.oneapi' in sys.modules:
+        import daal4py.oneapi as d4p_oneapi
+        devname = d4p_oneapi._get_device_name_sycl_ctxt()
+
+        if devname == 'gpu':
+            # daal4py.oneapi.sycl_context uses default_selector only to create a queue
+            # so we do not have to extract a queue object from daal4py and just create it
+            # one more time
+            return PyPolicy('gpu')
+    return PyPolicy('host')

--- a/onedal/common/policy.pyx
+++ b/onedal/common/policy.pyx
@@ -18,12 +18,17 @@ include "policy.pxi"
 
 cdef class PyPolicy:
     cdef policy* _policy
+    cdef object _devtype
 
     def __cinit__(self, type_):
+        self._devtype = type_
         self._policy = new policy(to_std_string( <PyObject*>type_))
 
     def __dealloc__(self):
         del self._policy
+
+    def get_device_type(self):
+        return self._devtype
 
     cdef const policy* get_cref(self):
         return self._policy

--- a/onedal/common/policy.pyx
+++ b/onedal/common/policy.pyx
@@ -1,0 +1,29 @@
+#===============================================================================
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+include "policy.pxi"
+
+cdef class PyPolicy:
+    cdef policy* _policy
+
+    def __cinit__(self, type_):
+        self._policy = new policy(to_std_string( <PyObject*>type_))
+
+    def __dealloc__(self):
+        del self._policy
+
+    cdef const policy* get_cref(self):
+        return self._policy

--- a/onedal/onedal.pyx
+++ b/onedal/onedal.pyx
@@ -26,3 +26,4 @@ npc.import_array()
 
 include "svm/svm.pyx"
 include "prims/kernel_functions.pyx"
+include "common/policy.pyx"

--- a/onedal/prims/backend/kernel_functions_py.h
+++ b/onedal/prims/backend/kernel_functions_py.h
@@ -19,12 +19,14 @@
 #define NO_IMPORT_ARRAY
 
 #include "backend/data/data.h"
+#include "common/backend/policy.h"
 
 #include "oneapi/dal/algo/linear_kernel.hpp"
 #include "oneapi/dal/algo/rbf_kernel.hpp"
 #include "oneapi/dal/algo/polynomial_kernel.hpp"
 
 namespace oneapi::dal::python {
+
 struct ONEDAL_BACKEND_EXPORT linear_kernel_params {
     double scale;
     double shift;
@@ -36,7 +38,7 @@ public:
     linear_kernel_compute(linear_kernel_params* params);
 
     // attributes from compute_input
-    void compute(PyObject* x, PyObject* y);
+    void compute(const policy* policy, PyObject* x, PyObject* y);
 
     // attributes from compute_result
     PyObject* get_values();
@@ -59,7 +61,7 @@ public:
     rbf_kernel_compute(rbf_kernel_params* params);
 
     // attributes from compute_input
-    void compute(PyObject* x, PyObject* y);
+    void compute(const policy* policy, PyObject* x, PyObject* y);
 
     // attributes from compute_result
     PyObject* get_values();
@@ -81,7 +83,7 @@ public:
     polynomial_kernel_compute(polynomial_kernel_params* params);
 
     // attributes from compute_input
-    void compute(PyObject* x, PyObject* y);
+    void compute(const policy* policy, PyObject* x, PyObject* y);
 
     // attributes from compute_result
     PyObject* get_values();

--- a/onedal/prims/kernel_functions.pxi
+++ b/onedal/prims/kernel_functions.pxi
@@ -21,7 +21,7 @@ cdef extern from "prims/backend/kernel_functions_py.h" namespace "oneapi::dal::p
 
     cdef cppclass linear_kernel_compute:
         linear_kernel_compute(linear_kernel_params *) except +
-        void compute(PyObject * x, PyObject * y) except +
+        void compute(const policy* p, PyObject * x, PyObject * y) except +
         PyObject * get_values() except +
 
     cdef cppclass rbf_kernel_params:
@@ -29,7 +29,7 @@ cdef extern from "prims/backend/kernel_functions_py.h" namespace "oneapi::dal::p
 
     cdef cppclass rbf_kernel_compute:
         rbf_kernel_compute(rbf_kernel_params *) except +
-        void compute(PyObject * x, PyObject * y) except +
+        void compute(const policy* p, PyObject * x, PyObject * y) except +
         PyObject * get_values() except +
 
     cdef cppclass polynomial_kernel_params:
@@ -39,5 +39,5 @@ cdef extern from "prims/backend/kernel_functions_py.h" namespace "oneapi::dal::p
 
     cdef cppclass polynomial_kernel_compute:
         polynomial_kernel_compute(polynomial_kernel_params *) except +
-        void compute(PyObject * x, PyObject * y) except +
+        void compute(const policy* p, PyObject * x, PyObject * y) except +
         PyObject * get_values() except +

--- a/onedal/prims/kernel_functions.py
+++ b/onedal/prims/kernel_functions.py
@@ -15,7 +15,7 @@
 #===============================================================================
 
 import numpy as np
-from onedal.common import _check_array
+from onedal.common import _check_array, _get_current_policy
 
 try:
     from _onedal4py_dpc import (
@@ -69,7 +69,7 @@ def linear_kernel(X, Y=None, scale=1.0, shift=0.0):
 
     _onedal_params = PyLinearKernelParams(scale, shift)
     c_kernel = PyLinearKernelCompute(_onedal_params)
-    c_kernel.compute(X, Y)
+    c_kernel.compute(_get_current_policy(), X, Y)
     return c_kernel.get_values()
 
 
@@ -108,7 +108,7 @@ def rbf_kernel(X, Y=None, gamma=None):
     sigma = np.sqrt(0.5 / gamma)
     _onedal_params = PyRbfKernelParams(sigma=sigma)
     c_kernel = PyRbfKernelCompute(_onedal_params)
-    c_kernel.compute(X, Y)
+    c_kernel.compute(_get_current_policy(), X, Y)
     return c_kernel.get_values()
 
 
@@ -147,5 +147,5 @@ def poly_kernel(X, Y=None, gamma=1.0, coef0=0.0, degree=3):
     _onedal_params = PyPolyKernelParams(
         scale=gamma, shift=coef0, degree=degree)
     c_kernel = PyPolyKernelCompute(_onedal_params)
-    c_kernel.compute(X, Y)
+    c_kernel.compute(_get_current_policy(), X, Y)
     return c_kernel.get_values()

--- a/onedal/prims/kernel_functions.pyx
+++ b/onedal/prims/kernel_functions.pyx
@@ -51,8 +51,8 @@ cdef class PyLinearKernelCompute:
     def __dealloc__(self):
         del self.thisptr
 
-    def compute(self, x, y):
-        self.thisptr.compute(<PyObject *>x, <PyObject *>y)
+    def compute(self, PyPolicy p, x, y):
+        self.thisptr.compute(p.get_cref(), <PyObject *>x, <PyObject *>y)
 
     def get_values(self):
         return <object>self.thisptr.get_values()
@@ -81,8 +81,8 @@ cdef class PyRbfKernelCompute:
     def __dealloc__(self):
         del self.thisptr
 
-    def compute(self, x, y):
-        self.thisptr.compute(<PyObject *>x, <PyObject *>y)
+    def compute(self, PyPolicy p, x, y):
+        self.thisptr.compute(p.get_cref(), <PyObject *>x, <PyObject *>y)
 
     def get_values(self):
         return <object>self.thisptr.get_values()
@@ -105,8 +105,8 @@ cdef class PyPolyKernelCompute:
     def __dealloc__(self):
         del self.thisptr
 
-    def compute(self, x, y):
-        self.thisptr.compute(<PyObject *>x, <PyObject *>y)
+    def compute(self, PyPolicy p, x, y):
+        self.thisptr.compute(p.get_cref(), <PyObject *>x, <PyObject *>y)
 
     def get_values(self):
         return <object>self.thisptr.get_values()

--- a/onedal/svm/backend/svm_py.cpp
+++ b/onedal/svm/backend/svm_py.cpp
@@ -39,7 +39,7 @@ KernelDescriptor get_kernel_params(const svm_params &params) {
 }
 
 template <typename Result, typename Descriptor, typename... Args>
-Result compute_descriptor_impl(Descriptor descriptor, const svm_params &params, Args &&... args) {
+Result compute_descriptor_impl(const policy* policy, Descriptor descriptor, const svm_params &params, Args &&... args) {
     using Task = typename Result::task_t;
     descriptor.set_c(params.c)
         .set_accuracy_threshold(params.accuracy_threshold)
@@ -55,20 +55,21 @@ Result compute_descriptor_impl(Descriptor descriptor, const svm_params &params, 
         descriptor.set_epsilon(params.epsilon);
     }
     if constexpr (std::is_same_v<Result, typename svm::train_result<Task>>) {
-        return python::train(descriptor, std::forward<Args>(args)...);
+        return python::train(policy, descriptor, std::forward<Args>(args)...);
     }
     else if constexpr (std::is_same_v<Result, typename svm::infer_result<Task>>) {
-        return python::infer(descriptor, std::forward<Args>(args)...);
+        return python::infer(policy, descriptor, std::forward<Args>(args)...);
     }
 }
 
 template <typename Result, typename... Args>
-Result compute_impl(svm_params &params, data_type data_type_input, Args &&... args) {
+Result compute_impl(const policy* policy, svm_params &params, data_type data_type_input, Args &&... args) {
     using Task = typename Result::task_t;
     if constexpr (std::is_same_v<Task, svm::task::classification>) {
         if (data_type_input == data_type::float32 && params.method == "smo" &&
             params.kernel == "linear") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::descriptor<float, svm::method::smo, Task, linear_kernel::descriptor<float>>{},
                 params,
                 std::forward<Args>(args)...);
@@ -76,6 +77,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
         else if (data_type_input == data_type::float32 && params.method == "smo" &&
                  params.kernel == "rbf") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::descriptor<float, svm::method::smo, Task, rbf_kernel::descriptor<float>>{},
                 params,
                 std::forward<Args>(args)...);
@@ -84,6 +86,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
         if (data_type_input == data_type::float32 && params.method == "smo" &&
             params.kernel == "poly") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::descriptor<float,
                                 svm::method::smo,
                                 Task,
@@ -94,6 +97,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
         if (data_type_input == data_type::float64 && params.method == "smo" &&
             params.kernel == "linear") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::
                     descriptor<double, svm::method::smo, Task, linear_kernel::descriptor<double>>{},
                 params,
@@ -102,6 +106,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
         else if (data_type_input == data_type::float64 && params.method == "smo" &&
                  params.kernel == "rbf") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::descriptor<double, svm::method::smo, Task, rbf_kernel::descriptor<double>>{},
                 params,
                 std::forward<Args>(args)...);
@@ -109,6 +114,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
         else if (data_type_input == data_type::float64 && params.method == "smo" &&
                  params.kernel == "poly") {
             return compute_descriptor_impl<Result>(
+                policy,
                 svm::descriptor<double,
                                 svm::method::smo,
                                 Task,
@@ -121,6 +127,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     if (data_type_input == data_type::float32 && params.method == "thunder" &&
         params.kernel == "linear") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::descriptor<float, svm::method::thunder, Task, linear_kernel::descriptor<float>>{},
             params,
             std::forward<Args>(args)...);
@@ -128,6 +135,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     else if (data_type_input == data_type::float32 && params.method == "thunder" &&
              params.kernel == "rbf") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::descriptor<float, svm::method::thunder, Task, rbf_kernel::descriptor<float>>{},
             params,
             std::forward<Args>(args)...);
@@ -135,6 +143,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     else if (data_type_input == data_type::float32 && params.method == "thunder" &&
              params.kernel == "poly") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::descriptor<float,
                             svm::method::thunder,
                             Task,
@@ -145,6 +154,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     else if (data_type_input == data_type::float64 && params.method == "thunder" &&
              params.kernel == "linear") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::
                 descriptor<double, svm::method::thunder, Task, linear_kernel::descriptor<double>>{},
             params,
@@ -153,6 +163,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     else if (data_type_input == data_type::float64 && params.method == "thunder" &&
              params.kernel == "rbf") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::descriptor<double, svm::method::thunder, Task, rbf_kernel::descriptor<double>>{},
             params,
             std::forward<Args>(args)...);
@@ -160,6 +171,7 @@ Result compute_impl(svm_params &params, data_type data_type_input, Args &&... ar
     else if (data_type_input == data_type::float64 && params.method == "thunder" &&
              params.kernel == "poly") {
         return compute_descriptor_impl<Result>(
+            policy,
             svm::descriptor<double,
                             svm::method::thunder,
                             Task,
@@ -200,12 +212,13 @@ svm_train<Task>::svm_train(svm_params *params) : params_(*params) {}
 
 // attributes from train_input
 template <typename Task>
-void svm_train<Task>::train(PyObject *data, PyObject *labels, PyObject *weights) {
+void svm_train<Task>::train(const policy* policy, PyObject *data, PyObject *labels, PyObject *weights) {
     auto data_table = convert_to_table(data);
     auto labels_table = convert_to_table(labels);
     auto weights_table = convert_to_table(weights);
     auto data_type = data_table.get_metadata().get_data_type(0);
-    train_result_ = compute_impl<decltype(train_result_)>(params_,
+    train_result_ = compute_impl<decltype(train_result_)>(policy,
+                                                          params_,
                                                           data_type,
                                                           data_table,
                                                           labels_table,
@@ -254,7 +267,8 @@ svm_infer<Task>::svm_infer(svm_params *params) : params_(*params) {}
 
 // attributes from infer_input.hpp expect model
 template <typename Task>
-void svm_infer<Task>::infer(PyObject *data,
+void svm_infer<Task>::infer(const policy* policy,
+                            PyObject *data,
                             PyObject *support_vectors,
                             PyObject *coeffs,
                             PyObject *biases) {
@@ -271,15 +285,15 @@ void svm_infer<Task>::infer(PyObject *data,
     if constexpr (std::is_same_v<Task, svm::task::classification>) {
         model.set_first_class_label(0).set_second_class_label(1);
     }
-    infer_result_ = compute_impl<decltype(infer_result_)>(params_, data_type, model, data_table);
+    infer_result_ = compute_impl<decltype(infer_result_)>(policy, params_, data_type, model, data_table);
 }
 
 // attributes from infer_input.hpp expect model
 template <typename Task>
-void svm_infer<Task>::infer(PyObject *data, svm_model<Task> *model) {
+void svm_infer<Task>::infer(const policy* policy, PyObject *data, svm_model<Task> *model) {
     auto data_table = convert_to_table(data);
     auto data_type = data_table.get_metadata().get_data_type(0);
-    infer_result_ = compute_impl<decltype(infer_result_)>(params_,
+    infer_result_ = compute_impl<decltype(infer_result_)>(policy, params_,
                                                           data_type,
                                                           model->get_onedal_model(),
                                                           data_table);

--- a/onedal/svm/backend/svm_py.h
+++ b/onedal/svm/backend/svm_py.h
@@ -24,7 +24,7 @@
 
 namespace oneapi::dal::python {
 
-struct svm_params {
+struct ONEDAL_BACKEND_EXPORT svm_params {
     std::string kernel;
     std::string method;
     double c;
@@ -42,7 +42,7 @@ struct svm_params {
 };
 
 template <typename Task>
-class svm_model {
+class ONEDAL_BACKEND_EXPORT svm_model {
 public:
     svm_model();
     svm_model(const svm::model<Task>& model);
@@ -56,7 +56,7 @@ private:
 };
 
 template <typename Task>
-class svm_train {
+class ONEDAL_BACKEND_EXPORT svm_train {
 public:
     // from descriptor
     svm_train(svm_params* params);
@@ -88,7 +88,7 @@ private:
 };
 
 template <typename Task>
-class svm_infer {
+class ONEDAL_BACKEND_EXPORT svm_infer {
 public:
     // from descriptor
     svm_infer(svm_params* params);

--- a/onedal/svm/backend/svm_py.h
+++ b/onedal/svm/backend/svm_py.h
@@ -19,9 +19,11 @@
 #define NO_IMPORT_ARRAY
 
 #include "oneapi/dal/algo/svm.hpp"
+#include "common/backend/policy.h"
 #include "backend/data/data.h"
 
 namespace oneapi::dal::python {
+
 struct svm_params {
     std::string kernel;
     std::string method;
@@ -60,7 +62,7 @@ public:
     svm_train(svm_params* params);
 
     // attributes from train_input
-    void train(PyObject* data, PyObject* labels, PyObject* weights);
+    void train(const policy* p, PyObject* data, PyObject* labels, PyObject* weights);
 
     // attributes from train_result
     svm_model<Task> get_model();
@@ -92,10 +94,10 @@ public:
     svm_infer(svm_params* params);
 
     // attributes from infer_input.hpp expect model
-    void infer(PyObject* data, svm_model<Task>* model);
+    void infer(const policy* p, PyObject* data, svm_model<Task>* model);
 
     // attributes from infer_input.hpp expect model
-    void infer(PyObject* data, PyObject* support_vectors, PyObject* coeffs, PyObject* biases);
+    void infer(const policy* p, PyObject* data, PyObject* support_vectors, PyObject* coeffs, PyObject* biases);
 
     // attributes from infer_result
     PyObject* get_labels();

--- a/onedal/svm/svm.pxi
+++ b/onedal/svm/svm.pxi
@@ -49,7 +49,7 @@ cdef extern from "svm/backend/svm_py.h" namespace "oneapi::dal::python":
 
     cdef cppclass svm_train[task_t]:
         svm_train(svm_params *) except +
-        void train(PyObject * data, PyObject * labels, PyObject * weights) except +
+        void train(const policy* p, PyObject * data, PyObject * labels, PyObject * weights) except +
         int get_support_vector_count()  except +
         PyObject * get_support_vectors() except +
         PyObject * get_support_indices() except +
@@ -59,7 +59,7 @@ cdef extern from "svm/backend/svm_py.h" namespace "oneapi::dal::python":
 
     cdef cppclass svm_infer[task_t]:
         svm_infer(svm_params *) except +
-        void infer(PyObject * data, PyObject * support_vectors, PyObject * coeffs, PyObject * biases) except +
-        void infer(PyObject * data, svm_model[task_t] * model) except +
+        void infer(const policy* p, PyObject * data, PyObject * support_vectors, PyObject * coeffs, PyObject * biases) except +
+        void infer(const policy* p, PyObject * data, svm_model[task_t] * model) except +
         PyObject * get_labels() except +
         PyObject * get_decision_function() except +

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -28,7 +28,8 @@ from ..common import (
     _get_sample_weight,
     _check_is_fitted,
     _column_or_1d,
-    _check_n_features
+    _check_n_features,
+    _get_current_policy
 )
 
 try:
@@ -165,7 +166,7 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
             self._scale_, self._sigma_ = self._compute_gamma_sigma(self.gamma, X)
 
         c_svm = Computer(self._get_onedal_params())
-        c_svm.train(X, y, sample_weight)
+        c_svm.train(_get_current_policy(), X, y, sample_weight)
 
         self.dual_coef_ = c_svm.get_coeffs().T
         self.support_vectors_ = c_svm.get_support_vectors()
@@ -199,9 +200,10 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
             c_svm = Computer(self._get_onedal_params())
 
             if hasattr(self, '_onedal_model'):
-                c_svm.infer(X, self._onedal_model)
+                c_svm.infer(_get_current_policy(), X, self._onedal_model)
             else:
-                c_svm.infer_builder(X, self.support_vectors_,
+                c_svm.infer_builder(_get_current_policy(),
+                                    X, self.support_vectors_,
                                     self.dual_coef_.T, self.intercept_)
             y = c_svm.get_labels()
         return y
@@ -232,9 +234,9 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
         _check_n_features(self, X, False)
         c_svm = PyClassificationSvmInfer(self._get_onedal_params())
         if hasattr(self, '_onedal_model'):
-            c_svm.infer(X, self._onedal_model)
+            c_svm.infer(_get_current_policy(), X, self._onedal_model)
         else:
-            c_svm.infer_builder(X, self.support_vectors_,
+            c_svm.infer_builder(_get_current_policy(), X, self.support_vectors_,
                                 self.dual_coef_.T, self.intercept_)
         decision_function = c_svm.get_decision_function()
         if len(self.classes_) == 2:

--- a/onedal/svm/svm.pyx
+++ b/onedal/svm/svm.pyx
@@ -73,8 +73,8 @@ cdef class PyClassificationSvmTrain:
     def __dealloc__(self):
         del self.thisptr
 
-    def train(self, data, labels, weights):
-        self.thisptr.train( < PyObject * >data, < PyObject * >labels, < PyObject * >weights)
+    def train(self, PyPolicy p, data, labels, weights):
+        self.thisptr.train( p.get_cref(), < PyObject * >data, < PyObject * >labels, < PyObject * >weights)
 
     def get_support_vectors(self):
         return < object > self.thisptr.get_support_vectors()
@@ -103,11 +103,11 @@ cdef class PyClassificationSvmInfer:
     def __dealloc__(self):
         del self.thisptr
 
-    def infer(self, data, PyClassificationSvmModel model):
-        self.thisptr.infer( < PyObject * >data, model.thisptr)
+    def infer(self, PyPolicy p, data, PyClassificationSvmModel model):
+        self.thisptr.infer( p.get_cref(), < PyObject * >data, model.thisptr)
 
-    def infer_builder(self, data, support_vectors, coeffs, biases):
-        self.thisptr.infer( < PyObject * >data, < PyObject * >support_vectors, < PyObject * >coeffs, < PyObject * >biases)
+    def infer_builder(self, PyPolicy p, data, support_vectors, coeffs, biases):
+        self.thisptr.infer( p.get_cref(), < PyObject * >data, < PyObject * >support_vectors, < PyObject * >coeffs, < PyObject * >biases)
 
     def get_labels(self):
         return < object > self.thisptr.get_labels()
@@ -147,8 +147,8 @@ cdef class PyRegressionSvmTrain:
     def __dealloc__(self):
         del self.thisptr
 
-    def train(self, data, labels, weights):
-        self.thisptr.train( < PyObject * >data, < PyObject * >labels, < PyObject * >weights)
+    def train(self, PyPolicy p, data, labels, weights):
+        self.thisptr.train( p.get_cref(), < PyObject * >data, < PyObject * >labels, < PyObject * >weights)
 
     def get_support_vectors(self):
         return < object > self.thisptr.get_support_vectors()
@@ -177,11 +177,11 @@ cdef class PyRegressionSvmInfer:
     def __dealloc__(self):
         del self.thisptr
 
-    def infer(self, data, PyRegressionSvmModel model):
-        self.thisptr.infer( < PyObject * >data, model.thisptr)
+    def infer(self, PyPolicy p, data, PyRegressionSvmModel model):
+        self.thisptr.infer( p.get_cref(), < PyObject * >data, model.thisptr)
 
-    def infer_builder(self, data, support_vectors, coeffs, biases):
-        self.thisptr.infer( < PyObject * >data, < PyObject * >support_vectors, < PyObject * >coeffs, < PyObject * >biases)
+    def infer_builder(self, PyPolicy p, data, support_vectors, coeffs, biases):
+        self.thisptr.infer( p.get_cref(), < PyObject * >data, < PyObject * >support_vectors, < PyObject * >coeffs, < PyObject * >biases)
 
     def get_labels(self):
         return < object > self.thisptr.get_labels()


### PR DESCRIPTION
- Support of device offload using old `daal4py.oneapi.sycl_context` control
- Fix of data transfer from oneDAL to Python

 
