### PR TITLE
Modify checks on alpha, l1_ratio, max_iter in coordinate descent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,31 +1,32 @@
 # Infra and tools
-.ci/                          @napetrov
-.github/                      @napetrov
-.circleci/                    @Pahandrovich
+.ci/                          @napetrov @Alexsandruss
+.github/                      @napetrov @Alexsandruss
+.circleci/                    @napetrov @Alexsandruss
 
 # Docs
 *.md                          @maria-Petrova
 doc/                          @maria-Petrova
 
 # DPC++
-**/oneapi/                    @vlad-nazarov
+**/oneapi/                    @Alexsandruss @samir-nasibli @KulikovNikita
+onedal/                       @Alexsandruss @samir-nasibli @KulikovNikita
+sklearnex/                    @Alexsandruss @samir-nasibli @KulikovNikita
 
 # Examples 
-examples/                     @Pahandrovich @vlad-nazarov
-examples/notebooks/           @maria-Petrova
+examples/daal4py/             @maria-Petrova @Alexsandruss @samir-nasibli
+examples/notebooks/           @maria-Petrova @Alexsandruss
 
 # Dependencies
-setup.py                      @Pahandrovich
-requirements*                 @Pahandrovich
-requirements-doc.txt          @maria-Petrova
-conda-recipe/                 @Pahandrovich
+setup.py                      @Alexsandruss
+requirements*                 @maria-Petrova @Alexsandruss
+conda-recipe/                 @Alexsandruss
 
 # Testing
-**/test*.py                   @Pahandrovich
+**/test*.py                   @Alexsandruss @samir-nasibli
 
 # Scikit-learn patching
-daal4py/sklearn/              @Pahandrovich @vlad-nazarov
+daal4py/sklearn/              @Alexsandruss @samir-nasibli
 
 # Core
