### PR TITLE
Setup helpers

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -69,9 +69,9 @@ if(IFACE STREQUAL "host")
     set(TARGET "_onedal_py_host")
 
     if(WIN32)
-        set(ONEDAL_LIBRARIES "onedal_dll" "onedal_core_dll")
+        set(ONEDAL_LIBRARIES "onedal_dll.${ONEDAL_MAJOR_BINARY}" "onedal_core_dll.${ONEDAL_MAJOR_BINARY}")
     else()
-        set(ONEDAL_LIBRARIES "onedal" "onedal_core" "onedal_thread")
+        set(ONEDAL_LIBRARIES "onedal.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS "NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
@@ -88,9 +88,9 @@ elseif(IFACE STREQUAL "dpc")
     endif()
 
     if(WIN32)
-        set(ONEDAL_LIBRARIES "onedal_dpc_dll" "onedal_core_dll")
+        set(ONEDAL_LIBRARIES "onedal_dpc_dll.${ONEDAL_MAJOR_BINARY}" "onedal_core_dll.${ONEDAL_MAJOR_BINARY}")
     else()
-        set(ONEDAL_LIBRARIES "onedal_dpc" "onedal_core" "onedal_thread")
+        set(ONEDAL_LIBRARIES "onedal_dpc.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -70,8 +70,10 @@ if(IFACE STREQUAL "host")
 
     if(WIN32)
         set(ONEDAL_LIBRARIES "onedal_dll.${ONEDAL_MAJOR_BINARY}" "onedal_core_dll.${ONEDAL_MAJOR_BINARY}")
-    else()
+    elseif(APPLE)
         set(ONEDAL_LIBRARIES "onedal.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
+    else()
+        set(ONEDAL_LIBRARIES "libonedal.so.${ONEDAL_MAJOR_BINARY}" "libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS "NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
@@ -89,8 +91,10 @@ elseif(IFACE STREQUAL "dpc")
 
     if(WIN32)
         set(ONEDAL_LIBRARIES "onedal_dpc_dll.${ONEDAL_MAJOR_BINARY}" "onedal_core_dll.${ONEDAL_MAJOR_BINARY}")
-    else()
+    elseif(APPLE)
         set(ONEDAL_LIBRARIES "onedal_dpc.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
+    else()
+        set(ONEDAL_LIBRARIES "libonedal_dpc.so.${ONEDAL_MAJOR_BINARY}" "libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -73,7 +73,7 @@ if(IFACE STREQUAL "host")
     elseif(APPLE)
         set(ONEDAL_LIBRARIES "onedal.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
     else()
-        set(ONEDAL_LIBRARIES "libonedal.so.${ONEDAL_MAJOR_BINARY}" "libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
+        set(ONEDAL_LIBRARIES "-l:libonedal.so.${ONEDAL_MAJOR_BINARY}" "-l:libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "-l:libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS "NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
@@ -94,7 +94,7 @@ elseif(IFACE STREQUAL "dpc")
     elseif(APPLE)
         set(ONEDAL_LIBRARIES "onedal_dpc.${ONEDAL_MAJOR_BINARY}" "onedal_core.${ONEDAL_MAJOR_BINARY}" "onedal_thread.${ONEDAL_MAJOR_BINARY}")
     else()
-        set(ONEDAL_LIBRARIES "libonedal_dpc.so.${ONEDAL_MAJOR_BINARY}" "libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
+        set(ONEDAL_LIBRARIES "-l:libonedal_dpc.so.${ONEDAL_MAJOR_BINARY}" "-l:libonedal_core.so.${ONEDAL_MAJOR_BINARY}" "-l:libonedal_thread.so.${ONEDAL_MAJOR_BINARY}")
     endif()
 
     list(APPEND COMPILE_DEFINITIONS

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -100,7 +100,7 @@ def build_cpp(cc, cxx, sources, targetprefix, targetname, targetsuffix, libs, li
     os.chdir(d4p_dir)
 
 
-def custom_build_cmake_clib(iface, cxx=None):
+def custom_build_cmake_clib(iface, cxx=None, onedal_major_binary_version=1):
     import pybind11
 
     root_dir = os.path.normpath(jp(os.path.dirname(__file__), ".."))
@@ -135,6 +135,7 @@ def custom_build_cmake_clib(iface, cxx=None):
         "-DCMAKE_INSTALL_PREFIX=" + install_directory,
         "-DCMAKE_PREFIX_PATH=" + install_directory,
         "-DIFACE=" + iface,
+        "-DONEDAL_MAJOR_BINARY=" + str(onedal_major_binary_version),
         "-DPYTHON_INCLUDE_DIR=" + python_include,
         "-DNUMPY_INCLUDE_DIRS=" + numpy_include,
         "-DPYTHON_LIBRARY_DIR=" + python_library_dir,

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -41,9 +41,12 @@ def get_onedal_version(dal_root, version_type='release'):
 
     with open(header_version, 'r') as header:
         if version_type == 'release':
-            version = find_defines(['__INTEL_DAAL__', '__INTEL_DAAL_MINOR__'], header)
+            version = find_defines(
+                ['__INTEL_DAAL__', '__INTEL_DAAL_MINOR__', '__INTEL_DAAL_UPDATE__'],
+                header)
             version = int(version['__INTEL_DAAL__']) * 10000 + \
-                int(version['__INTEL_DAAL_MINOR__']) * 100
+                int(version['__INTEL_DAAL_MINOR__']) * 100 + \
+                int(version['__INTEL_DAAL_UPDATE__'])
         elif version_type == 'binary':
             version = find_defines(
                 ['__INTEL_DAAL_MAJOR_BINARY__', '__INTEL_DAAL_MINOR_BINARY__'], header)

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -19,7 +19,7 @@ import re
 from os.path import join as jp
 
 
-def find_defines(defines:list, file_obj):
+def find_defines(defines: list, file_obj):
     defines_dict = {define: '' for define in defines}
     for elem in file_obj:
         for define in defines:

--- a/setup.py
+++ b/setup.py
@@ -156,10 +156,10 @@ def get_libs(iface='daal'):
         onedal_lib = [f'onedal.{major_version}']
         onedal_dpc_lib = [f'onedal_dpc.{major_version}']
     else:
-        libraries_plat = [f'libonedal_core.so.{major_version}',
-                          f'libonedal_thread.so.{major_version}']
-        onedal_lib = [f'libonedal.so.{major_version}']
-        onedal_dpc_lib = [f'libonedal_dpc.so.{major_version}']
+        libraries_plat = [f':libonedal_core.so.{major_version}',
+                          f':libonedal_thread.so.{major_version}']
+        onedal_lib = [f':libonedal.so.{major_version}']
+        onedal_dpc_lib = [f':libonedal_dpc.so.{major_version}']
     if iface == 'onedal':
         libraries_plat = onedal_lib + libraries_plat
     elif iface == 'onedal_dpc':

--- a/setup.py
+++ b/setup.py
@@ -151,8 +151,8 @@ def get_libs(iface='daal'):
         onedal_lib = [f'onedal_dll.{major_version}']
         onedal_dpc_lib = [f'onedal_dpc_dll.{major_version}']
     else:
-        libraries_plat = [f'onedal_core.{major_version}', 
-            f'onedal_thread.{major_version}']
+        libraries_plat = [f'onedal_core.{major_version}',
+                          f'onedal_thread.{major_version}']
         onedal_lib = [f'onedal.{major_version}']
         onedal_dpc_lib = [f'onedal_dpc.{major_version}']
     if iface == 'onedal':
@@ -335,11 +335,12 @@ class custom_build():
     def run(self):
         if is_onedal_iface:
             cxx = os.getenv('CXX', 'cl' if IS_WIN else 'g++')
-            build_backend.custom_build_cmake_clib('host', cxx)
+            build_backend.custom_build_cmake_clib(
+                'host', cxx, ONEDAL_MAJOR_BINARY_VERSION)
         if dpcpp:
             build_oneapi_backend()
             if is_onedal_iface:
-                build_backend.custom_build_cmake_clib('dpc')
+                build_backend.custom_build_cmake_clib('dpc', ONEDAL_MAJOR_BINARY_VERSION)
 
     def post_build(self):
         if IS_MAC:
@@ -347,7 +348,7 @@ class custom_build():
             major_version = ONEDAL_MAJOR_BINARY_VERSION
             major_is_available = find_library(
                 f'libonedal_core.{major_version}.dylib') is not None
-            none_is_available = find_library(f'libonedal_core.dylib') is not None
+            none_is_available = find_library('libonedal_core.dylib') is not None
             if major_is_available and not none_is_available \
                     and ONEDAL_VERSION == ONEDAL_2023_0_1:
                 extension_libs = list(pathlib.Path('.').glob('**/*darwin.so'))

--- a/setup.py
+++ b/setup.py
@@ -349,21 +349,20 @@ class custom_build():
 
     def post_build(self):
         if IS_MAC:
+            import subprocess
             # manually fix incorrect install_name of oneDAL 2023.0.1 libs
             major_version = ONEDAL_MAJOR_BINARY_VERSION
             major_is_available = find_library(
                 f'libonedal_core.{major_version}.dylib') is not None
-            none_is_available = find_library('libonedal_core.dylib') is not None
-            if major_is_available and not none_is_available \
-                    and ONEDAL_VERSION == ONEDAL_2023_0_1:
+            if major_is_available and ONEDAL_VERSION == ONEDAL_2023_0_1:
                 extension_libs = list(pathlib.Path('.').glob('**/*darwin.so'))
                 onedal_libs = ['onedal', 'onedal_dpc', 'onedal_core', 'onedal_thread']
                 for ext_lib in extension_libs:
                     for onedal_lib in onedal_libs:
-                        os.system('install_name_tool -change '
-                                  f'lib{onedal_lib}.dylib '
-                                  f'lib{onedal_lib}.{major_version}.dylib '
-                                  f'{ext_lib}')
+                        subprocess.call('/usr/bin/install_name_tool -change '
+                                        f'lib{onedal_lib}.dylib '
+                                        f'lib{onedal_lib}.{major_version}.dylib '
+                                        f'{ext_lib}', shell=False)
 
 
 class develop(orig_develop.develop, custom_build):

--- a/setup.py
+++ b/setup.py
@@ -145,15 +145,16 @@ def get_daal_type_defines():
 
 
 def get_libs(iface='daal'):
+    major_version = ONEDAL_MAJOR_BINARY_VERSION
     if IS_WIN:
-        major_version = ONEDAL_MAJOR_BINARY_VERSION
-        libraries_plat = [f'onedal_core_dll{major_version}']
-        onedal_lib = [f'onedal_dll{major_version}']
-        onedal_dpc_lib = [f'onedal_dpc_dll{major_version}']
+        libraries_plat = [f'onedal_core_dll.{major_version}']
+        onedal_lib = [f'onedal_dll.{major_version}']
+        onedal_dpc_lib = [f'onedal_dpc_dll.{major_version}']
     else:
-        libraries_plat = ['onedal_core', 'onedal_thread']
-        onedal_lib = ['onedal']
-        onedal_dpc_lib = ['onedal_dpc']
+        libraries_plat = [f'onedal_core.{major_version}', 
+            f'onedal_thread.{major_version}']
+        onedal_lib = [f'onedal.{major_version}']
+        onedal_dpc_lib = [f'onedal_dpc.{major_version}']
     if iface == 'onedal':
         libraries_plat = onedal_lib + libraries_plat
     elif iface == 'onedal_dpc':

--- a/setup.py
+++ b/setup.py
@@ -150,11 +150,16 @@ def get_libs(iface='daal'):
         libraries_plat = [f'onedal_core_dll.{major_version}']
         onedal_lib = [f'onedal_dll.{major_version}']
         onedal_dpc_lib = [f'onedal_dpc_dll.{major_version}']
-    else:
+    elif IS_MAC:
         libraries_plat = [f'onedal_core.{major_version}',
                           f'onedal_thread.{major_version}']
         onedal_lib = [f'onedal.{major_version}']
         onedal_dpc_lib = [f'onedal_dpc.{major_version}']
+    else:
+        libraries_plat = [f'libonedal_core.so.{major_version}',
+                          f'libonedal_thread.so.{major_version}']
+        onedal_lib = [f'libonedal.so.{major_version}']
+        onedal_dpc_lib = [f'libonedal_dpc.so.{major_version}']
     if iface == 'onedal':
         libraries_plat = onedal_lib + libraries_plat
     elif iface == 'onedal_dpc':

--- a/setup.py
+++ b/setup.py
@@ -57,23 +57,12 @@ elif sys.platform in ['win32', 'cygwin']:
 else:
     assert False, sys.platform + ' not supported'
 
+ONEDAL_MAJOR_BINARY_VERSION, ONEDAL_MINOR_BINARY_VERSION = get_onedal_version(
+    dal_root, 'binary')
 ONEDAL_VERSION = get_onedal_version(dal_root)
 ONEDAL_2021_3 = 2021 * 10000 + 3 * 100
 is_onedal_iface = \
     os.environ.get('OFF_ONEDAL_IFACE') is None and ONEDAL_VERSION >= ONEDAL_2021_3
-
-
-def get_win_major_version():
-    lib_name = find_library('onedal_core')
-    if lib_name is None:
-        return ''
-    version = lib_name.split('\\')[-1].split('.')[1]
-    try:
-        version = '.' + str(int(version))
-    except ValueError:
-        version = ''
-    return version
-
 
 d4p_version = (os.environ['DAAL4PY_VERSION'] if 'DAAL4PY_VERSION' in os.environ
                else time.strftime('%Y%m%d.%H%M%S'))
@@ -155,7 +144,7 @@ def get_daal_type_defines():
 
 def get_libs(iface='daal'):
     if IS_WIN:
-        major_version = get_win_major_version()
+        major_version = ONEDAL_MAJOR_BINARY_VERSION
         libraries_plat = [f'onedal_core_dll{major_version}']
         onedal_lib = [f'onedal_dll{major_version}']
         onedal_dpc_lib = [f'onedal_dpc_dll{major_version}']


### PR DESCRIPTION
# Description

Changes proposed in this pull request:
- Modify setup.py for linking to oneDAL libs with major binary version which are only available libs from conda/pip packages starting from 2023.0.1
- Manually fix install_name for 2023.0.1 oneDAL release on macos
 
