### PR TITLE
Overheads optimization and fixes for test fails

### DIFF
--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -71,12 +71,20 @@ def daal_check_version(rule):
     return True
 
 
+sklearn_versions_map = {}
+
+
 def sklearn_check_version(ver):
+    if ver in sklearn_versions_map.keys():
+        return sklearn_versions_map[ver]
     if hasattr(Version(ver), 'base_version'):
         base_sklearn_version = Version(sklearn_version).base_version
-        return bool(Version(base_sklearn_version) >= Version(ver))
-    # packaging module not available
-    return bool(Version(sklearn_version) >= Version(ver))
+        res = bool(Version(base_sklearn_version) >= Version(ver))
+    else:
+        # packaging module not available
+        res = bool(Version(sklearn_version) >= Version(ver))
+    sklearn_versions_map[ver] = res
+    return res
 
 
 def get_daal_version():

--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -40,6 +40,10 @@ try:
 except (ImportError, ModuleNotFoundError):
     ctx_imported = False
 
+oneapi_is_available = 'daal4py.oneapi' in sys.modules
+if oneapi_is_available:
+    from daal4py.oneapi import _get_device_name_sycl_ctxt
+
 
 def set_idp_sklearn_verbose():
     logLevel = os.environ.get("IDP_SKLEARN_VERBOSE")
@@ -120,8 +124,7 @@ def make2d(X):
 def get_patch_message(s):
     if s == "daal":
         message = "running accelerated version on "
-        if 'daal4py.oneapi' in sys.modules:
-            from daal4py.oneapi import _get_device_name_sycl_ctxt
+        if oneapi_is_available:
             dev = _get_device_name_sycl_ctxt()
             if dev == 'cpu' or dev is None:
                 message += 'CPU'
@@ -153,7 +156,6 @@ def is_in_sycl_ctxt():
 
 def is_DataFrame(X):
     if pandas_is_imported:
-        from pandas import DataFrame
         return isinstance(X, DataFrame)
     else:
         return False

--- a/daal4py/sklearn/cluster/_k_means_0_23.py
+++ b/daal4py/sklearn/cluster/_k_means_0_23.py
@@ -456,7 +456,7 @@ class KMeans(KMeans_original):
             n_clusters=8,
             *,
             init='k-means++',
-            n_init='warn' if sklearn_check_version('1.2') else 10,
+            n_init='auto' if sklearn_check_version('1.4') else 'warn',
             max_iter=300,
             tol=1e-4,
             verbose=0,

--- a/daal4py/sklearn/cluster/_k_means_0_23.py
+++ b/daal4py/sklearn/cluster/_k_means_0_23.py
@@ -178,7 +178,7 @@ def _daal4py_k_means_fit(X, nClusters, numIterations,
     def is_string(s, target_str):
         return isinstance(s, str) and s == target_str
 
-    if n_init == 'auto':
+    if n_init == 'auto' or 'warn':
         if is_string(cluster_centers_0, 'random'):
             n_init = 10
         elif is_string(cluster_centers_0, 'k-means++'):
@@ -447,13 +447,16 @@ class KMeans(KMeans_original):
     __doc__ = KMeans_original.__doc__
 
     if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **KMeans_original._parameter_constraints}
