### PR TITLE
Enabling automerge for docs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,17 +3,21 @@
     "config:base",
     ":preserveSemverRanges"
   ],
-  "pip_doc_requirements": {
+  "pip_doc_requirements": [
+    {
     "fileMatch": [
       "(^|/)requirements-doc.txt$"
     ],
     "matchUpdateTypes": ["minor", "patch"],
     "matchCurrentVersion": "!/^0/",
     "automerge": true
-  },
-  "pip_requirements": {
+    }
+  ],
+  "pip_requirements": [
+    {
     "fileMatch": [
       "(^|/)requirements.*\\.txt$"
     ]
-  }
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,14 @@
     "config:base",
     ":preserveSemverRanges"
   ],
+  "pip_doc_requirements": {
+    "fileMatch": [
+      "(^|/)requirements-doc.txt$"
+    ],
+    "matchUpdateTypes": ["minor", "patch"],
+    "matchCurrentVersion": "!/^0/",
+    "automerge": true
+  },
   "pip_requirements": {
     "fileMatch": [
       "(^|/)requirements.*\\.txt$"

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,0 +1,21 @@
+name: renovate-validation
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Renovate validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@v0.0.10
+        with:
+          pattern: '*.json' # Regular expression for filename to validate, default to *.json


### PR DESCRIPTION
# Description
This change is intended for enabling automerge for doc dependencies generated by renovate

Changes proposed in this pull request:
- enable automerge for renovate jobs on docs
- add github action validation for renovate config


 
