### PR TITLE
added shape attr check in validation

### DIFF
--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -331,7 +331,7 @@ def _num_samples(x):
             )
     # Check that shape is returning an integer or default to len
     # Dask dataframes may not return numeric shape[0] value
-    if isinstance(x.shape[0], Integral):
+    if hasattr(x, "shape") and isinstance(x.shape[0], Integral):
         return x.shape[0]
 
     try:


### PR DESCRIPTION
We ran into a problem with [predict_proba in knn](https://github.com/intel/scikit-learn-intelex/issues/1013). If the **predict_proba** method receives a **list** as input, the method will return an **error**. This is because we were trying to extract the **shape** attr from the **list**. 
I added an extra check to avoid this.