### PR TITLE
Pin scipy version for old scikit-learn

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 pytest==6.2.5
 scikit-learn==1.0 ; python_version >= '3.7'
 scikit-learn==0.24 ; python_version == '3.6'
+scipy<1.8.0
 pandas==1.1.5 ; python_version <= '3.6'
 pandas==1.2.2 ; python_version >= '3.7'


### PR DESCRIPTION
scikit-learn uses deprecated functionality which was removed in scipy 1.8.0.
PR-21741 in the scikit-learn repository.
[need to change this version for scikit-learn 1.0.2 in the future]