+
         @_deprecate_positional_args
         def __init__(
             self,
             n_clusters=8,
             *,
             init='k-means++',
-            n_init=10,
+            n_init='warn' if sklearn_check_version('1.2') else 10,
             max_iter=300,
             tol=1e-4,
             verbose=0,

--- a/daal4py/sklearn/cluster/_k_means_0_23.py
+++ b/daal4py/sklearn/cluster/_k_means_0_23.py
@@ -178,7 +178,7 @@ def _daal4py_k_means_fit(X, nClusters, numIterations,
     def is_string(s, target_str):
         return isinstance(s, str) and s == target_str
 
-    if n_init == 'auto' or 'warn':
+    if n_init in ['auto', 'warn']:
         if is_string(cluster_centers_0, 'random'):
             n_init = 10
         elif is_string(cluster_centers_0, 'k-means++'):

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -56,24 +56,27 @@ def _to_absolute_max_features(
         return n_features
     if isinstance(max_features, str):
         if max_features == "auto":
-            if sklearn_check_version('1.1'):
-                warnings.warn(
-                    "`max_features='auto'` has been deprecated in 1.1 "
-                    "and will be removed in 1.3. To keep the past behaviour, "
-                    "explicitly set `max_features=1.0` or remove this "
-                    "parameter as it is also the default value for "
-                    "RandomForestRegressors and ExtraTreesRegressors.",
-                    FutureWarning,
-                )
-            return max(1, int(np.sqrt(n_features))
-                       ) if is_classification else n_features
+            if not sklearn_check_version('1.3'):
+                if sklearn_check_version('1.1'):
+                    warnings.warn(
+                        "`max_features='auto'` has been deprecated in 1.1 "
+                        "and will be removed in 1.3. To keep the past behaviour, "
+                        "explicitly set `max_features=1.0` or remove this "
+                        "parameter as it is also the default value for "
+                        "RandomForestRegressors and ExtraTreesRegressors.",
+                        FutureWarning,
+                    )
+                return max(1, int(np.sqrt(n_features))
+                           ) if is_classification else n_features
         if max_features == 'sqrt':
             return max(1, int(np.sqrt(n_features)))
         if max_features == "log2":
             return max(1, int(np.log2(n_features)))
+        allowed_string_values = '"sqrt" or "log2"' if sklearn_check_version('1.3') \
+            else '"auto", "sqrt" or "log2"'
         raise ValueError(
             'Invalid value for max_features. Allowed string '
-            'values are "auto", "sqrt" or "log2".')
+            f'values are {allowed_string_values}.')
     if isinstance(max_features, (numbers.Integral, np.integer)):
         return max_features
     if max_features > 0.0:
@@ -604,7 +607,7 @@ class RandomForestClassifier(RandomForestClassifier_original):
                      min_samples_split=2,
                      min_samples_leaf=1,
                      min_weight_fraction_leaf=0.,
-                     max_features="auto",
+                     max_features='sqrt' if sklearn_check_version('1.1') else 'auto',
                      max_leaf_nodes=None,
                      min_impurity_decrease=0.,
                      bootstrap=True,
@@ -921,7 +924,7 @@ class RandomForestRegressor(RandomForestRegressor_original):
                      min_samples_split=2,
                      min_samples_leaf=1,
                      min_weight_fraction_leaf=0.,
-                     max_features="auto",
+                     max_features=1.0 if sklearn_check_version('1.1') else 'auto',
                      max_leaf_nodes=None,
                      min_impurity_decrease=0.,
                      bootstrap=True,

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -370,6 +370,8 @@ def _fit_classifier(self, X, y, sample_weight=None):
     if _dal_ready:
         _daal_fit_classifier(self, X, y, sample_weight=sample_weight)
 
+        if sklearn_check_version("1.2"):
+            self._estimator = DecisionTreeClassifier()
         self.estimators_ = self._estimators_
 
         # Decapsulate classes_ attributes
@@ -530,6 +532,8 @@ def _fit_regressor(self, X, y, sample_weight=None):
     if _dal_ready:
         _daal_fit_regressor(self, X, y, sample_weight=sample_weight)
 
+        if sklearn_check_version("1.2"):
+            self._estimator = DecisionTreeRegressor()
         self.estimators_ = self._estimators_
         return self
     return super(RandomForestRegressor, self).fit(
@@ -632,7 +636,6 @@ class RandomForestClassifier(RandomForestClassifier_original):
             self.maxBins = maxBins
             self.minBinSize = minBinSize
             self.min_impurity_split = None
-            self._estimator = DecisionTreeClassifier()
     else:
         def __init__(self,
                      n_estimators=100,
@@ -679,7 +682,6 @@ class RandomForestClassifier(RandomForestClassifier_original):
             )
             self.maxBins = maxBins
             self.minBinSize = minBinSize
-            self._estimator = DecisionTreeClassifier()
 
     @support_usm_ndarray()
     def fit(self, X, y, sample_weight=None):
@@ -947,7 +949,6 @@ class RandomForestRegressor(RandomForestRegressor_original):
             self.maxBins = maxBins
             self.minBinSize = minBinSize
             self.min_impurity_split = None
-            self._estimator = DecisionTreeRegressor()
     else:
         def __init__(self,
                      n_estimators=100, *,
@@ -992,7 +993,6 @@ class RandomForestRegressor(RandomForestRegressor_original):
             )
             self.maxBins = maxBins
             self.minBinSize = minBinSize
-            self._estimator = DecisionTreeRegressor()
 
     @support_usm_ndarray()
     def fit(self, X, y, sample_weight=None):

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -209,14 +209,7 @@ def _daal_fit_classifier(self, X, y, sample_weight=None):
     # create algorithm
     X_fptype = getFPType(X)
 
-    # limitation on the number of stream for mt2203 is 6024
-    # more details here:
-    # https://oneapi-src.github.io/oneDAL/daal/algorithms/engines/mt2203.html
-    max_stream_count = 6024
-    if self.n_estimators <= max_stream_count:
-        daal_engine = daal4py.engines_mt2203(seed=seed_, fptype=X_fptype)
-    else:
-        daal_engine = daal4py.engines_mt19937(seed=seed_, fptype=X_fptype)
+    daal_engine = daal4py.engines_mt19937(seed=seed_, fptype=X_fptype)
 
     features_per_node_ = _to_absolute_max_features(
         self.max_features, X.shape[1], is_classification=True)
@@ -408,14 +401,7 @@ def _daal_fit_regressor(self, X, y, sample_weight=None):
     X_fptype = getFPType(X)
     seed_ = rs_.randint(0, np.iinfo('i').max)
 
-    # limitation on the number of stream for mt2203 is 6024
-    # more details here:
-    # https://oneapi-src.github.io/oneDAL/daal/algorithms/engines/mt2203.html
-    max_stream_count = 6024
-    if self.n_estimators <= max_stream_count:
-        daal_engine = daal4py.engines_mt2203(seed=seed_, fptype=X_fptype)
-    else:
-        daal_engine = daal4py.engines_mt19937(seed=seed_, fptype=X_fptype)
+    daal_engine = daal4py.engines_mt19937(seed=seed_, fptype=X_fptype)
 
     _featuresPerNode = _to_absolute_max_features(
         self.max_features, X.shape[1], is_classification=False)

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -56,7 +56,7 @@ def _to_absolute_max_features(
         return n_features
     if isinstance(max_features, str):
         if max_features == "auto":
-            if sklearn_check_version('1.2'):
+            if sklearn_check_version('1.1'):
                 warnings.warn(
                     "`max_features='auto'` has been deprecated in 1.1 "
                     "and will be removed in 1.3. To keep the past behaviour, "
@@ -89,6 +89,10 @@ def _get_n_samples_bootstrap(n_samples, max_samples):
         if not sklearn_check_version('1.2'):
             if not (1 <= max_samples <= n_samples):
                 msg = "`max_samples` must be in range 1 to {} but got value {}"
+                raise ValueError(msg.format(n_samples, max_samples))
+        else:
+            if max_samples > n_samples:
+                msg = "`max_samples` must be <= n_samples={} but got value {}"
                 raise ValueError(msg.format(n_samples, max_samples))
         return float(max_samples / n_samples)
 
@@ -218,6 +222,13 @@ def _daal_fit_classifier(self, X, y, sample_weight=None):
         n_samples=X.shape[0],
         max_samples=self.max_samples
     )
+
+    if not self.bootstrap and self.max_samples is not None:
+        raise ValueError(
+            "`max_sample` cannot be set if `bootstrap=False`. "
+            "Either switch to `bootstrap=True` or set "
+            "`max_sample=None`."
+        )
 
     if not self.bootstrap and self.oob_score:
         raise ValueError("Out of bag estimation only available"
@@ -379,6 +390,13 @@ def _daal_fit_regressor(self, X, y, sample_weight=None):
         self.n_features_ = self.n_features_in_
 
     rs_ = check_random_state(self.random_state)
+
+    if not self.bootstrap and self.max_samples is not None:
+        raise ValueError(
+            "`max_sample` cannot be set if `bootstrap=False`. "
+            "Either switch to `bootstrap=True` or set "
+            "`max_sample=None`."
+        )
 
     if not self.bootstrap and self.oob_score:
         raise ValueError("Out of bag estimation only available"

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -412,6 +412,8 @@ def _daal_fit_regressor(self, X, y, sample_weight=None):
     )
 
     if sample_weight is not None:
+        if hasattr(sample_weight, '__array__'):
+            sample_weight[sample_weight == 0.0] = 1.0
         sample_weight = [sample_weight]
 
     # create algorithm

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -43,6 +43,9 @@ from sklearn.exceptions import DataConversionWarning
 from math import ceil
 from scipy import sparse as sp
 
+if sklearn_check_version('1.2'):
+    from sklearn.utils._param_validation import Interval
+
 
 def _to_absolute_max_features(
     max_features,
@@ -570,7 +573,9 @@ class RandomForestClassifier(RandomForestClassifier_original):
 
     if sklearn_check_version('1.2'):
         _parameter_constraints: dict = {
-            **RandomForestClassifier_original._parameter_constraints
+            **RandomForestClassifier_original._parameter_constraints,
+            "maxBins": [Interval(numbers.Integral, 2, None, closed="left")],
+            "minBinSize": [Interval(numbers.Integral, 1, None, closed="left")]
         }
 
     if sklearn_check_version('1.0'):
@@ -885,7 +890,9 @@ class RandomForestRegressor(RandomForestRegressor_original):
 
     if sklearn_check_version('1.2'):
         _parameter_constraints: dict = {
-            **RandomForestRegressor_original._parameter_constraints
+            **RandomForestRegressor_original._parameter_constraints,
+            "maxBins": [Interval(numbers.Integral, 2, None, closed="left")],
+            "minBinSize": [Interval(numbers.Integral, 1, None, closed="left")]
         }
 
     if sklearn_check_version('1.0'):

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -36,6 +36,10 @@ deselected_tests:
   - linear_model/tests/test_common.py::test_balance_property[42-True-LinearRegression]
   - linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-1-100-minkowski-1000-5-100]
+  - cluster/tests/test_k_means.py::test_k_means_fit_predict >=0.23,<0.24
+
+  - utils/tests/test_validation.py::test_check_memory <1.0
+
   # oneDAL doesn't throw error if resulting coeffs are not finite
   - linear_model/tests/test_coordinate_descent.py::test_enet_nonfinite_params
   - svm/tests/test_svm.py::test_svc_nonfinite_params

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -33,6 +33,8 @@ deselected_tests:
   # Non-critival but significant difference because of different implementations
   - ensemble/tests/test_forest.py::test_forest_classifier_oob[True-X2-y2-0.65-array-RandomForestClassifier]
   - ensemble/tests/test_forest.py::test_forest_classifier_oob[oob_score1-X2-y2-0.65-array-RandomForestClassifier]
+  - ensemble/tests/test_forest.py::test_importances[RandomForestClassifier-gini-float64]
+  - ensemble/tests/test_voting.py::test_set_estimator_drop
   - linear_model/tests/test_common.py::test_balance_property[42-True-LinearRegression]
   - linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-1-100-minkowski-1000-5-100]

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -40,7 +40,8 @@ deselected_tests:
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-1-100-minkowski-1000-5-100]
   - cluster/tests/test_k_means.py::test_k_means_fit_predict >=0.23,<0.24
 
-  - utils/tests/test_validation.py::test_check_memory <1.0
+  # cache directory is not accessible on some systems
+  - utils/tests/test_validation.py::test_check_memory
 
   # oneDAL doesn't throw error if resulting coeffs are not finite
   - linear_model/tests/test_coordinate_descent.py::test_enet_nonfinite_params

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -36,6 +36,15 @@ deselected_tests:
   - linear_model/tests/test_common.py::test_balance_property[42-True-LinearRegression]
   - linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-1-100-minkowski-1000-5-100]
+  - linear_model/tests/test_coordinate_descent.py::test_enet_nonfinite_params
+  - svm/tests/test_svm.py::test_svc_nonfinite_params
+
+  # Different exception types in sklearnex and sklearn
+  - utils/tests/test_validation.py::test_check_array_links_to_imputer_doc_only_for_X[asarray-X]
+  - utils/tests/test_validation.py::test_check_array_links_to_imputer_doc_only_for_X[csr_matrix-X]
+
+  # TODO: investigate copy failure of read-only buffer
+  - linear_model/tests/test_coordinate_descent.py::test_read_only_buffer
 
   # Warm starting issue on 1 iteration of LogReg
   - linear_model/tests/test_logistic.py::test_warm_start[multinomial-True-True-lbfgs]

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -36,6 +36,7 @@ deselected_tests:
   - linear_model/tests/test_common.py::test_balance_property[42-True-LinearRegression]
   - linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-1-100-minkowski-1000-5-100]
+  # oneDAL doesn't throw error if resulting coeffs are not finite
   - linear_model/tests/test_coordinate_descent.py::test_enet_nonfinite_params
   - svm/tests/test_svm.py::test_svc_nonfinite_params
 

--- a/onedal/common/_policy.py
+++ b/onedal/common/_policy.py
@@ -17,6 +17,10 @@
 from onedal import _backend, _is_dpc_backend
 import sys
 
+oneapi_is_available = 'daal4py.oneapi' in sys.modules
+if oneapi_is_available:
+    from daal4py.oneapi import _get_sycl_ctxt, sycl_execution_context
+
 
 def _get_policy(queue, *data):
     data_queue = _get_queue(*data)
@@ -39,12 +43,9 @@ def _get_queue(*data):
 
 class _Daal4PyContextReset:
     def __init__(self):
-        import sys
-
         self._d4p_context = None
         self._host_context = None
-        if 'daal4py.oneapi' in sys.modules:
-            from daal4py.oneapi import _get_sycl_ctxt, sycl_execution_context
+        if oneapi_is_available:
             self._d4p_context = _get_sycl_ctxt()
             self._host_context = sycl_execution_context('cpu')
             self._host_context.apply()

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -100,11 +100,10 @@ def _validate_targets(y, class_weight, dtype):
 
 def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
                  copy=False, force_all_finite=True,
-                 ensure_2d=True, accept_large_sparse=True, input_name=''):
+                 ensure_2d=True, accept_large_sparse=True):
     array = check_array(array=array, dtype=dtype, accept_sparse=accept_sparse,
                         order=order, copy=copy, force_all_finite=force_all_finite,
-                        ensure_2d=ensure_2d, accept_large_sparse=accept_large_sparse,
-                        input_name='X')
+                        ensure_2d=ensure_2d, accept_large_sparse=accept_large_sparse)
 
     if sp.isspmatrix(array):
         return array
