### PR TITLE
Sklearn wrapper fixes

### DIFF
--- a/daal4py/sklearn/cluster/_dbscan.py
+++ b/daal4py/sklearn/cluster/_dbscan.py
@@ -185,6 +185,8 @@ class DBSCAN(DBSCAN_original):
     >>> clustering
     DBSCAN(eps=3, min_samples=2)
     """
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**DBSCAN_original._parameter_constraints}
 
     def __init__(
         self,
@@ -232,8 +234,11 @@ class DBSCAN(DBSCAN_original):
         self : object
             Returns a fitted instance of self.
         """
-        if self.eps <= 0.0:
-            raise ValueError(f"eps == {self.eps}, must be > 0.0.")
+        if sklearn_check_version("1.2"):
+            self._validate_params()
+        else:
+            if self.eps <= 0.0:
+                raise ValueError(f"eps == {self.eps}, must be > 0.0.")
 
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)

--- a/daal4py/sklearn/decomposition/_pca.py
+++ b/daal4py/sklearn/decomposition/_pca.py
@@ -300,10 +300,14 @@ class PCA(PCA_original):
                 (1, self.explained_variance_.shape[0]),
                 self.n_samples_ - 1.0, dtype=X.dtype)
 
-        if X.shape[1] != self.n_features_:
+        if sklearn_check_version('1.2'):
+            expected_n_features = self.n_features_in_
+        else:
+            expected_n_features = self.n_features_
+        if X.shape[1] != expected_n_features:
             raise ValueError(
                 (f'X has {X.shape[1]} features, '
-                 f'but PCA is expecting {self.n_features_} features as input'))
+                 f'but PCA is expecting {expected_n_features} features as input'))
 
         tr_res = daal4py.pca_transform(
             fptype=fpType

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -392,6 +392,8 @@ def _daal4py_predict_lasso(self, X):
 def _fit(self, X, y, sample_weight=None, check_input=True):
     if sklearn_check_version('1.0'):
         self._check_feature_names(X, reset=True)
+    if sklearn_check_version("1.2"):
+        self._validate_params()
     # check X and y
     if check_input:
         X, y = check_X_y(
@@ -550,6 +552,8 @@ class ElasticNet(ElasticNet_original):
     __doc__ = ElasticNet_original.__doc__
 
     if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**ElasticNet_original._parameter_constraints}
+
         def __init__(
             self,
             alpha=1.0,

--- a/daal4py/sklearn/linear_model/_linear.py
+++ b/daal4py/sklearn/linear_model/_linear.py
@@ -234,6 +234,10 @@ class LinearRegression(LinearRegression_original):
     __doc__ = LinearRegression_original.__doc__
 
     if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **LinearRegression_original._parameter_constraints
+        }
+
         def __init__(
             self,
             fit_intercept=True,
@@ -309,6 +313,8 @@ class LinearRegression(LinearRegression_original):
             )
         if sklearn_check_version('1.0'):
             self._check_feature_names(X, reset=True)
+        if sklearn_check_version("1.2"):
+            self._validate_params()
 
         if sklearn_check_version('0.24'):
             _patching_status = PatchingConditionsChain(

--- a/daal4py/sklearn/linear_model/_ridge.py
+++ b/daal4py/sklearn/linear_model/_ridge.py
@@ -39,7 +39,9 @@ def _daal4py_fit(self, X, y_):
 
     ridge_params = np.asarray(self.alpha, dtype=X.dtype)
     if ridge_params.size != 1 and ridge_params.size != y.shape[1]:
-        raise ValueError("alpha length is wrong")
+        raise ValueError(
+            "Number of targets and number of penalties do not correspond: "
+            f"{ridge_params.size} != {y.shape[1]}")
     ridge_params = ridge_params.reshape((1, -1))
 
     ridge_alg = daal4py.ridge_regression_training(

--- a/daal4py/sklearn/linear_model/_ridge.py
+++ b/daal4py/sklearn/linear_model/_ridge.py
@@ -117,6 +117,8 @@ def _fit_ridge(self, X, y, sample_weight=None):
         )
     if sklearn_check_version('1.0'):
         self._check_feature_names(X, reset=True)
+    if sklearn_check_version("1.2"):
+        self._validate_params()
 
     X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=[np.float64, np.float32],
                      multi_output=True, y_numeric=True)
@@ -205,6 +207,8 @@ class Ridge(Ridge_original, _BaseRidge):
     __doc__ = Ridge_original.__doc__
 
     if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**Ridge_original._parameter_constraints}
