### PR TITLE
Add new deselected for release ci

### DIFF
--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -16,7 +16,7 @@
 
 variables:
   DESCRIPTION: ReleaseTesting
-  DESELECT: --deselect ::test_svc_clone_with_callable_kernel --deselect ::test_precomputed --deselect ::test_tweak_params --deselect ::test_custom_kernel_not_array_input --deselect ::test_svc_raises_error_internal_representation --deselect ::test_svc_ovr_tie_breaking[SVC] --deselect ::test_svc_ovr_tie_breaking[NuSVC]
+  DESELECT: --deselect ::test_svc_clone_with_callable_kernel --deselect ::test_precomputed --deselect ::test_tweak_params --deselect ::test_custom_kernel_not_array_input --deselect ::test_svc_raises_error_internal_representation --deselect ::test_svc_ovr_tie_breaking[SVC] --deselect ::test_svc_ovr_tie_breaking[NuSVC] --deselect ::test_gamma_auto --deselect ::test_gamma_scale
   TEST_COMMAND: python -m sklearnex -m pytest -ra --disable-warnings --pyargs sklearn.svm.tests.test_svm $(DESELECT)
 
 jobs:


### PR DESCRIPTION
The distutils package raises a deprecation warning. scikit-learn tests check the number of warnings and crash because of those warnings
[delete this deselected after 2021.6 release]
 
