### PR TITLE
Fix for calls of setup_sklearnex.py in CI

### DIFF
--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -76,6 +76,7 @@ jobs:
     displayName: 'Install requirements'
   - script: |
       export PREFIX=$(dirname $(dirname $(which python)))
+      export DALROOT=$PREFIX
       ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: 'Build daal4py/sklearnex'

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -76,6 +76,7 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      export DALROOT=$CONDA_PREFIX
       python setup_sklearnex.py install --single-version-externally-managed --record=record.txt
     displayName: 'Build slearnex'
   - script: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           command: |
             . ~/miniconda/etc/profile.d/conda.sh
             conda activate bld
+            export DALROOT=$CONDA_PREFIX
             python setup_sklearnex.py install --single-version-externally-managed --record=record1.txt
       - run:
           name: Testing sklearn patches with sklearnex


### PR DESCRIPTION
# Description
Set DALROOT before calls of setup_sklearnex.py in CI
 