-src/                          @Pahandrovich @vlad-nazarov
-generator/                    @Pahandrovich @vlad-nazarov
+src/                          @Alexsandruss
+generator/                    @Alexsandruss

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/scikit-learn-intelex)](https://pypi.org/project/scikit-learn-intelex/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scikit-learn-intelex)](https://anaconda.org/conda-forge/scikit-learn-intelex)
 [![python version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue)](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue)
-[![scikit-learn supported versions](https://img.shields.io/badge/sklern-0.22%20%7C%200.23%20%7C%200.24%20%7C%201.0-blue)](https://img.shields.io/badge/sklern-0.22%20%7C%200.23%20%7C%200.24%20%7C%201.0-blue)
+[![scikit-learn supported versions](https://img.shields.io/badge/sklearn-0.22%20%7C%200.23%20%7C%200.24%20%7C%201.0-blue)](https://img.shields.io/badge/sklearn-0.22%20%7C%200.23%20%7C%200.24%20%7C%201.0-blue)
 
 With Intel(R) Extension for Scikit-learn you can accelerate your Scikit-learn applications and still have full conformance with all Scikit-Learn APIs and algorithms. This is a **free software AI accelerator** that brings over **10-100X** acceleration across a variety of applications. And you do not even need to change the existing code!
 
@@ -160,3 +160,4 @@ The acceleration is achieved through the use of the Intel(R) oneAPI Data Analyti
 You can learn more about daal4py in [daal4py documentation](https://intelpython.github.io/daal4py).
 
 ---
+

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,8 +43,7 @@ requirements:
         - python
         - setuptools
         - numpy {{ numpy }}
-        - dal-devel ==2021.5.1  # [linux]
-        - dal-devel ==2021.5.0  # [win or osx]
+        - dal-devel ==2021.6.0
         - cython
         - jinja2
         - mpich  # [osx]
@@ -56,8 +55,7 @@ requirements:
         - python
         - dpcpp_cpp_rt ==2022.0.1  # [linux]
         - dpcpp_cpp_rt ==2022.0.0  # [win or osx]
-        - dal ==2021.5.1  # [linux]
-        - dal ==2021.5.0  # [win or osx]
+        - dal ==2021.6.0
     ignore_run_exports:
         - numpy
 

--- a/daal4py/sklearn/cluster/_dbscan.py
+++ b/daal4py/sklearn/cluster/_dbscan.py
@@ -233,7 +233,7 @@ class DBSCAN(DBSCAN_original):
             Returns a fitted instance of self.
         """
         if self.eps <= 0.0:
-            raise ValueError("eps must be positive.")
+            raise ValueError(f"eps == {self.eps}, must be > 0.0.")
 
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -27,7 +27,7 @@ from daal4py.sklearn._utils import (
     PatchingConditionsChain)
 import logging
 
-from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree._tree import Tree
 from sklearn.ensemble import RandomForestClassifier as RandomForestClassifier_original
 from sklearn.ensemble import RandomForestRegressor as RandomForestRegressor_original
@@ -1052,7 +1052,7 @@ class RandomForestRegressor(RandomForestRegressor_original):
         }
         if not sklearn_check_version('1.0'):
             params['min_impurity_split'] = self.min_impurity_split
-        est = DecisionTreeClassifier(**params)
+        est = DecisionTreeRegressor(**params)
 
         # we need to set est.tree_ field with Trees constructed from Intel(R)
         # oneAPI Data Analytics Library solution

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -40,16 +40,23 @@ def _daal4py_check(self, X, y, check_input):
     _fptype = getFPType(X)
 
     # check alpha
-    if self.alpha == 0:
+    if isinstance(self.alpha, numbers.Number) and self.alpha < 0:
+        raise ValueError(f"alpha == {self.alpha}, must be >= 0.0")
+    elif self.alpha == 0:
         warnings.warn("With alpha=0, this algorithm does not converge "
                       "well. You are advised to use the LinearRegression "
                       "estimator", stacklevel=2)
 
     # check l1_ratio
-    if not isinstance(self.l1_ratio, numbers.Number) or \
-            self.l1_ratio < 0 or self.l1_ratio > 1:
-        raise ValueError("l1_ratio must be between 0 and 1; "
-                         f"got l1_ratio={self.l1_ratio}")
+    if isinstance(self.l1_ratio, numbers.Number):
+        if self.l1_ratio < 0 or self.l1_ratio > 1:
+            raise ValueError("l1_ratio must be an instance of float between "
+                             f"0 and 1; got l1_ratio={self.l1_ratio}")
+    elif isinstance(self.l1_ratio, str):
+        raise TypeError("l1_ratio must be an instance of float, not str")
+
+    if isinstance(self.max_iter, int) and self.max_iter<1:
+        raise ValueError(f"max_iter == {self.max_iter}, must be >= 1.")
 
     # check precompute
     if isinstance(self.precompute, np.ndarray):

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -55,7 +55,7 @@ def _daal4py_check(self, X, y, check_input):
     elif isinstance(self.l1_ratio, str):
         raise TypeError("l1_ratio must be an instance of float, not str")
 
-    if isinstance(self.max_iter, int) and self.max_iter<1:
+    if isinstance(self.max_iter, int) and self.max_iter < 1:
         raise ValueError(f"max_iter == {self.max_iter}, must be >= 1.")
 
     # check precompute

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -48,12 +48,10 @@ def _daal4py_check(self, X, y, check_input):
                       "estimator", stacklevel=2)
 
     # check l1_ratio
-    if isinstance(self.l1_ratio, numbers.Number):
-        if self.l1_ratio < 0 or self.l1_ratio > 1:
-            raise ValueError("l1_ratio must be an instance of float between "
-                             f"0 and 1; got l1_ratio={self.l1_ratio}")
-    elif isinstance(self.l1_ratio, str):
-        raise TypeError("l1_ratio must be an instance of float, not str")
+    if not isinstance(self.l1_ratio, numbers.Number) or \
+            self.l1_ratio < 0 or self.l1_ratio > 1:
+        raise ValueError("l1_ratio must be between 0 and 1; "
+                         f"got l1_ratio={self.l1_ratio}")
 
     if isinstance(self.max_iter, int) and self.max_iter < 1:
         raise ValueError(f"max_iter == {self.max_iter}, must be >= 1.")

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -405,7 +405,10 @@ def _fit(self, X, y, sample_weight=None, check_input=True):
     else:
         self.fit_shape_good_for_daal_ = False
 
-    _function_name = f"sklearn.linear_model.{self.__class__.__name__}.fit"
+    class_name = self.__class__.__name__
+    class_inst = ElasticNet if class_name == 'ElasticNet' else Lasso
+
+    _function_name = f"sklearn.linear_model.{class_name}.fit"
     _patching_status = PatchingConditionsChain(
         _function_name)
     _dal_ready = _patching_status.and_conditions([
@@ -423,10 +426,10 @@ def _fit(self, X, y, sample_weight=None, check_input=True):
         if hasattr(self, 'daal_model_'):
             del self.daal_model_
         if sklearn_check_version('0.23'):
-            res_new = super(ElasticNet, self).fit(
+            res_new = super(class_inst, self).fit(
                 X, y, sample_weight=sample_weight, check_input=check_input)
         else:
-            res_new = super(ElasticNet, self).fit(
+            res_new = super(class_inst, self).fit(
                 X, y, check_input=check_input)
         self._gap = res_new.dual_gap_
         return res_new
@@ -447,7 +450,7 @@ def _fit(self, X, y, sample_weight=None, check_input=True):
         self._normalize = _deprecate_normalize(
             self.normalize,
             default=False,
-            estimator_name=self.__class__.__name__)
+            estimator_name=class_name)
 
     # only for pass tests
     # "check_estimators_fit_returns_self(readonly_memmap=True) and
@@ -457,7 +460,7 @@ def _fit(self, X, y, sample_weight=None, check_input=True):
     if not y.flags.writeable:
         y = np.copy(y)
 
-    if self.__class__.__name__ == "ElasticNet":
+    if class_name == "ElasticNet":
         res = _daal4py_fit_enet(self, X, y, check_input=check_input)
     else:
         res = _daal4py_fit_lasso(self, X, y, check_input=check_input)
@@ -468,14 +471,72 @@ def _fit(self, X, y, sample_weight=None, check_input=True):
             _function_name + ": " + get_patch_message("sklearn_after_daal")
         )
         if sklearn_check_version('0.23'):
-            res_new = super(ElasticNet, self).fit(
+            res_new = super(class_inst, self).fit(
                 X, y, sample_weight=sample_weight, check_input=check_input)
         else:
-            res_new = super(ElasticNet, self).fit(
+            res_new = super(class_inst, self).fit(
                 X, y, check_input=check_input)
         self._gap = res_new.dual_gap_
         return res_new
     return res
+
+
+def _dual_gap(self):
+    if (self._gap is None):
+        l1_reg = self.alpha * self.l1_ratio * self._X.shape[0]
+        l2_reg = self.alpha * (1.0 - self.l1_ratio) * self._X.shape[0]
+        n_targets = self._y.shape[1]
+
+        if (n_targets == 1):
+            self._gap = self.tol + 1.0
+            X_offset = np.average(self._X, axis=0)
+            y_offset = np.average(self._y, axis=0)
+            coef = np.reshape(self.coef_, (self.coef_.shape[0], 1))
+            R = (self._y - y_offset) - np.dot((self._X - X_offset), coef)
+            XtA = np.dot((self._X - X_offset).T, R) - l2_reg * coef
+            R_norm2 = np.dot(R.T, R)
+            coef_norm2 = np.dot(self.coef_, self.coef_)
+            dual_norm_XtA = np.max(
+                XtA) if self.positive else np.max(np.abs(XtA))
+            if dual_norm_XtA > l1_reg:
+                const = l1_reg / dual_norm_XtA
+                A_norm2 = R_norm2 * (const ** 2)
+                self._gap = 0.5 * (R_norm2 + A_norm2)
+            else:
+                const = 1.0
+                self._gap = R_norm2
+            l1_norm = np.sum(np.abs(self.coef_))
+            tmp = l1_reg * l1_norm
+            tmp -= const * np.dot(R.T, (self._y - y_offset))
+            tmp += 0.5 * l2_reg * (1 + const ** 2) * coef_norm2
+            self._gap += tmp
+            self._gap = self._gap[0][0]
+        else:
+            self._gap = np.full(n_targets, self.tol + 1.0)
+            X_offset = np.average(self._X, axis=0)
+            y_offset = np.average(self._y, axis=0)
+            for k in range(n_targets):
+                R = (self._y[:, k] - y_offset[k]) - \
+                    np.dot((self._X - X_offset), self.coef_[k, :].T)
+                XtA = np.dot((self._X - X_offset).T, R) - \
+                    l2_reg * self.coef_[k, :].T
+                R_norm2 = np.dot(R.T, R)
+                coef_norm2 = np.dot(self.coef_[k, :], self.coef_[k, :].T)
+                dual_norm_XtA = np.max(
+                    XtA) if self.positive else np.max(np.abs(XtA))
+                if dual_norm_XtA > l1_reg:
+                    const = l1_reg / dual_norm_XtA
+                    A_norm2 = R_norm2 * (const ** 2)
+                    self._gap[k] = 0.5 * (R_norm2 + A_norm2)
+                else:
+                    const = 1.0
+                    self._gap[k] = R_norm2
+                l1_norm = np.sum(np.abs(self.coef_[k, :]))
+                tmp = l1_reg * l1_norm
+                tmp -= const * np.dot(R.T, (self._y[:, k] - y_offset[k]))
+                tmp += 0.5 * l2_reg * (1 + const ** 2) * coef_norm2
+                self._gap[k] += tmp
+    return self._gap
 
 
 class ElasticNet(ElasticNet_original):
@@ -623,61 +684,7 @@ class ElasticNet(ElasticNet_original):
 
     @property
     def dual_gap_(self):
-        if (self._gap is None):
-            l1_reg = self.alpha * self.l1_ratio * self._X.shape[0]
-            l2_reg = self.alpha * (1.0 - self.l1_ratio) * self._X.shape[0]
-            n_targets = self._y.shape[1]
-
-            if (n_targets == 1):
-                self._gap = self.tol + 1.0
-                X_offset = np.average(self._X, axis=0)
-                y_offset = np.average(self._y, axis=0)
-                coef = np.reshape(self.coef_, (self.coef_.shape[0], 1))
-                R = (self._y - y_offset) - np.dot((self._X - X_offset), coef)
-                XtA = np.dot((self._X - X_offset).T, R) - l2_reg * coef
-                R_norm2 = np.dot(R.T, R)
-                coef_norm2 = np.dot(self.coef_, self.coef_)
-                dual_norm_XtA = np.max(
-                    XtA) if self.positive else np.max(np.abs(XtA))
-                if dual_norm_XtA > l1_reg:
-                    const = l1_reg / dual_norm_XtA
-                    A_norm2 = R_norm2 * (const ** 2)
-                    self._gap = 0.5 * (R_norm2 + A_norm2)
-                else:
-                    const = 1.0
-                    self._gap = R_norm2
-                l1_norm = np.sum(np.abs(self.coef_))
-                tmp = l1_reg * l1_norm
-                tmp -= const * np.dot(R.T, (self._y - y_offset))
-                tmp += 0.5 * l2_reg * (1 + const ** 2) * coef_norm2
-                self._gap += tmp
-                self._gap = self._gap[0][0]
-            else:
-                self._gap = np.full(n_targets, self.tol + 1.0)
-                X_offset = np.average(self._X, axis=0)
-                y_offset = np.average(self._y, axis=0)
-                for k in range(n_targets):
-                    R = (self._y[:, k] - y_offset[k]) - \
-                        np.dot((self._X - X_offset), self.coef_[k, :].T)
-                    XtA = np.dot((self._X - X_offset).T, R) - \
-                        l2_reg * self.coef_[k, :].T
-                    R_norm2 = np.dot(R.T, R)
-                    coef_norm2 = np.dot(self.coef_[k, :], self.coef_[k, :].T)
-                    dual_norm_XtA = np.max(
-                        XtA) if self.positive else np.max(np.abs(XtA))
-                    if dual_norm_XtA > l1_reg:
-                        const = l1_reg / dual_norm_XtA
-                        A_norm2 = R_norm2 * (const ** 2)
-                        self._gap[k] = 0.5 * (R_norm2 + A_norm2)
-                    else:
-                        const = 1.0
-                        self._gap[k] = R_norm2
-                    l1_norm = np.sum(np.abs(self.coef_[k, :]))
-                    tmp = l1_reg * l1_norm
-                    tmp -= const * np.dot(R.T, (self._y[:, k] - y_offset[k]))
-                    tmp += 0.5 * l2_reg * (1 + const ** 2) * coef_norm2
-                    self._gap[k] += tmp
-        return self._gap
+        return _dual_gap(self)
 
     @dual_gap_.setter
     def dual_gap_(self, value):
@@ -688,7 +695,7 @@ class ElasticNet(ElasticNet_original):
         self._gap = None
 
 
-class Lasso(ElasticNet):
+class Lasso(Lasso_original):
     __doc__ = Lasso_original.__doc__
 
     def __init__(
@@ -705,9 +712,9 @@ class Lasso(ElasticNet):
         random_state=None,
         selection='cyclic',
     ):
+        self.l1_ratio = 1.0
         super().__init__(
             alpha=alpha,
-            l1_ratio=1.0,
             fit_intercept=fit_intercept,
             normalize=normalize,
             precompute=precompute,
@@ -827,3 +834,15 @@ class Lasso(ElasticNet):
         if not _dal_ready:
             return self._decision_function(X)
         return _daal4py_predict_lasso(self, X)
+
+    @property
+    def dual_gap_(self):
+        return _dual_gap(self)
+
+    @dual_gap_.setter
+    def dual_gap_(self, value):
+        self._gap = value
+
+    @dual_gap_.deleter
+    def dual_gap_(self):
+        self._gap = None

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -658,13 +658,13 @@ def __logistic_regression_path(
                 else:
                     multi_w0 = np.reshape(w0, (classes.size, -1))
             else:
+                n_classes = max(2, classes.size)
                 if sklearn_check_version('1.1'):
                     if solver in ["lbfgs", "newton-cg"]:
                         multi_w0 = np.reshape(w0, (n_classes, -1), order="F")
                     else:
                         multi_w0 = w0
                 else:
-                    n_classes = max(2, classes.size)
                     multi_w0 = np.reshape(w0, (n_classes, -1))
                 if n_classes == 2:
                     multi_w0 = multi_w0[1][np.newaxis, :]

--- a/daal4py/sklearn/manifold/_t_sne.py
+++ b/daal4py/sklearn/manifold/_t_sne.py
@@ -164,7 +164,7 @@ class TSNE(BaseTSNE):
                                  "or 'auto'.")
 
         if hasattr(self, 'square_distances'):
-            if self.square_distances not in [True, 'legacy']:
+            if self.square_distances not in [True, 'legacy', 'deprecated']:
                 raise ValueError("'square_distances' must be True or 'legacy'.")
             if self.metric != "euclidean" and self.square_distances is not True:
                 warnings.warn(("'square_distances' has been introduced in 0.24"

--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -18,7 +18,7 @@ import daal4py as d4p
 import numpy as np
 from functools import partial
 from collections.abc import Sequence
-from scipy.sparse.base import spmatrix
+from scipy import sparse as sp
 
 from sklearn.utils import check_array
 from sklearn.utils.multiclass import is_multilabel
@@ -47,7 +47,7 @@ except ImportError:
 def _daal_type_of_target(y):
     valid = (
         isinstance(
-            y, (Sequence, spmatrix)) or hasattr(
+            y, Sequence) or sp.isspmatrix(y) or hasattr(
             y, '__array__')) and not isinstance(
                 y, str)
 

--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -158,6 +158,8 @@ def _daal_roc_auc_score(
         if _dal_ready:
             if not np.array_equal(labels, [0, 1]) or labels.dtype == bool:
                 y_true = label_binarize(y_true, classes=labels)[:, 0]
+                if hasattr(y_score, 'dtype') and y_score.dtype == bool:
+                    y_score = label_binarize(y_score, classes=labels)[:, 0]
             result = d4p.daal_roc_auc_score(y_true.reshape(-1, 1),
                                             y_score.reshape(-1, 1))
             if result != -1:

--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -37,7 +37,8 @@ if sklearn_check_version("0.22"):
     from sklearn.neighbors._base import NeighborsBase as BaseNeighborsBase
     from sklearn.neighbors._ball_tree import BallTree
     from sklearn.neighbors._kd_tree import KDTree
-    from sklearn.neighbors._base import _check_weights
+    if not sklearn_check_version("1.2"):
+        from sklearn.neighbors._base import _check_weights
 else:
     from sklearn.neighbors.base import KNeighborsMixin as BaseKNeighborsMixin
     from sklearn.neighbors.base import RadiusNeighborsMixin as BaseRadiusNeighborsMixin
@@ -288,7 +289,8 @@ class NeighborsBase(BaseNeighborsBase):
                               "The corresponding parameter from __init__ "
                               "is ignored.", SyntaxWarning, stacklevel=2)
 
-        if hasattr(self, 'weights') and sklearn_check_version("1.0"):
+        if hasattr(self, 'weights') and sklearn_check_version("1.0") \
+                and not sklearn_check_version("1.2"):
             self.weights = _check_weights(self.weights)
 
         if sklearn_check_version("1.0"):

--- a/daal4py/sklearn/neighbors/_classification.py
+++ b/daal4py/sklearn/neighbors/_classification.py
@@ -31,7 +31,8 @@ from scipy import sparse as sp
 if sklearn_check_version("0.22"):
     from sklearn.neighbors._classification import KNeighborsClassifier as \
         BaseKNeighborsClassifier
-    from sklearn.neighbors._base import _check_weights
+    if not sklearn_check_version("1.2"):
+        from sklearn.neighbors._base import _check_weights
     from sklearn.utils.validation import _deprecate_positional_args
 else:
     from sklearn.neighbors.classification import KNeighborsClassifier as \

--- a/daal4py/sklearn/neighbors/_regression.py
+++ b/daal4py/sklearn/neighbors/_regression.py
@@ -25,7 +25,8 @@ from .._device_offload import support_usm_ndarray
 if sklearn_check_version("0.22"):
     from sklearn.neighbors._regression import KNeighborsRegressor as \
         BaseKNeighborsRegressor
-    from sklearn.neighbors._base import _check_weights
+    if not sklearn_check_version("1.2"):
+        from sklearn.neighbors._base import _check_weights
     from sklearn.utils.validation import _deprecate_positional_args
 else:
     from sklearn.neighbors.regression import KNeighborsRegressor as \

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -62,9 +62,10 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
     dt = np.dtype(get_dtype(X))
     is_float = dt.kind in 'fc'
 
-    msg_err = "Input contains {} or a value too large for {!r}."
+    msg_err = "Input {} contains {} or a value too large for {!r}."
     type_err = 'infinity' if allow_nan else 'NaN, infinity'
-    err = msg_err.format(type_err, msg_dtype if msg_dtype is not None else dt)
+    err = msg_err.format(
+        input_name, type_err, msg_dtype if msg_dtype is not None else dt)
 
     if X.ndim in [1, 2] and not np.any(np.equal(X.shape, 0)) and \
             dt in [np.float32, np.float64]:
@@ -92,7 +93,7 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
     # for object dtype data, we only check for NaNs (GH-13254)
     elif dt == np.dtype('object') and not allow_nan:
         if _object_dtype_isnan(X).any():
-            raise ValueError("Input contains NaN")
+            raise ValueError(f"Input {input_name} contains NaN")
 
 
 def _pandas_check_array(array, array_orig, force_all_finite, ensure_min_samples,

--- a/examples/daal4py/decision_forest_classification_default_dense_batch.py
+++ b/examples/daal4py/decision_forest_classification_default_dense_batch.py
@@ -69,7 +69,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_result = predict_algo.compute(pdata, train_result.model)
 
     # Prediction result provides prediction
-    assert(predict_result.prediction.shape == (pdata.shape[0], 1))
+    assert predict_result.prediction.shape == (pdata.shape[0], 1)
 
     return (train_result, predict_result, plabels)
 

--- a/examples/daal4py/decision_forest_classification_hist_batch.py
+++ b/examples/daal4py/decision_forest_classification_hist_batch.py
@@ -71,7 +71,7 @@ def main(readcsv=read_csv, method='hist'):
     predict_result = predict_algo.compute(pdata, train_result.model)
 
     # Prediction result provides prediction
-    assert(predict_result.prediction.shape == (pdata.shape[0], 1))
+    assert predict_result.prediction.shape == (pdata.shape[0], 1)
 
     return (train_result, predict_result, plabels)
 

--- a/examples/daal4py/decision_tree_classification_batch.py
+++ b/examples/daal4py/decision_tree_classification_batch.py
@@ -56,7 +56,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_result = predict_algo.compute(pdata, train_result.model)
 
     # Prediction result provides prediction
-    assert(predict_result.prediction.shape == (pdata.shape[0], 1))
+    assert predict_result.prediction.shape == (pdata.shape[0], 1)
 
     return (train_result, predict_result, plabels)
 

--- a/examples/daal4py/distributions_bernoulli_batch.py
+++ b/examples/daal4py/distributions_bernoulli_batch.py
@@ -29,14 +29,14 @@ def main(readcsv=None, method='defaultDense'):
     data = np.zeros((1, 10))
     res = algorithm.compute(data)
 
-    assert(np.allclose(data, res.randomNumbers))
-    assert(np.allclose(
+    assert np.allclose(data, res.randomNumbers)
+    assert np.allclose(
         data,
         [[
             1.0, 1.000, 1.000, 0.000, 1.000,
             0.000, 1.000, 0.000, 1.000, 0.000
         ]]
-    ))
+    )
 
     return data
 

--- a/examples/daal4py/distributions_normal_batch.py
+++ b/examples/daal4py/distributions_normal_batch.py
@@ -29,14 +29,14 @@ def main(readcsv=None, method='defaultDense'):
     data = np.zeros((1, 10))
     res = algorithm.compute(data)
 
-    assert(np.allclose(data, res.randomNumbers))
-    assert(np.allclose(
+    assert np.allclose(data, res.randomNumbers)
+    assert np.allclose(
         data,
         [[
             -0.74104167, -0.13616829, -0.13679562, 2.40385531, -0.33556821,
             0.19041699, -0.61331181, 0.95958821, -0.42301092, 0.09460208
         ]]
-    ))
+    )
 
     return data
 

--- a/examples/daal4py/distributions_uniform_batch.py
+++ b/examples/daal4py/distributions_uniform_batch.py
@@ -29,14 +29,14 @@ def main(readcsv=None, method='defaultDense'):
     data = np.zeros((1, 10))
     res = algorithm.compute(data)
 
-    assert(np.allclose(data, res.randomNumbers))
-    assert(np.allclose(
+    assert np.allclose(data, res.randomNumbers)
+    assert np.allclose(
         data,
         [[
             0.22933409, 0.44584412, 0.44559617, 0.9918884, 0.36859825,
             0.57550881, 0.26983509, 0.83136875, 0.33614365, 0.53768455,
         ]]
-    ))
+    )
 
     return data
 

--- a/examples/daal4py/implicit_als_batch.py
+++ b/examples/daal4py/implicit_als_batch.py
@@ -53,7 +53,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     result3 = algo3.compute(result2.model)
 
     # implicit als prediction result objects provide prediction
-    assert(result3.prediction.shape == data.shape)
+    assert result3.prediction.shape == data.shape
 
     return result3
 

--- a/examples/daal4py/low_order_moms_dense_batch.py
+++ b/examples/daal4py/low_order_moms_dense_batch.py
@@ -42,9 +42,9 @@ def main(readcsv=read_csv, method="defaultDense"):
 
     # result provides minimum, maximum, sum, sumSquares, sumSquaresCentered,
     # mean, secondOrderRawMoment, variance, standardDeviation, variation
-    assert(all(getattr(res, name).shape == (1, data.shape[1]) for name in
+    assert all(getattr(res, name).shape == (1, data.shape[1]) for name in
                ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
-               'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']))
+               'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation'])
 
     return res
 

--- a/examples/daal4py/low_order_moms_spmd.py
+++ b/examples/daal4py/low_order_moms_spmd.py
@@ -44,9 +44,9 @@ def main():
 
     # result provides minimum, maximum, sum, sumSquares, sumSquaresCentered,
     # mean, secondOrderRawMoment, variance, standardDeviation, variation
-    assert(all(getattr(res, name).shape == (1, data.shape[1]) for name in
+    assert all(getattr(res, name).shape == (1, data.shape[1]) for name in
                ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
-                'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']))
+                'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation'])
 
     return res
 

--- a/examples/daal4py/naive_bayes_batch.py
+++ b/examples/daal4py/naive_bayes_batch.py
@@ -53,7 +53,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     presult = palgo.compute(pdata, tresult.model)
 
     # Prediction result provides prediction
-    assert(presult.prediction.shape == (pdata.shape[0], 1))
+    assert presult.prediction.shape == (pdata.shape[0], 1)
 
     return (presult, plabels)
 

--- a/examples/daal4py/naive_bayes_spmd.py
+++ b/examples/daal4py/naive_bayes_spmd.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         presult = palgo.compute(pdata, tresult.model)
 
         # Prediction result provides prediction
-        assert(presult.prediction.shape == (pdata.shape[0], 1))
+        assert presult.prediction.shape == (pdata.shape[0], 1)
 
         print('All looks good!')
 

--- a/examples/daal4py/naive_bayes_streaming.py
+++ b/examples/daal4py/naive_bayes_streaming.py
@@ -72,7 +72,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     pred_result = pred_algo.compute(pred_data, train_result.model)
 
     # Prediction result provides prediction
-    assert(pred_result.prediction.shape == (pred_data.shape[0], 1))
+    assert pred_result.prediction.shape == (pred_data.shape[0], 1)
 
     return (pred_result, pred_labels)
 

--- a/examples/daal4py/svm_batch.py
+++ b/examples/daal4py/svm_batch.py
@@ -55,7 +55,7 @@ def main(readcsv=read_csv, method='defaultDense'):
     predict_result = predict_algo.compute(pdata, train_result.model)
 
     # Prediction result provides prediction
-    assert(predict_result.prediction.shape == (pdata.shape[0], 1))
+    assert predict_result.prediction.shape == (pdata.shape[0], 1)
 
     # result of classification
     decision_result = predict_result.prediction

--- a/examples/daal4py/sycl/low_order_moms_dense_batch.py
+++ b/examples/daal4py/sycl/low_order_moms_dense_batch.py
@@ -112,9 +112,9 @@ def main(readcsv=read_csv, method="defaultDense"):
 
     # result provides minimum, maximum, sum, sumSquares, sumSquaresCentered,
     # mean, secondOrderRawMoment, variance, standardDeviation, variation
-    assert(all(getattr(result_classic, name).shape == (1, data.shape[1]) for name in
+    assert all(getattr(result_classic, name).shape == (1, data.shape[1]) for name in
            ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
-            'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']))
+            'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation'])
 
     for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered', 'mean',
                  'secondOrderRawMoment', 'variance', 'standardDeviation', 'variation']:

--- a/examples/daal4py/sycl/sklearn_sycl.py
+++ b/examples/daal4py/sycl/sklearn_sycl.py
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     for device in devices:
         for e in examples:
             print("*" * 80)
-            if(dpctl_available):
+            if dpctl_available:
                 print("device context:", device_type_to_str(device))
             else:
                 print("device context:", device)

--- a/gen.py
+++ b/gen.py
@@ -21,7 +21,8 @@ if __name__ == "__main__":
     import argparse
     global no_warn
 
-    description = """A tool to create cython interface files for HLAPI of oneDAL (aka daal4py).
+    description = """
+    A tool to create cython interface files for HLAPI of oneDAL (aka daal4py).
     Extracting necessary data and creating internal data structures.
     See parse.py for details about C++ parsing.
     See wrappers.py for necessary configuration that can not be auto-extracted.

--- a/generator/format.py
+++ b/generator/format.py
@@ -178,7 +178,7 @@ def mk_var(name='', typ='', const='', dflt=None, inpt=False, algo=None, doc=None
                     pydefault = ''
                     cppdefault = ''
                     sphinx_default = ''
-                assert(' ' not in typ), 'Error in parsing variable "{}"'.format(decl_c)
+                assert ' ' not in typ, 'Error in parsing variable "{}"'.format(decl_c)
 
             self.name = d4pname
             self.daalname = name

--- a/generator/parse.py
+++ b/generator/parse.py
@@ -323,7 +323,7 @@ class setget_parser(object):
                 # map input-enum to object-type and optional arg
                 if mgs.group(4) == 'get':  # a getter
                     name = mgs.group(6).strip()
-                    if(',' in mgs.group(3)):
+                    if (',' in mgs.group(3)):
                         arg = mgs.group(3).strip(')').split(',')[1].strip().split(' ')
                         ctxt.gdict['classes'][ctxt.curr_class].arg_gets[name] = \
                             (mgs.group(2).strip(), arg)

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -331,7 +331,7 @@ def _num_samples(x):
             )
     # Check that shape is returning an integer or default to len
     # Dask dataframes may not return numeric shape[0] value
-    if isinstance(x.shape[0], Integral):
+    if hasattr(x, "shape") and isinstance(x.shape[0], Integral):
         return x.shape[0]
 
     try:

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -18,7 +18,6 @@ import numpy as np
 import warnings
 from scipy import sparse as sp
 from scipy.sparse import issparse, dok_matrix, lil_matrix
-from scipy.sparse.base import spmatrix
 from collections.abc import Sequence
 from numbers import Integral
 
@@ -150,7 +149,7 @@ def _check_classification_targets(y):
 
 
 def _type_of_target(y):
-    valid = (isinstance(y, (Sequence, spmatrix)) or hasattr(y, '__array__')) \
+    valid = (isinstance(y, Sequence) or sp.isspmatrix(y) or hasattr(y, '__array__')) \
         and not isinstance(y, str)
 
     if not valid:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 Cython==0.29.24 ; python_version <= '3.9'
 Cython==0.29.25 ; python_version >= '3.10'
 Jinja2==3.0.3
-numpy==1.21.0 ; python_version <= '3.8'
-numpy==1.19.3 ; python_version == '3.9'
-numpy==1.22.0 ; python_version >= '3.10'
+numpy==1.19.5 ; python_version == '3.6'
+numpy==1.21.6 ; python_version == '3.7'
+numpy==1.23.2 ; python_version >= '3.8'
 pybind11==2.8.0
 cmake==3.21.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 Cython==0.29.24 ; python_version <= '3.9'
 Cython==0.29.25 ; python_version >= '3.10'
 Jinja2==3.0.3
-numpy==1.19.2 ; python_version <= '3.8'
+numpy==1.21.0 ; python_version <= '3.8'
 numpy==1.19.3 ; python_version == '3.9'
-numpy==1.21.3 ; python_version >= '3.10'
+numpy==1.22.0 ; python_version >= '3.10'
 pybind11==2.8.0
 cmake==3.21.3

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -27,7 +27,7 @@ jupyterlab-pygments==0.1.2
 MarkupSafe==2.0.1
 mistune==0.8.4
 nbclient==0.5.9
-nbconvert==6.3.0
+nbconvert==6.5.1
 nbformat==5.1.3
 nbsphinx==0.8.7
 nest-asyncio==1.5.4

--- a/sklearnex/manifold/tests/test_tsne.py
+++ b/sklearnex/manifold/tests/test_tsne.py
@@ -22,5 +22,5 @@ from numpy.testing import assert_allclose
 def test_sklearnex_import():
     from sklearnex.manifold import TSNE
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
-    tsne = TSNE(n_components=2).fit(X)
+    tsne = TSNE(n_components=2, perplexity=2.0).fit(X)
     assert 'daal4py' in tsne.__module__

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -15,17 +15,14 @@
 # limitations under the License.
 #===============================================================================
 
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
-from sklearn import __version__ as sklearn_version
+from daal4py.sklearn._utils import sklearn_check_version
 import warnings
 
 from sklearn.neighbors._base import NeighborsBase as sklearn_NeighborsBase
 from sklearn.neighbors._ball_tree import BallTree
 from sklearn.neighbors._kd_tree import KDTree
-from sklearn.neighbors._base import _check_weights
+if not sklearn_check_version('1.2'):
+    from sklearn.neighbors._base import _check_weights
 from sklearn.neighbors._base import VALID_METRICS
 from sklearn.neighbors._classification import KNeighborsClassifier as \
     sklearn_KNeighborsClassifier
@@ -41,7 +38,7 @@ import numpy as np
 from scipy import sparse as sp
 
 
-if Version(sklearn_version) >= Version("0.24"):
+if sklearn_check_version("0.24"):
     class KNeighborsClassifier_(sklearn_KNeighborsClassifier):
         @_deprecate_positional_args
         def __init__(self, n_neighbors=5, *,
@@ -55,9 +52,9 @@ if Version(sklearn_version) >= Version("0.24"):
                 metric_params=metric_params,
                 n_jobs=n_jobs, **kwargs)
             self.weights = \
-                weights if Version(sklearn_version) >= Version("1.0") \
+                weights if sklearn_check_version("1.0") \
                 else _check_weights(weights)
-elif Version(sklearn_version) >= Version("0.22"):
+elif sklearn_check_version("0.22"):
     from sklearn.neighbors._base import SupervisedIntegerMixin as \
         BaseSupervisedIntegerMixin
 
@@ -110,7 +107,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
             n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:
             if self.p is not None:
@@ -226,7 +223,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
     @wrap_output_data
     def predict(self, X):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.KNeighborsClassifier.predict', {
             'onedal': self.__class__._onedal_predict,
@@ -236,7 +233,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
     @wrap_output_data
     def predict_proba(self, X):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.KNeighborsClassifier.predict_proba', {
             'onedal': self.__class__._onedal_predict_proba,
@@ -246,7 +243,7 @@ class KNeighborsClassifier(KNeighborsClassifier_):
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.KNeighborsClassifier.kneighbors', {
             'onedal': self.__class__._onedal_kneighbors,
@@ -260,11 +257,11 @@ class KNeighborsClassifier(KNeighborsClassifier_):
 
         if _onedal_estimator is not None or getattr(self, '_tree', 0) is None and \
                 self._fit_method == 'kd_tree':
-            if Version(sklearn_version) >= Version("0.24"):
+            if sklearn_check_version("0.24"):
                 sklearn_NearestNeighbors.fit(self, self._fit_X, getattr(self, '_y', None))
             else:
                 sklearn_NearestNeighbors.fit(self, self._fit_X)
-        if Version(sklearn_version) >= Version("0.22"):
+        if sklearn_check_version("0.22"):
             result = sklearn_NearestNeighbors.radius_neighbors(
                 self, X, radius, return_distance, sort_results)
         else:

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -15,17 +15,14 @@
 # limitations under the License.
 #===============================================================================
 
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
-from sklearn import __version__ as sklearn_version
+from daal4py.sklearn._utils import sklearn_check_version
 import warnings
 
 from sklearn.neighbors._base import NeighborsBase as sklearn_NeighborsBase
 from sklearn.neighbors._ball_tree import BallTree
 from sklearn.neighbors._kd_tree import KDTree
-from sklearn.neighbors._base import _check_weights
+if not sklearn_check_version('1.2'):
+    from sklearn.neighbors._base import _check_weights
 from sklearn.neighbors._base import VALID_METRICS
 from sklearn.neighbors._regression import KNeighborsRegressor as \
     sklearn_KNeighborsRegressor
@@ -41,7 +38,7 @@ import numpy as np
 from scipy import sparse as sp
 
 
-if Version(sklearn_version) >= Version("0.24"):
+if sklearn_check_version("0.24"):
     class KNeighborsRegressor_(sklearn_KNeighborsRegressor):
         @_deprecate_positional_args
         def __init__(self, n_neighbors=5, *,
@@ -55,9 +52,9 @@ if Version(sklearn_version) >= Version("0.24"):
                 metric_params=metric_params,
                 n_jobs=n_jobs, **kwargs)
             self.weights = \
-                weights if Version(sklearn_version) >= Version("1.0") \
+                weights if sklearn_check_version("1.0") \
                 else _check_weights(weights)
-elif Version(sklearn_version) >= Version("0.22"):
+elif sklearn_check_version("0.22"):
     from sklearn.neighbors._base import SupervisedFloatMixin as \
         BaseSupervisedFloatMixin
 
@@ -110,7 +107,7 @@ class KNeighborsRegressor(KNeighborsRegressor_):
             n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:
             if self.p is not None:
@@ -226,7 +223,7 @@ class KNeighborsRegressor(KNeighborsRegressor_):
     @wrap_output_data
     def predict(self, X):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.KNeighborsRegressor.predict', {
             'onedal': self.__class__._onedal_predict,
@@ -236,7 +233,7 @@ class KNeighborsRegressor(KNeighborsRegressor_):
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.KNeighborsRegressor.kneighbors', {
             'onedal': self.__class__._onedal_kneighbors,
@@ -250,11 +247,11 @@ class KNeighborsRegressor(KNeighborsRegressor_):
 
         if _onedal_estimator is not None or getattr(self, '_tree', 0) is None and \
                 self._fit_method == 'kd_tree':
-            if Version(sklearn_version) >= Version("0.24"):
+            if sklearn_check_version("0.24"):
                 sklearn_NearestNeighbors.fit(self, self._fit_X, getattr(self, '_y', None))
             else:
                 sklearn_NearestNeighbors.fit(self, self._fit_X)
-        if Version(sklearn_version) >= Version("0.22"):
+        if sklearn_check_version("0.22"):
             result = sklearn_NearestNeighbors.radius_neighbors(
                 self, X, radius, return_distance, sort_results)
         else:

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     from distutils.version import LooseVersion as Version
 from sklearn import __version__ as sklearn_version
+from daal4py.sklearn._utils import sklearn_check_version
 import warnings
 
 from sklearn.neighbors._base import NeighborsBase as sklearn_NeighborsBase
@@ -39,7 +40,7 @@ import numpy as np
 from scipy import sparse as sp
 
 
-if Version(sklearn_version) >= Version("0.22") and \
+if sklearn_check_version("0.22") and \
    Version(sklearn_version) < Version("0.23"):
     class NearestNeighbors_(sklearn_NearestNeighbors):
         def __init__(self, n_neighbors=5, radius=1.0,
@@ -78,7 +79,7 @@ class NearestNeighbors(NearestNeighbors_):
             metric_params=metric_params, n_jobs=n_jobs)
 
     def fit(self, X, y=None):
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:
             if self.p is not None:
@@ -194,7 +195,7 @@ class NearestNeighbors(NearestNeighbors_):
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'neighbors.NearestNeighbors.kneighbors', {
             'onedal': self.__class__._onedal_kneighbors,
@@ -208,11 +209,11 @@ class NearestNeighbors(NearestNeighbors_):
 
         if _onedal_estimator is not None or getattr(self, '_tree', 0) is None and \
                 self._fit_method == 'kd_tree':
-            if Version(sklearn_version) >= Version("0.24"):
+            if sklearn_check_version("0.24"):
                 sklearn_NearestNeighbors.fit(self, self._fit_X, getattr(self, '_y', None))
             else:
                 sklearn_NearestNeighbors.fit(self, self._fit_X)
-        if Version(sklearn_version) >= Version("0.22"):
+        if sklearn_check_version("0.22"):
             result = sklearn_NearestNeighbors.radius_neighbors(
                 self, X, radius, return_distance, sort_results)
         else:

--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -146,6 +146,8 @@ def split_train_inference(kf, x, y, estimator):
         elif isinstance(x, pd.core.frame.DataFrame):
             x_train, x_test = x.iloc[train_index], x.iloc[test_index]
             y_train, y_test = y.iloc[train_index], y.iloc[test_index]
+        # TODO: add parameters for all estimators to prevent
+        # fallback to stock scikit-learn with default parameters
         alg = estimator()
         alg.fit(x_train, y_train)
         if hasattr(alg, 'predict'):

--- a/sklearnex/tests/test_run_to_run_stability_tests.py
+++ b/sklearnex/tests/test_run_to_run_stability_tests.py
@@ -32,8 +32,8 @@ from sklearn.svm import SVC, NuSVC, SVR, NuSVR
 from sklearn.manifold import TSNE
 from sklearn.model_selection import train_test_split
 
-from sklearn.datasets import (make_classification, load_breast_cancer,
-                              load_diabetes, load_iris, load_boston)
+from sklearn.datasets import (make_classification, make_regression,
+                              load_breast_cancer, load_diabetes, load_iris)
 from sklearn.metrics import pairwise_distances, roc_auc_score
 from scipy import sparse
 from daal4py.sklearn._utils import daal_check_version
@@ -113,7 +113,8 @@ def _run_test(model, methods, dataset):
             X2 = sparse.csr_matrix(X2)
         datasets.append((X2, y2))
     elif dataset == 'regression':
-        X1, y1 = load_boston(return_X_y=True)
+        X1, y1 = make_regression(n_samples=500, n_features=10,
+                                 noise=64.0, random_state=42)
         datasets.append((X1, y1))
         X2, y2 = load_diabetes(return_X_y=True)
         datasets.append((X2, y2))


### PR DESCRIPTION
# Description
Added checks on alpha, and max_iter to improve alignment with scikit-learn.
reverted back checks on l1_ratio

Details of changes made in the pull request:
alpha: added a check to raise value error if alpha is < 0.
l1_ratio: proposed changes were failing internal ci due to differences in how scikit-learn and scikit-learn-intelex handles error, so all changes were discarded and reverted back to original code to match with internal ci .
max_iter: added a check to raise value error if max_iter < 1.

 
