### PR TITLE
Fix binary AUC calculation for boolean labels

### DIFF
--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -158,6 +158,7 @@ def _daal_roc_auc_score(
         if _dal_ready:
             if not np.array_equal(labels, [0, 1]) or labels.dtype == bool:
                 y_true = label_binarize(y_true, classes=labels)[:, 0]
+                y_score = label_binarize(y_score, classes=labels)[:, 0]
             result = d4p.daal_roc_auc_score(y_true.reshape(-1, 1),
                                             y_score.reshape(-1, 1))
             if result != -1:

--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -158,7 +158,8 @@ def _daal_roc_auc_score(
         if _dal_ready:
             if not np.array_equal(labels, [0, 1]) or labels.dtype == bool:
                 y_true = label_binarize(y_true, classes=labels)[:, 0]
-                y_score = label_binarize(y_score, classes=labels)[:, 0]
+                if hasattr(y_score, 'dtype') and y_score.dtype == bool:
+                    y_score = label_binarize(y_score, classes=labels)[:, 0]
             result = d4p.daal_roc_auc_score(y_true.reshape(-1, 1),
                                             y_score.reshape(-1, 1))
             if result != -1:


### PR DESCRIPTION
Fixes #1029 

When `y_true` passed as `bool`, it is converted to `int` using `label_binarizer`. But `y_score` was not handled for such case. 

When boolean labels passed, e.g. binary classification problem, AUC calculation fails as  `y_true` is converted to `int` but `y_score` is not. 

This PR converts `y_score` to `int` using `label_binarizer` just like `y_true`. 