### PR TITLE
XGBoost model builder fix

### DIFF
--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -121,6 +121,12 @@ def get_gbt_model_from_xgboost(booster: Any) -> Any:
             self.parent_id = parent_id
             self.position = position
 
+    # Release Note for XGBoost 1.5.0: Python interface now supports configuring 
+    # constraints using feature names instead of feature indices.
+    if booster.feature_names is None:
+        lst = [*range(booster.num_features())]
+        booster.feature_names = [str(i) for i in lst]
+
     trees_arr = booster.get_dump(dump_format="json")
     xgb_config = json.loads(booster.save_config())
 


### PR DESCRIPTION
# Description
Fix for numpy like datasets due to xgb 1.5.0 changes:
"Python interface now supports configuring constraints using feature names instead of feature indices"

 
