### PR TITLE
Running of sklearn tests on device=cpu

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -100,7 +100,7 @@ jobs:
     displayName: 'System info'
   - script: |
       conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCTL_PACKAGE=; else export DPCTL_PACKAGE=; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCTL_PACKAGE=; else export DPCTL_PACKAGE="dpctl>=0.14"; fi
       conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCTL_PACKAGE
     displayName: 'Conda create'
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -146,6 +146,11 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      bash .ci/scripts/run_sklearn_tests.sh cpu
+    displayName: 'Sklearn testing [device=cpu]'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
       cd ..
       python s/.ci/scripts/test_global_patch.py
     displayName: global patching testing

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -100,8 +100,8 @@ jobs:
     displayName: 'System info'
   - script: |
       conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCTL_PACKAGE=; else export DPCTL_PACKAGE="dpctl>=0.14"; fi
-      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCTL_PACKAGE
+      if [ $(echo $(PYTHON_VERSION) | grep '3.7') ] || [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCPP_PACKAGE="dpcpp-cpp-rt>=2023.0.0"; else export DPCPP_PACKAGE="dpctl>=0.14"; fi
+      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE
     displayName: 'Conda create'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/scripts/run_sklearn_tests.py
+++ b/.ci/scripts/run_sklearn_tests.py
@@ -18,6 +18,7 @@ from sklearnex import patch_sklearn
 patch_sklearn()
 
 import os
+import sys
 import argparse
 import pytest
 import sklearn
@@ -41,6 +42,7 @@ if __name__ == '__main__':
 
     if args.device != 'none':
         with sklearn.config_context(target_offload=args.device):
-            pytest.main(pytest_args)
+            return_code = pytest.main(pytest_args)
     else:
-        pytest.main(pytest_args)
+        return_code = pytest.main(pytest_args)
+    sys.exit(int(return_code))

--- a/.ci/scripts/run_sklearn_tests.py
+++ b/.ci/scripts/run_sklearn_tests.py
@@ -1,0 +1,46 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+from sklearnex import patch_sklearn
+patch_sklearn()
+
+import os
+import argparse
+import pytest
+import sklearn
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--device',
+        type=str,
+        default='none',
+        help='device name',
+        choices=['none', 'cpu', 'gpu']
+    )
+    args = parser.parse_args()
+
+    os.chdir(os.path.dirname(sklearn.__file__))
+
+    pytest_args = '--verbose --pyargs --durations=100 --durations-min=0.01 ' \
+        f'{os.environ["DESELECTED_TESTS"]} {os.environ["SELECTED_TESTS"]}'.split(' ')
+
+    if args.device != 'none':
+        with sklearn.config_context(target_offload=args.device):
+            pytest.main(pytest_args)
+    else:
+        pytest.main(pytest_args)

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -15,11 +15,13 @@
 # limitations under the License.
 #===============================================================================
 
+# Args:
+# 1 - device name (optional)
+
 ci_dir=$( dirname $( dirname "${BASH_SOURCE[0]}" ) )
 cd $ci_dir
 
 export SELECTED_TESTS=$(python scripts/select_sklearn_tests.py)
 export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_tests.yaml)
-cd $(python -c "import sklearn, os; print(os.path.dirname(sklearn.__file__))")
-export SKLEARNEX_VERBOSE=DEBUG
-python -m sklearnex -m pytest --verbose --pyargs --durations=100 --durations-min=0.01 $DESELECTED_TESTS $SELECTED_TESTS
+
+python scripts/run_sklearn_tests.py -d ${1:-none}

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -25,3 +25,4 @@ export SELECTED_TESTS=$(python scripts/select_sklearn_tests.py)
 export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_tests.yaml)
 
 python scripts/run_sklearn_tests.py -d ${1:-none}
+exit $?

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -43,6 +43,8 @@ class DummySyclQueue:
             self._filter_string = filter_string
             self.is_cpu = 'cpu' in filter_string
             self.is_gpu = 'gpu' in filter_string
+            # TODO: check for possibility of fp64 support
+            # on other devices in this dummy class
             self.has_aspect_fp64 = self.is_cpu
 
             if not (self.is_cpu):

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -43,6 +43,7 @@ class DummySyclQueue:
             self._filter_string = filter_string
             self.is_cpu = 'cpu' in filter_string
             self.is_gpu = 'gpu' in filter_string
+            self.has_aspect_fp64 = self.is_cpu
 
             if not (self.is_cpu):
                 import logging


### PR DESCRIPTION
Changes:
- Update dpcpp packages installation in CI on Linux
- Add `'Sklearn testing [device=cpu]'` step in CI on Linux
- Update sklearn tests running scripts to run with context and output correct exit code
- Add `has_aspect_fp64` attribute in `DummySyclDevice` to avoid failure in `onedal.datatypes._convert_to_supported` function