### PR TITLE
Changed AI Kit references

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@
 Intel(R) Extension for Scikit-learn is available at the [Python Package Index](https://pypi.org/project/scikit-learn-intelex/),
 on Anaconda Cloud in [Conda-Forge channel](https://anaconda.org/conda-forge/scikit-learn-intelex) and in [Intel channel](https://anaconda.org/intel/scikit-learn-intelex). You can also build the extension from sources.
 
-The extension is also available as a part of [Intel® oneAPI AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit). If you already have AI Kit installed, you do not need to separately install the extension.
+The extension is also available as a part of [Intel® AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit). If you already have AI Kit installed, you do not need to separately install the extension.
 
 ## Installation scenarios <!-- omit in toc -->
 
@@ -193,11 +193,11 @@ Intel(R) Extension for Scikit-learn is easily built from sources with the majori
 
 ⚠️ Keys `--single-version-externally-managed` and `--no-deps` are required so that daal4py is not downloaded after installation of Intel(R) Extension for Scikit-learn
 
-⚠️ The `develop` mode will not install the package but it will create a `.egg-link` in the deployment directory 
-back to the project source code directory. That way you can edit the source code and see the changes 
+⚠️ The `develop` mode will not install the package but it will create a `.egg-link` in the deployment directory
+back to the project source code directory. That way you can edit the source code and see the changes
 without having to reinstall package every time you make a small change.
 
-⚠️ `--single-version-externally-managed` is an option used for Python packages instructing the setuptools module 
+⚠️ `--single-version-externally-managed` is an option used for Python packages instructing the setuptools module
 to create a Python package that can be easily managed by the package manager on the host.
 
 ## Build documentation for Intel(R) Extension for Scikit-learn

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ One of the ways to patch scikit-learn is by modifying the code. First, you impor
     ```
 
 - **Enable Intel GPU optimizations**
-  
+
     ```py
     import numpy as np
     import dpctl
@@ -56,7 +56,7 @@ This software acceleration is achieved through the use of vector instructions, I
 
 ## Supported Algorithms
 
-❗ The patching only affects [selected algorithms and their parameters](https://intel.github.io/scikit-learn-intelex/algorithms.html). 
+❗ The patching only affects [selected algorithms and their parameters](https://intel.github.io/scikit-learn-intelex/algorithms.html).
 
 You may still use algorithms and parameters not supported by Intel(R) Extension for Scikit-learn in your code. You will not get an error if you do this. When you use algorithms or parameters not supported by the extension, the package fallbacks into original stock version of scikit-learn.
 
@@ -76,7 +76,7 @@ Configurations:
 Intel(R) Extension for Scikit-learn is available at the [Python Package Index](https://pypi.org/project/scikit-learn-intelex/),
 on Anaconda Cloud in [Conda-Forge channel](https://anaconda.org/conda-forge/scikit-learn-intelex) and in [Intel channel](https://anaconda.org/intel/scikit-learn-intelex). You can also build the extension from [sources](INSTALL.md#build-from-sources).
 
-The extension is also available as a part of [Intel® oneAPI AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit). If you already have AI Kit installed, you do not need to install the extension.
+The extension is also available as a part of [Intel® AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit). If you already have AI Kit installed, you do not need to install the extension.
 
 Installation via `pip` package manager is recommended by default:
 
@@ -111,7 +111,7 @@ We publish blogs on Medium, so [follow us](https://medium.com/intel-analytics-so
 
 ### ❓ Are all algorithms affected by patching?
 
-> No. The patching only affects [selected algorithms and their parameters](https://intel.github.io/scikit-learn-intelex/algorithms.html). 
+> No. The patching only affects [selected algorithms and their parameters](https://intel.github.io/scikit-learn-intelex/algorithms.html).
 
 ### ❓ What happens if I use parameters not supported by the extension?
 
@@ -147,7 +147,7 @@ You may reach out to project maintainers privately at onedal.maintainers@intel.c
 
 ## oneAPI
 
-Intel(R) Extension for Scikit-learn is part of [oneAPI](https://oneapi.io) and [Intel® oneAPI AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit).
+Intel(R) Extension for Scikit-learn is part of [oneAPI](https://oneapi.io) and [Intel® AI Analytics Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html) (AI Kit).
 
 ## daalpy and oneDAL
 

--- a/doc/sources/installation.rst
+++ b/doc/sources/installation.rst
@@ -23,9 +23,9 @@ Installation
 
 |intelex| is available at the `Python Package Index <https://pypi.org/project/scikit-learn-intelex/>`_,
 on Anaconda Cloud in `Conda-Forge channel <https://anaconda.org/conda-forge/scikit-learn-intelex>`_ and
-in `Intel channel <https://anaconda.org/intel/scikit-learn-intelex>`_. 
+in `Intel channel <https://anaconda.org/intel/scikit-learn-intelex>`_.
 
-|intelex| is also available as a part of `Intel oneAPI AI Analytics Toolkit
+|intelex| is also available as a part of `Intel AI Analytics Toolkit
 <https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html#gs.3lkbv3>`_ (AI Kit).
 If you already have AI Kit installed, you do not need to separately install the extension.
 
@@ -48,7 +48,7 @@ Install from PyPI (recommended by default)
       .. tab:: Linux
 
          ::
-            
+
             python -m venv env
             source env/bin/activate
 
@@ -77,21 +77,21 @@ For each distribution channel, there are two installation options: with and with
 
        conda create -n env -c conda-forge python=3.9 scikit-learn-intelex
 
-    .. important:: 
-    
+    .. important::
+
        If you do not specify the version of Python (``python=3.9`` in the example above), then Python 3.10 is downloaded by default,
        which is not supported.
 
        See :ref:`supported configurations for Conda-Forge channel <sys_req_conda_forge>`.
 
   - into your current environment::
-    
+
        conda install scikit-learn-intelex -c conda-forge
 
 - Install from **Anaconda Cloud: Intel channel** (recommended for the users of Intel® Distribution for Python):
 
   - into a newly created environment (recommended)::
-    
+
        conda create -n env -c intel python scikit-learn-intelex
 
     Note that you may also specify the version of Python to download
@@ -101,24 +101,24 @@ For each distribution channel, there are two installation options: with and with
        conda create -n env -c intel python=3.7 scikit-learn-intelex
 
   - into your current environment::
-    
+
        conda install scikit-learn-intelex -c intel
 
 - Install from **Anaconda Cloud: Main channel**:
 
   - into a newly created environment (recommended)::
-    
+
        conda create -n env python=3.9 scikit-learn-intelex
 
-    .. important:: 
-    
+    .. important::
+
        If you do not specify the version of Python (``python=3.9`` in the example above), then Python 3.10 is downloaded by default,
        which is not supported.
-       
+
        See :ref:`supported configurations for Anaconda main channel <sys_req_conda_main>`.
 
   - into your current environment::
-    
+
        conda install scikit-learn-intelex
 
 .. _build_from_sources:


### PR DESCRIPTION

# Description
Removed "oneAPI" from the AI Kit name. Used the name in namesdb.intel.com "Intel(R) AI Analytics Toolkit"

Changes proposed in this pull request:
- remove "oneAPI" from the AI Kit brand name to match what is in namesdb.intel.com
-
-

This PR satisfies [DOC-10220](https://jira.devtools.intel.com/browse/DOC-10220)
