### PR TITLE
Update gcc version in CircleCI config; limit cmake jobs

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -24,6 +24,7 @@ trigger:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
+    - .circleci/config.yml
 
 pr:
   branches:
@@ -35,6 +36,7 @@ pr:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
+    - .circleci/config.yml
 
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET

--- a/.ci/scripts/describe_system.sh
+++ b/.ci/scripts/describe_system.sh
@@ -35,6 +35,10 @@ else
     echo "Unable to get operating system via uname or python/platform"
 fi
 echo
+# meminfo
+if [ -f /proc/meminfo ]; then
+    cat /proc/meminfo
+fi
 # Compilers
 echo "Compilers:"
 if [ -x "$(command -v gcc)" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             ls -la
             sudo apt-get update
-            sudo apt-get install -q -y gcc-10
+            sudo apt-get install -q -y gcc-10 gxx-10
             source ./.circleci/setup_env.sh
       - run:
           name: Building daal4py
@@ -73,7 +73,7 @@ jobs:
           command: |
             ls -la
             sudo apt-get update
-            sudo apt-get install -q -y gcc-10
+            sudo apt-get install -q -y gcc-10 gxx-10
             source ./.circleci/setup_env.sh 3.10
       - run:
           name: Building daal4py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -q -y gcc-10 g++-10
             source ./.circleci/setup_env.sh
+            bash .ci/scripts/describe_system.sh
       - run:
           name: Building daal4py
           command: |
@@ -75,6 +76,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install -q -y gcc-10 g++-10
             source ./.circleci/setup_env.sh 3.10
+            bash .ci/scripts/describe_system.sh
       - run:
           name: Building daal4py
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
           name: Setting up build environment
           command: |
             ls -la
+            sudo apt-get update
+            sudo apt-get install -q -y gcc-10
             source ./.circleci/setup_env.sh
       - run:
           name: Building daal4py
@@ -37,7 +39,7 @@ jobs:
             conda activate bld
             export DALROOT=$CONDA_PREFIX
             export NO_DIST=1
-            python setup.py install --single-version-externally-managed --record=record.txt
+            CC=gcc-10 CXX=g++-10 python setup.py install --single-version-externally-managed --record=record.txt
       - run:
           name: Building sklearnex
           command: |
@@ -70,6 +72,8 @@ jobs:
           name: Setting up build environment
           command: |
             ls -la
+            sudo apt-get update
+            sudo apt-get install -q -y gcc-10
             source ./.circleci/setup_env.sh 3.10
       - run:
           name: Building daal4py
@@ -78,7 +82,7 @@ jobs:
             conda activate bld
             export DALROOT=$CONDA_PREFIX
             export NO_DIST=1
-            python setup.py install --single-version-externally-managed --record=record.txt
+            CC=gcc-10 CXX=g++-10 python setup.py install --single-version-externally-managed --record=record.txt
       - run:
           name: Testing sklearn patches
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             ls -la
             sudo apt-get update
-            sudo apt-get install -q -y gcc-10 gxx-10
+            sudo apt-get install -q -y gcc-10 g++-10
             source ./.circleci/setup_env.sh
       - run:
           name: Building daal4py
@@ -73,7 +73,7 @@ jobs:
           command: |
             ls -la
             sudo apt-get update
-            sudo apt-get install -q -y gcc-10 gxx-10
+            sudo apt-get install -q -y gcc-10 g++-10
             source ./.circleci/setup_env.sh 3.10
       - run:
           name: Building daal4py

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -187,7 +187,7 @@ def custom_build_cmake_clib(iface, cxx=None, onedal_major_binary_version=1, no_d
             memtotal = meminfo_file_obj.read().split('\n')[0].split(' ')
             while '' in memtotal:
                 memtotal.remove('')
-            memtotal = int(memtotal[1]) # total memory in kB
+            memtotal = int(memtotal[1])  # total memory in kB
         cpu_count = min(cpu_count, floor(max(1, memtotal / 2 ** 20)))
 
     make_args = [

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -184,11 +184,11 @@ def custom_build_cmake_clib(iface, cxx=None, onedal_major_binary_version=1, no_d
     # TODO: add on all platforms
     if IS_LIN:
         with open('/proc/meminfo', 'r') as meminfo_file_obj:
-            memtotal = meminfo_file_obj.read().split('\n')[0].split(' ')
-            while '' in memtotal:
-                memtotal.remove('')
-            memtotal = int(memtotal[1])  # total memory in kB
-        cpu_count = min(cpu_count, floor(max(1, memtotal / 2 ** 20)))
+            memfree = meminfo_file_obj.read().split('\n')[1].split(' ')
+            while '' in memfree:
+                memfree.remove('')
+            memfree = int(memfree[1])  # total memory in kB
+        cpu_count = min(cpu_count, floor(max(1, memfree / 2 ** 20)))
 
     make_args = [
         "cmake",

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -22,6 +22,7 @@ import numpy as np
 import subprocess
 from distutils import log
 from distutils.sysconfig import get_python_inc, get_config_var
+import multiprocessing
 
 IS_WIN = False
 IS_MAC = False
@@ -177,8 +178,8 @@ def custom_build_cmake_clib(iface, cxx=None, onedal_major_binary_version=1, no_d
             "-DONEDAL_DIST_SPMD:BOOL=ON"
         ]
 
-    import multiprocessing
-    cpu_count = multiprocessing.cpu_count()
+    # cpu_count = multiprocessing.cpu_count()
+    cpu_count = 2
 
     make_args = [
         "cmake",


### PR DESCRIPTION
- Update GNU compiler version to 10 in CircleCI config
- Limit cmake jobs to minimum from number of logical cores and free memory size in GB
- Output `meminfo` in .ci/describe_system.sh script