### PR TITLE
Exclude dbscan from nightly jupyter testing

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -83,6 +83,6 @@ jobs:
       conda activate CB
       cd examples/notebooks
       pip install jupyter matplotlib
-      jupyter nbconvert --execute --ExecutePreprocessor.timeout=10900 --to notebook *.ipynb
+      jupyter nbconvert --execute --ExecutePreprocessor.timeout=10900 --to notebook $(ls | grep -E '.*\.ipynb' | grep -v "dbscan.*")
     timeoutInMinutes: 180
     displayName: 'Run jupyter notebook demo'


### PR DESCRIPTION
dbscan requires more memory than is available in the Azure VM

 