@@ -130,8 +129,7 @@ def _check_X_y(X, y, dtype="numeric", accept_sparse=False, order=None, copy=Fals
                      dtype=dtype, order=order, copy=copy,
                      force_all_finite=force_all_finite,
                      ensure_2d=ensure_2d,
-                     accept_large_sparse=accept_large_sparse,
-                     input_name='X')
+                     accept_large_sparse=accept_large_sparse)
 
     y = _column_or_1d(y, warn=True)
     if y_numeric and y.dtype.kind == 'O':

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -19,6 +19,7 @@ import warnings
 from scipy import sparse as sp
 from scipy.sparse import issparse, dok_matrix, lil_matrix
 from sklearn.preprocessing import LabelEncoder
+from sklearn.utils.validation import check_array
 from collections.abc import Sequence
 from numbers import Integral
 
@@ -99,12 +100,11 @@ def _validate_targets(y, class_weight, dtype):
 
 def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
                  copy=False, force_all_finite=True,
-                 ensure_2d=True, accept_large_sparse=True):
-    # TODO
-    from sklearn.utils.validation import check_array
+                 ensure_2d=True, accept_large_sparse=True, input_name=''):
     array = check_array(array=array, dtype=dtype, accept_sparse=accept_sparse,
                         order=order, copy=copy, force_all_finite=force_all_finite,
-                        ensure_2d=ensure_2d, accept_large_sparse=accept_large_sparse)
+                        ensure_2d=ensure_2d, accept_large_sparse=accept_large_sparse,
+                        input_name='X')
 
     if sp.isspmatrix(array):
         return array
