### PR TITLE
Fix recursive imports for daal4py module

### DIFF
--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -21,29 +21,9 @@ import os
 from functools import lru_cache
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 
-# Classes for patching
-if os.environ.get('OFF_ONEDAL_IFACE') is None and daal_check_version((2021, 'P', 300)):
-    from ._config import set_config as set_config_sklearnex
-    from ._config import get_config as get_config_sklearnex
-    from ._config import config_context as config_context_sklearnex
-
-    from .svm import SVR as SVR_sklearnex
-    from .svm import SVC as SVC_sklearnex
-    from .svm import NuSVR as NuSVR_sklearnex
-    from .svm import NuSVC as NuSVC_sklearnex
-
-    from .neighbors import KNeighborsClassifier as KNeighborsClassifier_sklearnex
-    from .neighbors import NearestNeighbors as NearestNeighbors_sklearnex
-
-    new_patching_available = True
-else:
-    new_patching_available = False
-
-# Scikit-learn* modules
-
-import sklearn as base_module
-import sklearn.svm as svm_module
-import sklearn.neighbors as neighbors_module
+def _is_new_patching_available():
+    return os.environ.get('OFF_ONEDAL_IFACE') is None \
+           and daal_check_version((2021, 'P', 300))
 
 
 @lru_cache(maxsize=None)
@@ -51,7 +31,28 @@ def get_patch_map():
     from daal4py.sklearn.monkeypatch.dispatcher import _get_map_of_algorithms
     mapping = _get_map_of_algorithms().copy()
 
-    if new_patching_available:
+    if _is_new_patching_available():
+       # Classes for patching
+
+        from ._config import set_config as set_config_sklearnex
+        from ._config import get_config as get_config_sklearnex
+        from ._config import config_context as config_context_sklearnex
+
+        from .svm import SVR as SVR_sklearnex
+        from .svm import SVC as SVC_sklearnex
+        from .svm import NuSVR as NuSVR_sklearnex
+        from .svm import NuSVC as NuSVC_sklearnex
+
+        from .neighbors import KNeighborsClassifier as KNeighborsClassifier_sklearnex
+        from .neighbors import NearestNeighbors as NearestNeighbors_sklearnex
+
+        # Scikit-learn* modules
+
+        import sklearn as base_module
+        import sklearn.svm as svm_module
+        import sklearn.neighbors as neighbors_module
+
+        # Patch for mapping
         # Algorithms
         # SVM
         mapping.pop('svm')
@@ -101,7 +102,7 @@ def patch_sklearn(name=None, verbose=True, global_patch=False):
 
     from daal4py.sklearn import patch_sklearn as patch_sklearn_orig
 
-    if new_patching_available:
+    if _is_new_patching_available():
         for config in ['set_config', 'get_config', 'config_context']:
             patch_sklearn_orig(config, verbose=False, deprecation=False,
                                get_map=get_patch_map)
@@ -129,7 +130,7 @@ def unpatch_sklearn(name=None, global_unpatch=False):
         for algorithm in name:
             unpatch_sklearn_orig(algorithm, get_map=get_patch_map)
     else:
-        if new_patching_available:
+        if _is_new_patching_available():
             for config in ['set_config', 'get_config', 'config_context']:
                 unpatch_sklearn_orig(config, get_map=get_patch_map)
         unpatch_sklearn_orig(name, get_map=get_patch_map)

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -21,9 +21,10 @@ import os
 from functools import lru_cache
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 
+
 def _is_new_patching_available():
     return os.environ.get('OFF_ONEDAL_IFACE') is None \
-           and daal_check_version((2021, 'P', 300))
+        and daal_check_version((2021, 'P', 300))
 
 
 @lru_cache(maxsize=None)
@@ -32,7 +33,7 @@ def get_patch_map():
     mapping = _get_map_of_algorithms().copy()
 
     if _is_new_patching_available():
-       # Classes for patching
+        # Classes for patching
 
         from ._config import set_config as set_config_sklearnex
         from ._config import get_config as get_config_sklearnex


### PR DESCRIPTION
Noticed circular dependency ( For example, when executing code `from daal4py.sklearn.cluster import KMeans`):
**daal4py -> daal4py.sklearn -> daal4py.monkeypatch.dispatcher -> daal4py.sklearn.neighbors -> daal4py._device_offload -> sklearnex -> sklearnex.dispatcher -> sklearnex.neighbors -> daal4py.sklearn.neighbors**

 
