### PR TITLE
Force usage of daal4py assert_all_finite in sklearnex

### DIFF
--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -68,7 +68,8 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
     err = msg_err.format(
         input_name, type_err, msg_dtype if msg_dtype is not None else dt)
 
-    _patching_status = PatchingConditionsChain('sklearn.utils.validation._assert_all_finite')
+    _patching_status = PatchingConditionsChain(
+        'sklearn.utils.validation._assert_all_finite')
     _dal_ready = _patching_status.and_conditions([
         (X.ndim in [1, 2], "X has not 1 or 2 dimensions."),
         (not np.any(np.equal(X.shape, 0)), "X shape contains 0."),

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -104,7 +104,7 @@ def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
                  copy=False, force_all_finite=True,
                  ensure_2d=True, accept_large_sparse=True):
     if force_all_finite:
-        assert_all_finite(array)
+        assert_all_finite(array.data if sp.issparse(array) else array)
     array = check_array(
         array=array,
         dtype=dtype,

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -22,10 +22,7 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_array
 from collections.abc import Sequence
 from numbers import Integral
-try:
-    from daal4py.utils.validation import _daal_assert_all_finite as assert_all_finite
-except ImportError:
-    from sklearn.utils.validation import assert_all_finite
+from daal4py.sklearn.utils.validation import _daal_assert_all_finite as assert_all_finite
 
 
 class DataConversionWarning(UserWarning):

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -103,15 +103,13 @@ def _validate_targets(y, class_weight, dtype):
 def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
                  copy=False, force_all_finite=True,
                  ensure_2d=True, accept_large_sparse=True):
-    if force_all_finite:
-        assert_all_finite(array.data if sp.issparse(array) else array)
     array = check_array(
         array=array,
         dtype=dtype,
         accept_sparse=accept_sparse,
         order=order,
         copy=copy,
-        force_all_finite=False,
+        force_all_finite=force_all_finite,
         ensure_2d=ensure_2d,
         accept_large_sparse=accept_large_sparse)
 

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -103,6 +103,14 @@ def _validate_targets(y, class_weight, dtype):
 def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
                  copy=False, force_all_finite=True,
                  ensure_2d=True, accept_large_sparse=True):
+    if force_all_finite:
+        if sp.issparse(array):
+            if hasattr(array, 'data'):
+                assert_all_finite(array.data)
+                force_all_finite = False
+        else:
+            assert_all_finite(array)
+            force_all_finite = False
     array = check_array(
         array=array,
         dtype=dtype,


### PR DESCRIPTION
Changes proposed in this pull request:
- Force usage of daal4py `assert_all_finite` in onedal validation module
- Add verbose messages for daal4py `assert_all_finite` patch

 