@@ -130,7 +130,8 @@ def _check_X_y(X, y, dtype="numeric", accept_sparse=False, order=None, copy=Fals
                      dtype=dtype, order=order, copy=copy,
                      force_all_finite=force_all_finite,
                      ensure_2d=ensure_2d,
-                     accept_large_sparse=accept_large_sparse)
+                     accept_large_sparse=accept_large_sparse,
+                     input_name='X')
 
     y = _column_or_1d(y, warn=True)
     if y_numeric and y.dtype.kind == 'O':

--- a/sklearnex/ensemble/tests/test_random_forest.py
+++ b/sklearnex/ensemble/tests/test_random_forest.py
@@ -37,7 +37,10 @@ def test_sklearnex_import_rf_regression():
                            random_state=0, shuffle=False)
     rf = RandomForestRegressor(max_depth=2, random_state=0).fit(X, y)
     assert 'daal4py' in rf.__module__
+    pred = rf.predict([[0, 0, 0, 0]])
     if daal_check_version((2021, 'P', 400)):
-        assert_allclose([-6.97], rf.predict([[0, 0, 0, 0]]), atol=1e-2)
+        # random engine work was changed in sklearnex 2023.1
+        assert np.allclose([-6.97], pred, atol=1e-2) \
+            or np.allclose([-8.36], pred, atol=1e-2)
     else:
-        assert_allclose([-6.66], rf.predict([[0, 0, 0, 0]]), atol=1e-2)
+        assert_allclose([-6.66], pred, atol=1e-2)

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -40,6 +40,10 @@ from scipy import sparse as sp
 
 if sklearn_check_version("0.24"):
     class KNeighborsClassifier_(sklearn_KNeighborsClassifier):
+        if sklearn_check_version('1.2'):
+            _parameter_constraints: dict = {
+                **sklearn_KNeighborsClassifier._parameter_constraints}
+
         @_deprecate_positional_args
         def __init__(self, n_neighbors=5, *,
                      weights='uniform', algorithm='auto', leaf_size=30,
@@ -93,6 +97,10 @@ else:
 
 
 class KNeighborsClassifier(KNeighborsClassifier_):
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **KNeighborsClassifier_._parameter_constraints}
+
     @_deprecate_positional_args
     def __init__(self, n_neighbors=5, *,
                  weights='uniform', algorithm='auto', leaf_size=30,
@@ -107,6 +115,8 @@ class KNeighborsClassifier(KNeighborsClassifier_):
             n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -101,18 +101,30 @@ class KNeighborsClassifier(KNeighborsClassifier_):
         _parameter_constraints: dict = {
             **KNeighborsClassifier_._parameter_constraints}
 
-    @_deprecate_positional_args
-    def __init__(self, n_neighbors=5, *,
-                 weights='uniform', algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, n_jobs=None,
-                 **kwargs):
-        super().__init__(
-            n_neighbors=n_neighbors,
-            weights=weights,
-            algorithm=algorithm,
-            leaf_size=leaf_size, metric=metric, p=p,
-            metric_params=metric_params,
-            n_jobs=n_jobs, **kwargs)
+    if sklearn_check_version('1.0'):
+        def __init__(self, n_neighbors=5, *,
+                     weights='uniform', algorithm='auto', leaf_size=30,
+                     p=2, metric='minkowski', metric_params=None, n_jobs=None):
+            super().__init__(
+                n_neighbors=n_neighbors,
+                weights=weights,
+                algorithm=algorithm,
+                leaf_size=leaf_size, metric=metric, p=p,
+                metric_params=metric_params,
+                n_jobs=n_jobs)
+    else:
+        @_deprecate_positional_args
+        def __init__(self, n_neighbors=5, *,
+                     weights='uniform', algorithm='auto', leaf_size=30,
+                     p=2, metric='minkowski', metric_params=None, n_jobs=None,
+                     **kwargs):
+            super().__init__(
+                n_neighbors=n_neighbors,
+                weights=weights,
+                algorithm=algorithm,
+                leaf_size=leaf_size, metric=metric, p=p,
+                metric_params=metric_params,
+                n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
         if sklearn_check_version("1.2"):

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -101,18 +101,30 @@ class KNeighborsRegressor(KNeighborsRegressor_):
         _parameter_constraints: dict = {
             **KNeighborsRegressor_._parameter_constraints}
 
-    @_deprecate_positional_args
-    def __init__(self, n_neighbors=5, *,
-                 weights='uniform', algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, n_jobs=None,
-                 **kwargs):
-        super().__init__(
-            n_neighbors=n_neighbors,
-            weights=weights,
-            algorithm=algorithm,
-            leaf_size=leaf_size, metric=metric, p=p,
-            metric_params=metric_params,
-            n_jobs=n_jobs, **kwargs)
+    if sklearn_check_version('1.0'):
+        def __init__(self, n_neighbors=5, *,
+                     weights='uniform', algorithm='auto', leaf_size=30,
+                     p=2, metric='minkowski', metric_params=None, n_jobs=None):
+            super().__init__(
+                n_neighbors=n_neighbors,
+                weights=weights,
+                algorithm=algorithm,
+                leaf_size=leaf_size, metric=metric, p=p,
+                metric_params=metric_params,
+                n_jobs=n_jobs)
+    else:
+        @_deprecate_positional_args
+        def __init__(self, n_neighbors=5, *,
+                     weights='uniform', algorithm='auto', leaf_size=30,
+                     p=2, metric='minkowski', metric_params=None, n_jobs=None,
+                     **kwargs):
+            super().__init__(
+                n_neighbors=n_neighbors,
+                weights=weights,
+                algorithm=algorithm,
+                leaf_size=leaf_size, metric=metric, p=p,
+                metric_params=metric_params,
+                n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
         if sklearn_check_version("1.2"):

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -40,6 +40,10 @@ from scipy import sparse as sp
 
 if sklearn_check_version("0.24"):
     class KNeighborsRegressor_(sklearn_KNeighborsRegressor):
+        if sklearn_check_version('1.2'):
+            _parameter_constraints: dict = {
+                **sklearn_KNeighborsRegressor._parameter_constraints}
+
         @_deprecate_positional_args
         def __init__(self, n_neighbors=5, *,
                      weights='uniform', algorithm='auto', leaf_size=30,
@@ -93,6 +97,10 @@ else:
 
 
 class KNeighborsRegressor(KNeighborsRegressor_):
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **KNeighborsRegressor_._parameter_constraints}
+
     @_deprecate_positional_args
     def __init__(self, n_neighbors=5, *,
                  weights='uniform', algorithm='auto', leaf_size=30,
@@ -107,6 +115,8 @@ class KNeighborsRegressor(KNeighborsRegressor_):
             n_jobs=n_jobs, **kwargs)
 
     def fit(self, X, y):
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -54,6 +54,10 @@ if sklearn_check_version("0.22") and \
                 metric_params=metric_params, n_jobs=n_jobs)
 else:
     class NearestNeighbors_(sklearn_NearestNeighbors):
+        if sklearn_check_version('1.2'):
+            _parameter_constraints: dict = {
+                **sklearn_NearestNeighbors._parameter_constraints}
+
         @_deprecate_positional_args
         def __init__(self, *, n_neighbors=5, radius=1.0,
                      algorithm='auto', leaf_size=30, metric='minkowski',
@@ -67,6 +71,10 @@ else:
 
 
 class NearestNeighbors(NearestNeighbors_):
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **NearestNeighbors_._parameter_constraints}
+
     @_deprecate_positional_args
     def __init__(self, n_neighbors=5, radius=1.0,
                  algorithm='auto', leaf_size=30, metric='minkowski',
@@ -79,6 +87,8 @@ class NearestNeighbors(NearestNeighbors_):
             metric_params=metric_params, n_jobs=n_jobs)
 
     def fit(self, X, y=None):
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         if self.metric_params is not None and 'p' in self.metric_params:

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -78,6 +78,8 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.NuSVC.fit', {
@@ -177,8 +179,6 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
             return hasattr(self, '_onedal_estimator')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        if sklearn_check_version("1.2"):
-            self._validate_params()
         onedal_params = {
             'nu': self.nu,
             'kernel': self.kernel,

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -72,6 +72,8 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.NuSVR.fit', {
@@ -115,8 +117,6 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             return hasattr(self, '_onedal_estimator')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        if sklearn_check_version("1.2"):
-            self._validate_params()
         onedal_params = {
             'C': self.C,
             'nu': self.nu,

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -78,6 +78,8 @@ class SVC(sklearn_SVC, BaseSVC):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.SVC.fit', {
@@ -191,8 +193,6 @@ class SVC(sklearn_SVC, BaseSVC):
         raise RuntimeError(f'Unknown method {method_name} in {self.__class__.__name__}')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        if sklearn_check_version("1.2"):
-            self._validate_params()
         onedal_params = {
             'C': self.C,
             'kernel': self.kernel,

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -72,6 +72,8 @@ class SVR(sklearn_SVR, BaseSVR):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        if sklearn_check_version("1.2"):
+            self._validate_params()
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(self, 'svm.SVR.fit', {
@@ -116,8 +118,6 @@ class SVR(sklearn_SVR, BaseSVR):
             return hasattr(self, '_onedal_estimator')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        if sklearn_check_version("1.2"):
-            self._validate_params()
         onedal_params = {
             'C': self.C,
             'epsilon': self.epsilon,


### PR DESCRIPTION
Changes proposed in this pull request:
- Move imports from frequently used function
- Cache sklearn_check_version function results
- Align `n_init` default value in KMeans to sklearn
- Align random forest parameters to sklearn
- Remove `mt2203` daal4py engine from patched RandomForest due to it's instability and alignment with sklearn
- Add _parameter_constraints in kNN models
- Move check of parameters' constraints in SVM models to avoid usage of wrongly typed parameters
- Deselect some tests