### PR TITLE
Split pipelines so docs updates woudl not trigger all builds

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -24,7 +24,7 @@ trigger:
     exclude:
     - requirements-doc.txt
     - doc/
-    - ci/pipeline/docs.yml
+    - .ci/pipeline/docs.yml
 
 pr:
   branches:
@@ -36,7 +36,7 @@ pr:
     exclude:
     - requirements-doc.txt
     - doc/
-    - ci/pipeline/docs.yml
+    - .ci/pipeline/docs.yml
 
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -23,6 +23,7 @@ trigger:
   paths:
     exclude:
     - requirements-doc.txt
+    - doc/
 
 pr:
   branches:
@@ -33,7 +34,8 @@ pr:
   paths:
     exclude:
     - requirements-doc.txt
-  
+    - doc/
+
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET
     value: '10.15'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -24,6 +24,7 @@ trigger:
     exclude:
     - requirements-doc.txt
     - doc/
+    - ci/pipeline/docs.yml
 
 pr:
   branches:
@@ -35,6 +36,7 @@ pr:
     exclude:
     - requirements-doc.txt
     - doc/
+    - ci/pipeline/docs.yml
 
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -14,6 +14,26 @@
 # limitations under the License.
 #===============================================================================
 
+trigger:
+  branches:
+    include:
+    - master
+    - releases
+    - rls/*
+  paths:
+    exclude:
+    - requirements-doc.txt
+
+pr:
+  branches:
+    include:
+    - master
+    - releases
+    - rls/*
+  paths:
+    exclude:
+    - requirements-doc.txt
+  
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET
     value: '10.15'
@@ -36,50 +56,7 @@ jobs:
       pip install flake8
       flake8 --ignore=E265,E722,E402,F401,F403 --max-line-length=90 --count
     displayName: 'PEP 8 check'
-- job: Docs
-  pool:
-    vmImage: 'ubuntu-22.04'
-  steps:
-  - script: |
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.9'
-      addToPath: true
-  - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: 'apt-get'
-  - script: |
-      pip install daal-devel impi-devel
-      pip install -r requirements-dev.txt
-      pip install -r requirements-doc.txt
-      pip install -r requirements-test.txt
-      pip list
-    displayName: 'Install requirements'
-  - script: |
-      export PREFIX=$(dirname $(dirname $(which python)))
-      ./conda-recipe/build.sh
-      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
-  - script: |
-      export LD_LIBRARY_PATH=$(dirname $(dirname $(which python)))/lib:$LD_LIBRARY_PATH
-      cd doc/daal4py
-      make html
-    displayName: 'Build daal4py documentation'
-  - script: |
-      cd doc
-      make html
-    displayName: 'Build scikit-learn-intelex documentation'
-  - script: |
-      mkdir $(Build.ArtifactStagingDirectory)/html/daal4py
-      mkdir $(Build.ArtifactStagingDirectory)/html/sklearnex
-      cp -R doc/daal4py/_build $(Build.ArtifactStagingDirectory)/html_daal4py
-      cp -R doc/_build $(Build.ArtifactStagingDirectory)/html_sklearnex
-    displayName: 'Copy build'
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'documentation'
-      targetPath: '$(Build.ArtifactStagingDirectory)/'
+
 - job: Linux
   strategy:
     matrix:

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -24,6 +24,7 @@ trigger:
     include:
     - requirements-doc.txt
     - doc/
+    - ci/pipeline/docs.yml
 
 pr:
   branches:
@@ -35,6 +36,7 @@ pr:
     include:
     - requirements-doc.txt
     - doc/
+    - ci/pipeline/docs.yml
 
 variables:
   - name: 'PYTHON'

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -1,0 +1,102 @@
+#===============================================================================
+# Copyright 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+trigger:
+  branches:
+    include:
+    - master
+    - releases
+    - rls/*
+  paths:
+    include:
+    - requirements-doc.txt
+
+pr:
+  branches:
+    include:
+    - master
+    - releases
+    - rls/*
+  paths:
+    include:
+    - requirements-doc.txt
+
+variables:
+  - name: MACOSX_DEPLOYMENT_TARGET
+    value: '10.15'
+  - name: 'PYTHON'
+    value: python
+  - name: 'ARGS'
+    value: '1'
+
+jobs:
+- job: PEP8
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.9'
+      addToPath: true
+  - script: |
+      python -m pip install --upgrade pip setuptools
+      pip install flake8
+      flake8 --ignore=E265,E722,E402,F401,F403 --max-line-length=90 --count
+    displayName: 'PEP 8 check'
+- job: Docs
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:
+  - script: |
+      bash .ci/scripts/describe_system.sh
+    displayName: 'System info'
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.9'
+      addToPath: true
+  - script: sudo apt-get update && sudo apt-get install -y clang-format
+    displayName: 'apt-get'
+  - script: |
+      pip install daal-devel impi-devel
+      pip install -r requirements-dev.txt
+      pip install -r requirements-doc.txt
+      pip install -r requirements-test.txt
+      pip list
+    displayName: 'Install requirements'
+  - script: |
+      export PREFIX=$(dirname $(dirname $(which python)))
+      ./conda-recipe/build.sh
+      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
+    displayName: 'Build daal4py/sklearnex'
+  - script: |
+      export LD_LIBRARY_PATH=$(dirname $(dirname $(which python)))/lib:$LD_LIBRARY_PATH
+      cd doc/daal4py
+      make html
+    displayName: 'Build daal4py documentation'
+  - script: |
+      cd doc
+      make html
+    displayName: 'Build scikit-learn-intelex documentation'
+  - script: |
+      mkdir $(Build.ArtifactStagingDirectory)/html/daal4py
+      mkdir $(Build.ArtifactStagingDirectory)/html/sklearnex
+      cp -R doc/daal4py/_build $(Build.ArtifactStagingDirectory)/html_daal4py
+      cp -R doc/_build $(Build.ArtifactStagingDirectory)/html_sklearnex
+    displayName: 'Copy build'
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'documentation'
+      targetPath: '$(Build.ArtifactStagingDirectory)/'

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -24,7 +24,7 @@ trigger:
     include:
     - requirements-doc.txt
     - doc/
-    - ci/pipeline/docs.yml
+    - .ci/pipeline/docs.yml
 
 pr:
   branches:
@@ -36,7 +36,7 @@ pr:
     include:
     - requirements-doc.txt
     - doc/
-    - ci/pipeline/docs.yml
+    - .ci/pipeline/docs.yml
 
 variables:
   - name: 'PYTHON'

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -36,6 +36,9 @@ pr:
     - requirements-doc.txt
     - doc/
 
+variables:
+  - name: 'PYTHON'
+    value: python
 
 jobs:
 - job: PEP8

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020 Intel Corporation
+# Copyright 2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ trigger:
   paths:
     include:
     - requirements-doc.txt
+    - doc/
 
 pr:
   branches:
@@ -33,14 +34,8 @@ pr:
   paths:
     include:
     - requirements-doc.txt
+    - doc/
 
-variables:
-  - name: MACOSX_DEPLOYMENT_TARGET
-    value: '10.15'
-  - name: 'PYTHON'
-    value: python
-  - name: 'ARGS'
-    value: '1'
 
 jobs:
 - job: PEP8

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -41,9 +41,9 @@ copyright = '2022, Intel'
 author = 'Intel'
 
 # The short X.Y version
-version = '2021'
+version = '2023'
 # The full version, including alpha/beta/rc tags
-release = '2021.6'
+release = '2023.0.1'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
# Description
Split pipelines so docs updates woudl not trigger all builds. Currently all package update starts all builds

Changes proposed in this pull request:
- splitting to docs and ci pipelines


 
