### PR TITLE
Update installation.rst

### DIFF
--- a/doc/sources/installation.rst
+++ b/doc/sources/installation.rst
@@ -59,7 +59,7 @@ Sources are available in |intelex_repo|_.
 
 ::
 
-    Python version >= 3.6
+    Python version >= 3.6, < 3.10
 
 Configure the build with environment variables
 ==============================================


### PR DESCRIPTION
It seems installation under python 3.10 is not supported, at least on windows.
under 3.9 installation works great

# Description
Please include a summary of the change. For large or complex changes please include enough information to introduce your change and explain motivation for it.

Changes proposed in this pull request:
-
-
-

 
