### PR TITLE
Fix `get_number_of_types` failing with pandas dtypes

### DIFF
--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -147,6 +147,7 @@ def get_dtype(X):
 
 def get_number_of_types(dataframe):
     dtypes = getattr(dataframe, "dtypes", None)
-    if dtypes is None or isinstance(dtypes, np.dtype):
+    try:
+        return len(set(dtypes))
+    except TypeError:
         return 1
-    return len(set(dtypes))


### PR DESCRIPTION
# Description
`get_number_of_types` will throw an exception if it checks a dataframe with just one dtype, and that dtype is a pandas one (eg. CategoricalDtype). As those are not numpy dtypes, it will assume it's an iterable, and raise a TypeError when it cannot be converted to set.

Changes proposed in this pull request:
- Replace the check in `get_number_of_types` with a more robust try-except approach
 
