### PR TITLE
[kNN] Default d4p usage for classification and search

### DIFF
--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -28,6 +28,12 @@ from ..datatypes import (
     _num_samples
 )
 
+from daal4py import (
+    bf_knn_classification_training,
+    bf_knn_classification_prediction,
+    kdtree_knn_classification_training,
+    kdtree_knn_classification_prediction
+)
 from onedal import _backend
 
 from ..common._mixin import ClassifierMixin
@@ -128,6 +134,20 @@ class NeighborsCommonBase(metaclass=ABCMeta):
             'result_option': 'indices|distances',
         }
 
+    def _get_daal_params(self, data):
+        class_count = 0 if self.classes_ is None else len(self.classes_)
+        weights = getattr(self, 'weights', 'uniform')
+        return {
+            'fptype': 'float' if data.dtype is np.dtype('float32') else 'double',
+            'nClasses': class_count,
+            'method': 'defaultDense',
+            'k': self.n_neighbors,
+            'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
+            'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
+            'resultsToEvaluate': 'none' if getattr(self, '_y', None) is None
+                else 'computeClassLabels'
+        }
+
 
 class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
     def __init__(self, n_neighbors=None, radius=None,
@@ -220,7 +240,7 @@ class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
         if y is not None and _is_regressor(self):
             self._y = y if self._shape is None else y.reshape(self._shape)
 
-        self._onedal_model = result.model
+        self._onedal_model = result
         result = self
 
         return result
@@ -272,12 +292,22 @@ class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
         chunked_results = None
         method = super()._parse_auto_method(
             self._fit_method, self.n_samples_fit_, n_features)
-        params = super()._get_onedal_params(X)
+
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            params = super()._get_daal_params(X)
+        else:
+            params = super()._get_onedal_params(X)
+
         prediction_results = self._onedal_predict(
             self._onedal_model, X, params, queue=queue)
 
-        distances = from_table(prediction_results.distances)
-        indices = from_table(prediction_results.indices)
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            distances = prediction_results.distances
+            indices = prediction_results.indices
+        else:
+            distances = from_table(prediction_results.distances)
+            indices = from_table(prediction_results.indices)
 
         if method == 'kd_tree':
             for i in range(distances.shape[0]):
@@ -348,15 +378,41 @@ class KNeighborsClassifier(NeighborsBase, ClassifierMixin):
         params['result_option'] = 'responses'
         return params
 
+    def _get_daal_params(self, data):
+        params = super()._get_daal_params(data)
+        params['resultsToEvaluate'] = 'computeClassLabels'
+        params['resultsToCompute'] = ''
+        return params
+
     def _onedal_fit(self, X, y, queue):
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            params = self._get_daal_params(X)
+            if self._fit_method == 'brute':
+                train_alg = bf_knn_classification_training
+
+            else:
+                train_alg = kdtree_knn_classification_training
+
+            return train_alg(**params).compute(X, y).model
+
         policy = _get_policy(queue, X, y)
         params = self._get_onedal_params(X)
         train_alg = _backend.neighbors.classification.train(policy, params,
                                                             *to_table(X, y))
 
-        return train_alg
+        return train_alg.model
 
     def _onedal_predict(self, model, X, params, queue):
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            if self._fit_method == 'brute':
+                predict_alg = bf_knn_classification_prediction
+
+            else:
+                predict_alg = kdtree_knn_classification_prediction
+
+            return predict_alg(**params).compute(X, model)
         policy = _get_policy(queue, X)
 
         if hasattr(self, '_onedal_model'):
@@ -390,10 +446,17 @@ class KNeighborsClassifier(NeighborsBase, ClassifierMixin):
 
         self._validate_n_classes()
 
-        params = self._get_onedal_params(X)
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            params = self._get_daal_params(X)
+        else:
+            params = self._get_onedal_params(X)
 
         prediction_result = self._onedal_predict(onedal_model, X, params, queue=queue)
-        responses = from_table(prediction_result.responses)
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            responses = prediction_result.responses
+        else:
+            responses = from_table(prediction_result.responses)
         result = self.classes_.take(
             np.asarray(responses.ravel(), dtype=np.intp))
 
@@ -458,15 +521,43 @@ class NearestNeighbors(NeighborsBase):
         params['result_option'] = 'indices|distances'
         return params
 
+    def _get_daal_params(self, data):
+        params = super()._get_daal_params(data)
+        params['resultsToCompute'] = 'computeIndicesOfNeighbors|computeDistances'
+        params['resultsToCompute'] = 'none' if getattr(self, '_y', None) is None \
+            else 'computeClassLabels'
+        return params
+
     def _onedal_fit(self, X, y, queue):
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            params = self._get_daal_params(X)
+            if self._fit_method == 'brute':
+                train_alg = bf_knn_classification_training
+
+            else:
+                train_alg = kdtree_knn_classification_training
+
+            return train_alg(**params).compute(X, y).model
+
         policy = _get_policy(queue, X, y)
         params = self._get_onedal_params(X)
         train_alg = _backend.neighbors.search.train(policy, params,
                                                     to_table(X))
 
-        return train_alg
+        return train_alg.model
 
     def _onedal_predict(self, model, X, params, queue):
+        gpu_device = queue is not None and queue.sycl_device.is_gpu
+        if self.effective_metric_ == 'euclidean' and not gpu_device:
+            if self._fit_method == 'brute':
+                predict_alg = bf_knn_classification_prediction
+
+            else:
+                predict_alg = kdtree_knn_classification_prediction
+
+            return predict_alg(**params).compute(X, model)
+
         policy = _get_policy(queue, X)
 
         if hasattr(self, '_onedal_model'):

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -49,7 +49,7 @@ class NeighborsCommonBase(metaclass=ABCMeta):
         if (method in ['auto', 'ball_tree']):
             condition = self.n_neighbors is not None and \
                 self.n_neighbors >= n_samples // 2
-            if self.metric == 'precomputed' or n_features > 11 or condition:
+            if self.metric == 'precomputed' or n_features > 15 or condition:
                 result_method = 'brute'
             else:
                 if self.metric == 'euclidean':

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -144,7 +144,7 @@ class NeighborsCommonBase(metaclass=ABCMeta):
             'voteWeights': 'voteUniform' if weights == 'uniform' else 'voteDistance',
             'resultsToCompute': 'computeIndicesOfNeighbors|computeDistances',
             'resultsToEvaluate': 'none' if getattr(self, '_y', None) is None
-                else 'computeClassLabels'
+            else 'computeClassLabels'
         }
         if class_count != 0:
             params['nClasses'] = class_count

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -33,7 +33,6 @@ if os.environ.get('OFF_ONEDAL_IFACE') is None and daal_check_version((2021, 'P',
     from .svm import NuSVC as NuSVC_sklearnex
 
     from .neighbors import KNeighborsClassifier as KNeighborsClassifier_sklearnex
-    # from .neighbors import KNeighborsRegressor as KNeighborsRegressor_sklearnex
     from .neighbors import NearestNeighbors as NearestNeighbors_sklearnex
 
     new_patching_available = True
@@ -65,17 +64,11 @@ def get_patch_map():
         # kNN
         mapping.pop('knn_classifier')
         mapping.pop('kneighborsclassifier')
-        # TODO: make kNN regression patching through onedal ifaces
-        # mapping.pop('knn_regressor')
-        # mapping.pop('kneighborsregressor')
         mapping.pop('nearest_neighbors')
         mapping.pop('nearestneighbors')
         mapping['knn_classifier'] = [[(neighbors_module,
                                        'KNeighborsClassifier',
                                        KNeighborsClassifier_sklearnex), None]]
-        # mapping['knn_regressor'] = [[(neighbors_module,
-        #                               'KNeighborsRegressor',
-        #                               KNeighborsRegressor_sklearnex), None]]
         mapping['nearest_neighbors'] = [[(neighbors_module,
                                           'NearestNeighbors',
                                           NearestNeighbors_sklearnex), None]]

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -282,7 +282,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
         if self._fit_method in ['auto', 'ball_tree']:
             condition = self.n_neighbors is not None and \
                 self.n_neighbors >= self.n_samples_fit_ // 2
-            if self.n_features_in_ > 11 or condition:
+            if self.n_features_in_ > 15 or condition:
                 result_method = 'brute'
             else:
                 if self.effective_metric_ in ['euclidean']:
@@ -330,7 +330,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
         if self._fit_method in ['auto', 'ball_tree']:
             condition = self.n_neighbors is not None and \
                 self.n_neighbors >= self.n_samples_fit_ // 2
-            if self.n_features_in_ > 11 or condition:
+            if self.n_features_in_ > 15 or condition:
                 result_method = 'brute'
             else:
                 if self.effective_metric_ in ['euclidean']:

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -306,7 +306,9 @@ class KNeighborsClassifier(KNeighborsClassifier_):
         is_valid_for_brute = result_method in ['brute'] and \
             self.effective_metric_ in ['manhattan',
                                        'minkowski',
-                                       'euclidean']
+                                       'euclidean',
+                                       'chebyshev',
+                                       'cosine']
         is_valid_weights = self.weights in ['uniform', "distance"]
         main_condition = is_valid_for_brute and not is_sparse and \
             is_single_output and is_valid_weights

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -244,7 +244,9 @@ class NearestNeighbors(NearestNeighbors_):
         is_valid_for_brute = result_method in ['brute'] and \
             self.effective_metric_ in ['manhattan',
                                        'minkowski',
-                                       'euclidean']
+                                       'euclidean',
+                                       'chebyshev',
+                                       'cosine']
         main_condition = is_valid_for_brute and not is_sparse
 
         if method_name == 'neighbors.NearestNeighbors.fit':

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -230,7 +230,7 @@ class NearestNeighbors(NearestNeighbors_):
         if self._fit_method in ['auto', 'ball_tree']:
             condition = self.n_neighbors is not None and \
                 self.n_neighbors >= self.n_samples_fit_ // 2
-            if self.n_features_in_ > 11 or condition:
+            if self.n_features_in_ > 15 or condition:
                 result_method = 'brute'
             else:
                 if self.effective_metric_ in ['euclidean']:
@@ -264,7 +264,7 @@ class NearestNeighbors(NearestNeighbors_):
         if self._fit_method in ['auto', 'ball_tree']:
             condition = self.n_neighbors is not None and \
                 self.n_neighbors >= self.n_samples_fit_ // 2
-            if self.n_features_in_ > 11 or condition:
+            if self.n_features_in_ > 15 or condition:
                 result_method = 'brute'
             else:
                 if self.effective_metric_ in ['euclidean']:


### PR DESCRIPTION
# Description
Usage of d4p functions has been returned for the default case(euclidean metric) to be aligned with previous performance results (temporary solution).
Commented lines from dispatcher has been removed.
Support for cosine and chebyshev metrics has been enabled for GPU (thanks to Nikita).