+
         def __init__(
             self,
             alpha=1.0,

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -825,6 +825,11 @@ if sklearn_check_version('0.24'):
     class LogisticRegression(LogisticRegression_original):
         __doc__ = LogisticRegression_original.__doc__
 
+        if sklearn_check_version('1.2'):
+            _parameter_constraints: dict = {
+                **LogisticRegression_original._parameter_constraints
+            }
+
         def __init__(
             self,
             penalty='l2',
@@ -891,6 +896,8 @@ if sklearn_check_version('0.24'):
             """
             if sklearn_check_version('1.0'):
                 self._check_feature_names(X, reset=True)
+            if sklearn_check_version("1.2"):
+                self._validate_params()
             which, what = logistic_module, '_logistic_regression_path'
             replacer = logistic_regression_path
             descriptor = getattr(which, what, None)

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -118,11 +118,11 @@ class NeighborsCommonBase(metaclass=ABCMeta):
                 "'distance', or a callable function"
             )
 
-    def _get_onedal_params(self, data):
+    def _get_onedal_params(self, X, y=None):
         class_count = 0 if self.classes_ is None else len(self.classes_)
         weights = getattr(self, 'weights', 'uniform')
         return {
-            'fptype': 'float' if data.dtype is np.dtype('float32') else 'double',
+            'fptype': 'float' if X.dtype is np.dtype('float32') else 'double',
             'vote_weights': 'uniform' if weights == 'uniform' else 'distance',
             'method': self._fit_method,
             'radius': self.radius,
@@ -131,7 +131,7 @@ class NeighborsCommonBase(metaclass=ABCMeta):
             'metric': self.effective_metric_,
             'p': self.p,
             'metric_params': self.effective_metric_params_,
-            'result_option': 'indices|distances',
+            'result_option': 'indices|distances' if y is None else 'responses',
         }
 
     def _get_daal_params(self, data):
@@ -379,9 +379,8 @@ class KNeighborsClassifier(NeighborsBase, ClassifierMixin):
             **kwargs)
         self.weights = weights
 
-    def _get_onedal_params(self, data):
-        params = super()._get_onedal_params(data)
-        params['result_option'] = 'responses'
+    def _get_onedal_params(self, X, y=None):
+        params = super()._get_onedal_params(X, y)
         return params
 
     def _get_daal_params(self, data):
@@ -403,7 +402,7 @@ class KNeighborsClassifier(NeighborsBase, ClassifierMixin):
             return train_alg(**params).compute(X, y).model
 
         policy = _get_policy(queue, X, y)
-        params = self._get_onedal_params(X)
+        params = self._get_onedal_params(X, y)
         train_alg = _backend.neighbors.classification.train(policy, params,
                                                             *to_table(X, y))
 
@@ -524,9 +523,8 @@ class KNeighborsRegressor(NeighborsBase, RegressorMixin):
             **kwargs)
         self.weights = weights
 
-    def _get_onedal_params(self, data):
-        params = super()._get_onedal_params(data)
-        params['result_option'] = 'responses'
+    def _get_onedal_params(self, X, y=None):
+        params = super()._get_onedal_params(X, y)
         return params
 
     def _get_daal_params(self, data):
@@ -548,7 +546,7 @@ class KNeighborsRegressor(NeighborsBase, RegressorMixin):
             return train_alg(**params).compute(X, y).model
 
         policy = _get_policy(queue, X, y)
-        params = self._get_onedal_params(X)
+        params = self._get_onedal_params(X, y)
         train_alg_regr = _backend.neighbors.regression.train
         train_alg_srch = _backend.neighbors.search.train
         if gpu_device:
@@ -653,9 +651,8 @@ class NearestNeighbors(NeighborsBase):
             **kwargs)
         self.weights = weights
 
-    def _get_onedal_params(self, data):
-        params = super()._get_onedal_params(data)
-        params['result_option'] = 'indices|distances'
+    def _get_onedal_params(self, X, y=None):
+        params = super()._get_onedal_params(X, y)
         return params
 
     def _get_daal_params(self, data):
@@ -678,7 +675,7 @@ class NearestNeighbors(NeighborsBase):
             return train_alg(**params).compute(X, y).model
 
         policy = _get_policy(queue, X, y)
-        params = self._get_onedal_params(X)
+        params = self._get_onedal_params(X, y)
         train_alg = _backend.neighbors.search.train(policy, params,
                                                     to_table(X))
 

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
+from daal4py.sklearn._utils import sklearn_check_version
 from sklearn.base import BaseEstimator
 from abc import ABCMeta, abstractmethod
 from enum import Enum
@@ -152,7 +153,9 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
                     len(np.unique(y[sample_weight > 0])) != len(self.classes_):
                 raise ValueError(
                     'Invalid input - all samples with positive weights '
-                    'belong to the same class')
+                    'belong to the same class' if sklearn_check_version('1.2') else
+                    'Invalid input - all samples with positive weights '
+                    'have the same label.')
         ww = sample_weight
         if self.class_weight_ is not None:
             for i, v in enumerate(self.class_weight_):

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -152,7 +152,7 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
                     len(np.unique(y[sample_weight > 0])) != len(self.classes_):
                 raise ValueError(
                     'Invalid input - all samples with positive weights '
-                    'have the same label.')
+                    'belong to the same class')
         ww = sample_weight
         if self.class_weight_ is not None:
             for i, v in enumerate(self.class_weight_):

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -121,18 +121,12 @@ class KNeighborsClassifier(KNeighborsClassifier_):
             effective_p = self.p
 
         if self.metric in ["minkowski"]:
-            if effective_p < 1:
-                raise ValueError("p must be greater or equal to one for minkowski metric")
             self.effective_metric_params_["p"] = effective_p
 
         self.effective_metric_ = self.metric
         # For minkowski distance, use more efficient methods where available
         if self.metric == "minkowski":
             p = self.effective_metric_params_.pop("p", 2)
-            if p < 1:
-                raise ValueError(
-                    "p must be greater or equal to one for minkowski metric"
-                )
             if p == 1:
                 self.effective_metric_ = "manhattan"
             elif p == 2:
@@ -289,6 +283,10 @@ class KNeighborsClassifier(KNeighborsClassifier_):
         else:
             result_method = self._fit_method
 
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
+
         is_sparse = sp.isspmatrix(data[0])
         is_single_output = False
         class_count = 1
@@ -336,6 +334,10 @@ class KNeighborsClassifier(KNeighborsClassifier_):
                     result_method = 'brute'
         else:
             result_method = self._fit_method
+
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
 
         is_sparse = sp.isspmatrix(data[0])
         is_single_output = False

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -121,18 +121,12 @@ class KNeighborsRegressor(KNeighborsRegressor_):
             effective_p = self.p
 
         if self.metric in ["minkowski"]:
-            if effective_p < 1:
-                raise ValueError("p must be greater or equal to one for minkowski metric")
             self.effective_metric_params_["p"] = effective_p
 
         self.effective_metric_ = self.metric
         # For minkowski distance, use more efficient methods where available
         if self.metric == "minkowski":
             p = self.effective_metric_params_.pop("p", 2)
-            if p < 1:
-                raise ValueError(
-                    "p must be greater or equal to one for minkowski metric"
-                )
             if p == 1:
                 self.effective_metric_ = "manhattan"
             elif p == 2:
@@ -279,6 +273,10 @@ class KNeighborsRegressor(KNeighborsRegressor_):
         else:
             result_method = self._fit_method
 
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
+
         is_sparse = sp.isspmatrix(data[0])
         is_single_output = False
         if len(data) > 1 or hasattr(self, '_onedal_estimator'):
@@ -321,6 +319,10 @@ class KNeighborsRegressor(KNeighborsRegressor_):
                     result_method = 'brute'
         else:
             result_method = self._fit_method
+
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
 
         is_sparse = sp.isspmatrix(data[0])
         is_single_output = False

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -93,18 +93,12 @@ class NearestNeighbors(NearestNeighbors_):
             effective_p = self.p
 
         if self.metric in ["minkowski"]:
-            if effective_p < 1:
-                raise ValueError("p must be greater or equal to one for minkowski metric")
             self.effective_metric_params_["p"] = effective_p
 
         self.effective_metric_ = self.metric
         # For minkowski distance, use more efficient methods where available
         if self.metric == "minkowski":
             p = self.effective_metric_params_.pop("p", 2)
-            if p < 1:
-                raise ValueError(
-                    "p must be greater or equal to one for minkowski metric"
-                )
             if p == 1:
                 self.effective_metric_ = "manhattan"
             elif p == 2:
@@ -241,6 +235,10 @@ class NearestNeighbors(NearestNeighbors_):
         else:
             result_method = self._fit_method
 
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
+
         is_sparse = sp.isspmatrix(data[0])
         is_valid_for_brute = result_method in ['brute'] and \
             self.effective_metric_ in ['manhattan',
@@ -274,6 +272,10 @@ class NearestNeighbors(NearestNeighbors_):
                     result_method = 'brute'
         else:
             result_method = self._fit_method
+
+        if "p" in self.effective_metric_params_.keys() and \
+                self.effective_metric_params_["p"] < 1:
+            return False
 
         is_sparse = sp.isspmatrix(data[0])
         is_valid_for_kd_tree = \

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -16,15 +16,11 @@
 
 from abc import ABC
 import numpy as np
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
+from daal4py.sklearn._utils import sklearn_check_version
 
 from sklearn.model_selection import StratifiedKFold
 from sklearn.preprocessing import LabelEncoder
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn import __version__ as sklearn_version
 
 from onedal.datatypes.validation import _column_or_1d
 
@@ -86,7 +82,7 @@ class BaseSVC(ABC):
                     n_splits=n_splits,
                     shuffle=True,
                     random_state=self.random_state)
-                if Version(sklearn_version) >= Version("0.24"):
+                if sklearn_check_version("0.24"):
                     self.clf_prob = CalibratedClassifierCV(
                         clf_base, ensemble=False, cv=cv, method='sigmoid',
                         n_jobs=n_jobs)
@@ -130,7 +126,7 @@ class BaseSVC(ABC):
         self.intercept_ = self._intercept_
         self._is_in_fit = False
 
-        if Version(sklearn_version) >= Version("1.1"):
+        if sklearn_check_version("1.1"):
             length = int(len(self.classes_) * (len(self.classes_) - 1) / 2)
             self.n_iter_ = np.full((length, ), self._onedal_estimator.n_iter_)
 
@@ -159,5 +155,5 @@ class BaseSVR(ABC):
         self.intercept_ = self._intercept_
         self._is_in_fit = False
 
-        if Version(sklearn_version) >= Version("1.1"):
+        if sklearn_check_version("1.1"):
             self.n_iter_ = self._onedal_estimator.n_iter_

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -14,23 +14,22 @@
 # limitations under the License.
 #===============================================================================
 
+from daal4py.sklearn._utils import sklearn_check_version
 from ._common import BaseSVC
 from .._device_offload import dispatch, wrap_output_data
 
 from sklearn.svm import NuSVC as sklearn_NuSVC
 from sklearn.utils.validation import _deprecate_positional_args
 from sklearn.exceptions import NotFittedError
-from sklearn import __version__ as sklearn_version
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
 
 from onedal.svm import NuSVC as onedal_NuSVC
 
 
 class NuSVC(sklearn_NuSVC, BaseSVC):
     __doc__ = sklearn_NuSVC.__doc__
+
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**sklearn_NuSVC._parameter_constraints}
 
     @_deprecate_positional_args
     def __init__(self, *, nu=0.5, kernel='rbf', degree=3, gamma='scale',
@@ -79,7 +78,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.NuSVC.fit', {
             'onedal': self.__class__._onedal_fit,
@@ -106,7 +105,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         y_pred : ndarray of shape (n_samples,)
             The predicted values.
         """
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'svm.NuSVC.predict', {
             'onedal': self.__class__._onedal_predict,
@@ -146,10 +145,10 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
 
     @wrap_output_data
     def _predict_proba(self, X):
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         sklearn_pred_proba = (sklearn_NuSVC.predict_proba
-                              if Version(sklearn_version) >= Version("1.0")
+                              if sklearn_check_version("1.0")
                               else sklearn_NuSVC._predict_proba)
 
         return dispatch(self, 'svm.NuSVC.predict_proba', {
@@ -159,7 +158,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
 
     @wrap_output_data
     def decision_function(self, X):
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'svm.NuSVC.decision_function', {
             'onedal': self.__class__._onedal_decision_function,
@@ -178,6 +177,8 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
             return hasattr(self, '_onedal_estimator')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         onedal_params = {
             'nu': self.nu,
             'kernel': self.kernel,

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -14,22 +14,20 @@
 # limitations under the License.
 #===============================================================================
 
+from daal4py.sklearn._utils import sklearn_check_version
 from ._common import BaseSVR
 from .._device_offload import dispatch, wrap_output_data
 
 from sklearn.svm import NuSVR as sklearn_NuSVR
 from sklearn.utils.validation import _deprecate_positional_args
-from sklearn import __version__ as sklearn_version
-
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version
 from onedal.svm import NuSVR as onedal_NuSVR
 
 
 class NuSVR(sklearn_NuSVR, BaseSVR):
     __doc__ = sklearn_NuSVR.__doc__
+
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**sklearn_NuSVR._parameter_constraints}
 
     @_deprecate_positional_args
     def __init__(self, *, kernel='rbf', degree=3, gamma='scale',
@@ -74,7 +72,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.NuSVR.fit', {
             'onedal': self.__class__._onedal_fit,
@@ -100,7 +98,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         y_pred : ndarray of shape (n_samples,)
             The predicted values.
         """
-        if Version(sklearn_version) >= Version("1.0"):
+        if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
         return dispatch(self, 'svm.NuSVR.predict', {
             'onedal': self.__class__._onedal_predict,
@@ -117,6 +115,8 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             return hasattr(self, '_onedal_estimator')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         onedal_params = {
             'C': self.C,
             'nu': self.nu,


### PR DESCRIPTION
Changes:
- Parameters constraints checks in SVM, linear model and DBSCAN (introduced in sklearn 1.2)
- Update messages in ValueErrors
- Add fallback to stock sklearn for metric='minkowski' and p<1 (not supported by oneDAL currently)
- Fix for parameters of oneDAL's kNN call