### PR TITLE
Train_test_split fix and test for specific subset sizes

### DIFF
--- a/daal4py/sklearn/model_selection/_split.py
+++ b/daal4py/sklearn/model_selection/_split.py
@@ -108,9 +108,12 @@ def _daal_train_test_split(*arrays, **options):
                 (isinstance(random_state, int) or random_state is None) and \
                     platform.system() != 'Windows':
                 indexes = np.empty(
-                    shape=(n_samples,),
-                    dtype=np.int64 if n_train + n_test > 2 ** 31 - 1 else np.int32
-                )
+                    shape=(
+                        n_samples,
+                    ),
+                    dtype=np.int64 if n_train +
+                    n_test > 2 ** 31 -
+                    1 else np.int32)
                 random_state = np.random.RandomState(random_state)
                 random_state = random_state.get_state()[1]
                 d4p.daal_generate_shuffled_indices([indexes], [random_state])

--- a/daal4py/sklearn/model_selection/_split.py
+++ b/daal4py/sklearn/model_selection/_split.py
@@ -108,12 +108,9 @@ def _daal_train_test_split(*arrays, **options):
                 (isinstance(random_state, int) or random_state is None) and \
                     platform.system() != 'Windows':
                 indexes = np.empty(
-                    shape=(
-                        n_samples,
-                    ),
-                    dtype=np.int64 if n_train +
-                    n_test > 2 ** 31 -
-                    1 else np.int32)
+                    shape=(n_samples,),
+                    dtype=np.int64 if n_train + n_test > 2 ** 31 - 1 else np.int32
+                )
                 random_state = np.random.RandomState(random_state)
                 random_state = random_state.get_state()[1]
                 d4p.daal_generate_shuffled_indices([indexes], [random_state])

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 from sklearn.model_selection import train_test_split as skl_train_test_split
 from daal4py.sklearn.model_selection import _daal_train_test_split as d4p_train_test_split
+from daal4py.sklearn._utils import daal_check_version
 from sklearn.datasets import make_classification
 
 
@@ -27,6 +28,8 @@ RANDOM_STATE = 777
 
 @pytest.mark.parametrize('n_samples', N_SAMPLES)
 def test_results_similarity(n_samples):
+    if not daal_check_version((2021, 'P', 400)):
+        return None
     x, y = make_classification(
         n_samples=n_samples, n_features=4, random_state=RANDOM_STATE)
     d4p_res = d4p_train_test_split(

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -1,0 +1,42 @@
+#===============================================================================
+# Copyright 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+import numpy as np
+import pytest
+from sklearn.model_selection import train_test_split as skl_train_test_split
+from daal4py.sklearn.model_selection import _daal_train_test_split as d4p_train_test_split
+from sklearn.datasets import make_classification
+
+
+N_SAMPLES = [2 ** i + 1 for i in range(2, 17)]
+RANDOM_STATE = 42
+
+
+@pytest.mark.parametrize('n_samples', N_SAMPLES)
+def test_results_similarity(n_samples):
+    x, y = make_classification(
+        n_samples=n_samples, n_features=4, random_state=RANDOM_STATE)
+    d4p_res = d4p_train_test_split(
+        x, y, test_size=n_samples // 2 - 1, train_size=n_samples // 2 - 1, random_state=RANDOM_STATE)
+    skl_res = skl_train_test_split(
+        x, y, test_size=n_samples // 2 - 1, train_size=n_samples // 2 - 1, random_state=RANDOM_STATE)
+
+    assert len(d4p_res) == len(
+        skl_res), 'train_test_splits have different output size'
+
+    for i in range(len(d4p_res)):
+        assert np.all(d4p_res[i] == skl_res[i]
+                      ), 'train_test_splits have different output'

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -22,7 +22,7 @@ from sklearn.datasets import make_classification
 
 
 N_SAMPLES = [2 ** i + 1 for i in range(2, 17)]
-RANDOM_STATE = 42
+RANDOM_STATE = 777
 
 
 @pytest.mark.parametrize('n_samples', N_SAMPLES)

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -26,10 +26,11 @@ N_SAMPLES = [2 ** i + 1 for i in range(2, 17)]
 RANDOM_STATE = 777
 
 
+@pytest.mark.skipif(
+    not daal_check_version((2021, 'P', 400)),
+    reason='train_test_split has bugfix since 2021.4 release')
 @pytest.mark.parametrize('n_samples', N_SAMPLES)
 def test_results_similarity(n_samples):
-    if not daal_check_version((2021, 'P', 400)):
-        return None
     x, y = make_classification(
         n_samples=n_samples, n_features=4, random_state=RANDOM_STATE)
     d4p_res = d4p_train_test_split(

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -30,13 +30,21 @@ def test_results_similarity(n_samples):
     x, y = make_classification(
         n_samples=n_samples, n_features=4, random_state=RANDOM_STATE)
     d4p_res = d4p_train_test_split(
-        x, y, test_size=n_samples // 2 - 1, train_size=n_samples // 2 - 1, random_state=RANDOM_STATE)
+        x,
+        y,
+        test_size=n_samples // 2 - 1,
+        train_size=n_samples // 2 - 1,
+        random_state=RANDOM_STATE)
     skl_res = skl_train_test_split(
-        x, y, test_size=n_samples // 2 - 1, train_size=n_samples // 2 - 1, random_state=RANDOM_STATE)
+        x,
+        y,
+        test_size=n_samples // 2 - 1,
+        train_size=n_samples // 2 - 1,
+        random_state=RANDOM_STATE)
 
     assert len(d4p_res) == len(
         skl_res), 'train_test_splits have different output size'
 
-    for i in range(len(d4p_res)):
+    for i, _ in enumerate(d4p_res):
         assert np.all(d4p_res[i] == skl_res[i]
                       ), 'train_test_splits have different output'


### PR DESCRIPTION
# Description
Fix for incorrect work of train_test_split when `train_size + test_size < input_size`:
 - number of indices from RNG is corrected
 - test for case is added
 
Merged https://github.com/oneapi-src/oneDAL/pull/1817 are required for full fix.

Fixes intel/scikit-learn-intelex#767 issue.