### PR TITLE
Pin numpydoc for circleci scikit-learn testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
-            pip install -q scikit-learn
+            pip install -q scikit-learn numpydoc<1.2
             conda list
             source ./.circleci/run_and_compare.sh ~/daal4py-ci /tmp/patched_and_unpatched_sklearn_pypi_pytest_logs_sklearnex.tar.bz2 sklearnex skex
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             export PATH=~/miniconda/bin:$PATH
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
-            pip install -q scikit-learn numpydoc<1.2
+            pip install -q scikit-learn "numpydoc<1.2"
             conda list
             source ./.circleci/run_and_compare.sh ~/daal4py-ci /tmp/patched_and_unpatched_sklearn_pypi_pytest_logs_sklearnex.tar.bz2 sklearnex skex
       - store_artifacts:


### PR DESCRIPTION
numpydoc 1.2 is breaking some scikit-learn tests.
PR-22286 in scikit-learn project.


 
