### PR TITLE
Fix incorrect global patching command

### DIFF
--- a/doc/sources/global-patching.rst
+++ b/doc/sources/global-patching.rst
@@ -33,7 +33,7 @@ Patch all supported algorithms
 
 To patch all :ref:`supported algorithms <sklearn_algorithms>`, run::
 
-    python sklearnex.glob patch_sklearn
+    python -m sklearnex.glob patch_sklearn
 
 Patch selected algorithms
 =========================
@@ -43,14 +43,14 @@ with a list of algorithms to patch.
 
 For example, to patch only SVC and RandomForestClassifier estimators, run::
 
-    python sklearnex.glob patch_sklearn -a svc random_forest_classifier
+    python -m sklearnex.glob patch_sklearn -a svc random_forest_classifier
 
 Disable patching notifications
 ==============================
 
 If you do not want to receive patching notifications, then use ``--no-verbose`` or ``-nv`` keys::
 
-    python sklearnex.glob patch_sklearn -a svc random_forest_classifier -nv
+    python -m sklearnex.glob patch_sklearn -a svc random_forest_classifier -nv
 
 .. note::
     If you run the global patching command several times with different parameters,
@@ -61,7 +61,7 @@ Disable global patching
 
 To disable global patching, use the following command::
 
-    python sklearnex.glob unpatch_sklearn
+    python -m sklearnex.glob unpatch_sklearn
 
 Enable global patching via code
 ===============================


### PR DESCRIPTION
We received an [issue](https://github.com/intel/scikit-learn-intelex/issues/1004) on the github about the incorrect command for global patching.

# Description
I've changed 
```
python sklearnex.glob patch_sklearn
```
 to
 
```
python -m sklearnex.glob patch_sklearn 
```