### PR TITLE
Bump up `dal` and `dal-devel` version to 2021.6.0 in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -53,9 +53,9 @@ requirements:
         - make
     run:
         - python
-        - dpcpp_cpp_rt ==2022.0.1
-        - dal ==2021.6.0  # [linux]
-        - dal ==2021.6.0  # [win or osx]
+        - dpcpp_cpp_rt ==2022.0.1  # [linux]
+        - dpcpp_cpp_rt ==2022.0.0  # [win or osx]
+        - dal ==2021.6.0
     ignore_run_exports:
         - numpy
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,8 +43,7 @@ requirements:
         - python
         - setuptools
         - numpy {{ numpy }}
-        - dal-devel ==2021.6.0  # [linux]
-        - dal-devel ==2021.6.0  # [win or osx]
+        - dal-devel ==2021.6.0
         - cython
         - jinja2
         - mpich  # [osx]
@@ -54,8 +53,7 @@ requirements:
         - make
     run:
         - python
-        - dpcpp_cpp_rt ==2022.0.1  # [linux]
-        - dpcpp_cpp_rt ==2022.0.0  # [win or osx]
+        - dpcpp_cpp_rt ==2022.0.1
         - dal ==2021.6.0  # [linux]
         - dal ==2021.6.0  # [win or osx]
     ignore_run_exports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,8 +43,8 @@ requirements:
         - python
         - setuptools
         - numpy {{ numpy }}
-        - dal-devel ==2021.5.1  # [linux]
-        - dal-devel ==2021.5.0  # [win or osx]
+        - dal-devel ==2021.6.0  # [linux]
+        - dal-devel ==2021.6.0  # [win or osx]
         - cython
         - jinja2
         - mpich  # [osx]
@@ -56,8 +56,8 @@ requirements:
         - python
         - dpcpp_cpp_rt ==2022.0.1  # [linux]
         - dpcpp_cpp_rt ==2022.0.0  # [win or osx]
-        - dal ==2021.5.1  # [linux]
-        - dal ==2021.5.0  # [win or osx]
+        - dal ==2021.6.0  # [linux]
+        - dal ==2021.6.0  # [win or osx]
     ignore_run_exports:
         - numpy
 


### PR DESCRIPTION
# Description
Bump up `dal` and `dal-devel` version to 2021.6.0 in conda recipe

 
