### PR TITLE
add `-m` option make the document could be use correctly

### DIFF
--- a/doc/sources/patching/patching-options.rst
+++ b/doc/sources/patching/patching-options.rst
@@ -38,4 +38,4 @@
 
 - Through :ref:`global patching <global_patching>` to enable patching for your scikit-learn installation for all further runs::
 
-    python sklearnex.glob patch_sklearn
+    python -m sklearnex.glob patch_sklearn

--- a/doc/sources/what-is-patching.rst
+++ b/doc/sources/what-is-patching.rst
@@ -34,7 +34,7 @@ Patching
       One of the patching options available in |intelex|.
       With global patching, you can patch all scikit-learn applications at once::
 
-         python sklearnex.glob patch_sklearn
+         python -m sklearnex.glob patch_sklearn
       
       .. seealso:: :ref:`global_patching`
    


### PR DESCRIPTION
# Description
Some document page does not update the correct usage of `global patching`


## Relate pull request

https://github.com/intel/scikit-learn-intelex/pull/1008

> `python sklearnex.glob patch_sklearn` to `python -m sklearnex.glob patch_sklearn`

## Change page

- [scikit-learn-intelex](https://intel.github.io/scikit-learn-intelex/)
- [global-patching](https://intel.github.io/scikit-learn-intelex/global-patching.html#patch-all-supported-algorithms)