### PR TITLE
Fix memory leak in table conversion

### DIFF
--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -225,6 +225,7 @@ static PyObject *convert_to_numpy_impl(const dal::array<T> &array,
     if (!obj)
         throw std::invalid_argument("Conversion to numpy array failed");
 
+
     void *opaque_value = static_cast<void *>(new dal::array<T>(host_array));
     PyObject *cap = PyCapsule_New(opaque_value, NULL, free_capsule);
     PyArray_SetBaseObject(reinterpret_cast<PyArrayObject *>(obj), cap);


### PR DESCRIPTION
# Description
Removal of PyCapsule fixes release of training result memory.
