### PR TITLE
FIX: oneapi_backend building WIN

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -81,11 +81,11 @@ def build_cpp(cc, cxx, sources, targetprefix, targetname, targetsuffix, libs, li
             out = [f'/Fo{objfiles[i]}']
         else:
             out = ['-o', objfiles[i]]
-        cmd = [cc] + include_dir_plat + eca + [f'{d4p_dir}/{cppfile}'] + out + defines
+        cmd = [cc] + eca + include_dir_plat + [f'{d4p_dir}/{cppfile}'] + out + defines
         log.info(subprocess.list2cmdline(cmd))
         subprocess.check_call(cmd)
 
-    cmd = [cxx] + objfiles + library_dir_plat + ela + libs + additional_linker_opts
+    cmd = [cxx] + ela + objfiles + library_dir_plat + libs + additional_linker_opts
     log.info(subprocess.list2cmdline(cmd))
     subprocess.check_call(cmd)
     shutil.copy(f'{targetprefix}{targetname}{targetsuffix}',

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -81,11 +81,14 @@ def build_cpp(cc, cxx, sources, targetprefix, targetname, targetsuffix, libs, li
             out = [f'/Fo{objfiles[i]}']
         else:
             out = ['-o', objfiles[i]]
-        cmd = [cc] + eca + include_dir_plat + [f'{d4p_dir}/{cppfile}'] + out + defines
+        cmd = [cc] + include_dir_plat + eca + [f'{d4p_dir}/{cppfile}'] + out + defines
         log.info(subprocess.list2cmdline(cmd))
         subprocess.check_call(cmd)
 
-    cmd = [cxx] + ela + objfiles + library_dir_plat + libs + additional_linker_opts
+    if IS_WIN:
+        cmd = [cxx] + ela + objfiles + library_dir_plat + libs + additional_linker_opts
+    else:
+        cmd = [cxx] + objfiles + library_dir_plat + ela + libs + additional_linker_opts
     log.info(subprocess.list2cmdline(cmd))
     subprocess.check_call(cmd)
     shutil.copy(f'{targetprefix}{targetname}{targetsuffix}',

--- a/setup.py
+++ b/setup.py
@@ -310,8 +310,8 @@ def build_oneapi_backend():
         cxx = 'icx'
     else:
         cxx = 'icpx'
-    eca += ['-fsycl']
-    ela += ['-fsycl']
+    eca = ['-fsycl'] + eca
+    ela = ['-fsycl'] + ela
 
     return build_backend.build_cpp(
         cc=cc,


### PR DESCRIPTION
# Description
`icx` was ignoring `-fsycl` for WIN build of `oneapi_backend`. `-fsycl` is required for sycl compilation.
Since `icx` MVCS compatible driver, so it is needed add extra link args before `/link` command.

 
