### PR TITLE
Update logistic_path.py

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -661,6 +661,7 @@ def __logistic_regression_path(
                 n_classes = max(2, classes.size)
                 if sklearn_check_version('1.1'):
                     if solver in ["lbfgs", "newton-cg"]:
+                        n_classes = max(2, classes.size)
                         multi_w0 = np.reshape(w0, (n_classes, -1), order="F")
                     else:
                         multi_w0 = w0


### PR DESCRIPTION
Multinomial multi classes were erroring with unhandled exceptions for logistic_path because n_classes hadn't been assigned. This patch fixes the issue.

# Description
This is a one-liner to set the n_classes variable. The recent changes for scikit-learn 1.1 eliminated the required assignement of class count, causing multiclass logistic regressions to fail with exception. 

Changes proposed in this pull request:
- Assign n_class

 
