### PR TITLE
Fix OOB scores in preview Random Forest; preview algorithms fixes

### DIFF
--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -18,6 +18,7 @@ import numpy as np
 import warnings
 from onedal import _backend
 from daal4py.sklearn._utils import make2d
+from onedal import _is_dpc_backend
 
 
 def _apply_and_pass(func, *args):
@@ -43,11 +44,7 @@ def to_table(*args):
     return _apply_and_pass(convert_one_to_table, *args)
 
 
-from onedal import _is_dpc_backend
-
 if _is_dpc_backend:
-    import numpy as np
-
     from ..common._policy import _HostInteropPolicy
 
     def _convert_to_supported(policy, *data):

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ===============================================================================
 
+import numpy as np
 import warnings
 from onedal import _backend
 from daal4py.sklearn._utils import make2d
@@ -31,6 +32,10 @@ def from_table(*args):
 
 def convert_one_to_table(arg):
     arg = make2d(arg)
+    # TODO: investigate why np.ndarray with OWNDATA=FALSE flag
+    # fails to be converted to oneDAL table
+    if isinstance(arg, np.ndarray) and not arg.flags['OWNDATA']:
+        arg = arg.copy()
     return _backend.to_table(arg)
 
 

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -33,10 +33,6 @@ def from_table(*args):
 
 def convert_one_to_table(arg):
     arg = make2d(arg)
-    # TODO: investigate why np.ndarray with OWNDATA=FALSE flag
-    # fails to be converted to oneDAL table
-    if isinstance(arg, np.ndarray) and not arg.flags['OWNDATA']:
-        arg = arg.copy()
     return _backend.to_table(arg)
 
 

--- a/onedal/decomposition/pca.py
+++ b/onedal/decomposition/pca.py
@@ -49,6 +49,10 @@ class PCA():
 
         policy = _get_policy(queue, X, y)
 
+        # TODO: investigate why np.ndarray with OWNDATA=FALSE flag
+        # fails to be converted to oneDAL table
+        if isinstance(X, np.ndarray) and not X.flags['OWNDATA']:
+            X = X.copy()
         X, y = _convert_to_supported(policy, X, y)
         params = self.get_onedal_params(X)
         cov_result = _backend.covariance.compute(

--- a/onedal/ensemble/forest.cpp
+++ b/onedal/ensemble/forest.cpp
@@ -73,6 +73,14 @@ auto get_error_metric_mode(const py::dict& params) {
             result_mode |= error_metric_mode::out_of_bag_error;
         else if (modes[i] == "out_of_bag_error_per_observation")
             result_mode |= error_metric_mode::out_of_bag_error_per_observation;
+        else if (modes[i] == "out_of_bag_error_accuracy")
+            result_mode |= error_metric_mode::out_of_bag_error_accuracy;
+        else if (modes[i] == "out_of_bag_error_r2")
+            result_mode |= error_metric_mode::out_of_bag_error_r2;
+        else if (modes[i] == "out_of_bag_error_decision_function")
+            result_mode |= error_metric_mode::out_of_bag_error_decision_function;
+        else if (modes[i] == "out_of_bag_error_prediction")
+            result_mode |= error_metric_mode::out_of_bag_error_prediction;
         else
             ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(mode);
     }
@@ -238,6 +246,10 @@ void init_train_result(py::module_& m) {
         .DEF_ONEDAL_PY_PROPERTY(model, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err_per_observation, result_t)
+        .DEF_ONEDAL_PY_PROPERTY(oob_err_accuracy, result_t)
+        .DEF_ONEDAL_PY_PROPERTY(oob_err_r2, result_t)
+        .DEF_ONEDAL_PY_PROPERTY(oob_err_decision_function, result_t)
+        .DEF_ONEDAL_PY_PROPERTY(oob_err_prediction, result_t)
         .DEF_ONEDAL_PY_PROPERTY(var_importance, result_t);
 }
 

--- a/onedal/ensemble/forest.cpp
+++ b/onedal/ensemble/forest.cpp
@@ -17,6 +17,7 @@
 #include "oneapi/dal/algo/decision_forest.hpp"
 
 #include "onedal/common.hpp"
+#include "onedal/version.hpp"
 
 namespace py = pybind11;
 
@@ -73,6 +74,7 @@ auto get_error_metric_mode(const py::dict& params) {
             result_mode |= error_metric_mode::out_of_bag_error;
         else if (modes[i] == "out_of_bag_error_per_observation")
             result_mode |= error_metric_mode::out_of_bag_error_per_observation;
+#if defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20230101
         else if (modes[i] == "out_of_bag_error_accuracy")
             result_mode |= error_metric_mode::out_of_bag_error_accuracy;
         else if (modes[i] == "out_of_bag_error_r2")
@@ -81,6 +83,7 @@ auto get_error_metric_mode(const py::dict& params) {
             result_mode |= error_metric_mode::out_of_bag_error_decision_function;
         else if (modes[i] == "out_of_bag_error_prediction")
             result_mode |= error_metric_mode::out_of_bag_error_prediction;
+#endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20230101
         else
             ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(mode);
     }
@@ -246,10 +249,12 @@ void init_train_result(py::module_& m) {
         .DEF_ONEDAL_PY_PROPERTY(model, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err_per_observation, result_t)
+#if defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20230101
         .DEF_ONEDAL_PY_PROPERTY(oob_err_accuracy, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err_r2, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err_decision_function, result_t)
         .DEF_ONEDAL_PY_PROPERTY(oob_err_prediction, result_t)
+#endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20230101
         .DEF_ONEDAL_PY_PROPERTY(var_importance, result_t);
 }
 

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -359,9 +359,14 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
         self._onedal_model = train_result.model
 
         if self.oob_score:
-            self.oob_score_ = from_table(train_result.oob_err)[0, 0]
-            self.oob_prediction_ = from_table(
-                train_result.oob_err_per_observation)
+            if self.is_classification:
+                self.oob_score_ = from_table(train_result.oob_err_accuracy)[0, 0]
+                self.oob_prediction_ = from_table(
+                    train_result.oob_err_decision_function)
+            else:
+                self.oob_score_ = from_table(train_result.oob_err_r2)[0, 0]
+                self.oob_prediction_ = from_table(
+                    train_result.oob_err_prediction)
             if np.any(self.oob_prediction_ == 0):
                 warnings.warn(
                     "Some inputs do not have OOB scores. This probably means "

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -302,7 +302,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
         return _column_or_1d(y, warn=True).astype(dtype, copy=False)
 
     def _get_sample_weight(self, X, y, sample_weight):
-        n_samples, _ = X.shape
+        n_samples = X.shape[0]
         dtype = X.dtype
         if n_samples == 1:
             raise ValueError("n_samples=1")

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -366,7 +366,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
             else:
                 self.oob_score_ = from_table(train_result.oob_err_r2)[0, 0]
                 self.oob_prediction_ = from_table(
-                    train_result.oob_err_prediction)
+                    train_result.oob_err_prediction).reshape(-1)
             if np.any(self.oob_prediction_ == 0):
                 warnings.warn(
                     "Some inputs do not have OOB scores. This probably means "

--- a/sklearnex/preview/decomposition/pca.py
+++ b/sklearnex/preview/decomposition/pca.py
@@ -107,13 +107,6 @@ class PCA(sklearn_PCA):
                 "TruncatedSVD for a possible alternative."
             )
 
-        if sklearn_check_version('0.23'):
-            X = self._validate_data(X, dtype=[np.float64, np.float32],
-                                    ensure_2d=True, copy=False)
-        else:
-            X = check_array(X, dtype=[np.float64, np.float32],
-                            ensure_2d=True, copy=False)
-
         n_samples, n_features = X.shape
         n_sf_min = min(n_samples, n_features)
 

--- a/sklearnex/preview/decomposition/pca.py
+++ b/sklearnex/preview/decomposition/pca.py
@@ -107,6 +107,13 @@ class PCA(sklearn_PCA):
                 "TruncatedSVD for a possible alternative."
             )
 
+        if sklearn_check_version('0.23'):
+            X = self._validate_data(X, dtype=[np.float64, np.float32],
+                                    ensure_2d=True, copy=False)
+        else:
+            X = _check_array(X, dtype=[np.float64, np.float32],
+                             ensure_2d=True, copy=False)
+
         n_samples, n_features = X.shape
         n_sf_min = min(n_samples, n_features)
 

--- a/sklearnex/preview/decomposition/pca.py
+++ b/sklearnex/preview/decomposition/pca.py
@@ -28,6 +28,8 @@ from onedal.datatypes import _check_array
 from sklearn.utils.validation import check_array
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
+if sklearn_check_version('1.1') and not sklearn_check_version('1.2'):
+    from sklearn.utils import check_scalar
 if sklearn_check_version('0.23'):
     from sklearn.decomposition._pca import _infer_dimension
 else:
@@ -38,6 +40,9 @@ from sklearn.decomposition import PCA as sklearn_PCA
 
 
 class PCA(sklearn_PCA):
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {**sklearn_PCA._parameter_constraints}
+
     def __init__(
         self,
         n_components=None,
@@ -83,6 +88,15 @@ class PCA(sklearn_PCA):
                                  % (n_components, type(n_components)))
 
     def fit(self, X, y=None):
+        if sklearn_check_version('1.2'):
+            self._validate_params()
+        elif sklearn_check_version('1.1'):
+            check_scalar(
+                self.n_oversamples,
+                "n_oversamples",
+                min_val=1,
+                target_type=numbers.Integral,
+            )
         self._fit(X)
         return self
 
@@ -93,12 +107,12 @@ class PCA(sklearn_PCA):
                 "TruncatedSVD for a possible alternative."
             )
 
-        X = _check_array(
-            X,
-            dtype=[np.float64, np.float32],
-            ensure_2d=True,
-            copy=False
-        )
+        if sklearn_check_version('0.23'):
+            X = self._validate_data(X, dtype=[np.float64, np.float32],
+                                    ensure_2d=True, copy=False)
+        else:
+            X = check_array(X, dtype=[np.float64, np.float32],
+                            ensure_2d=True, copy=False)
 
         n_samples, n_features = X.shape
         n_sf_min = min(n_samples, n_features)

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -539,6 +539,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                 return False
             elif self.warm_start:
                 return False
+            elif self.oob_score and not daal_check_version((2023, 'P', 101)):
+                return False
             elif not self.n_outputs_ == 1:
                 return False
             elif hasattr(self, 'estimators_'):
@@ -579,6 +581,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             elif not self.ccp_alpha == 0.0:
                 return False
             elif self.warm_start:
+                return False
+            elif self.oob_score:
                 return False
             elif not self.n_outputs_ == 1:
                 return False
@@ -881,6 +885,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
                 return False
             elif self.warm_start:
                 return False
+            elif self.oob_score and not daal_check_version((2023, 'P', 101)):
+                return False
             elif not self.n_outputs_ == 1:
                 return False
             elif hasattr(self, 'estimators_'):
@@ -921,6 +927,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
             elif not self.ccp_alpha == 0.0:
                 return False
             elif self.warm_start:
+                return False
+            elif self.oob_score:
                 return False
             elif not self.n_outputs_ == 1:
                 return False

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -340,8 +340,6 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             self._validate_params()
         else:
             self._check_parameters()
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
 
         correct_sparsity = not sp.issparse(X)
         correct_ccp_alpha = self.ccp_alpha == 0.0
@@ -605,6 +603,9 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
 
         y = check_array(y, ensure_2d=False)
 
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
+
         y, expanded_class_weight = self._validate_y_class_weight(y)
 
         n_classes_ = self.n_classes_[0]
@@ -859,8 +860,6 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     def _onedal_cpu_supported(self, method_name, *data):
         if method_name == 'ensemble.RandomForestRegressor.fit':
             X, y, sample_weight = data
-            if sample_weight is not None:
-                sample_weight = _check_sample_weight(sample_weight, X)
             if not (self.oob_score and daal_check_version(
                     (2021, 'P', 500)) or not self.oob_score):
                 return False
@@ -902,8 +901,6 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     def _onedal_gpu_supported(self, method_name, *data):
         X, y, sample_weight = data
         if method_name == 'ensemble.RandomForestRegressor.fit':
-            if sample_weight is not None:
-                sample_weight = _check_sample_weight(sample_weight, X)
             if not (self.oob_score and daal_check_version(
                     (2021, 'P', 500)) or not self.oob_score):
                 return False

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -859,6 +859,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     def _onedal_cpu_supported(self, method_name, *data):
         if method_name == 'ensemble.RandomForestRegressor.fit':
             X, y, sample_weight = data
+            if sample_weight is not None:
+                sample_weight = _check_sample_weight(sample_weight, X)
             if not (self.oob_score and daal_check_version(
                     (2021, 'P', 500)) or not self.oob_score):
                 return False
@@ -900,6 +902,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     def _onedal_gpu_supported(self, method_name, *data):
         X, y, sample_weight = data
         if method_name == 'ensemble.RandomForestRegressor.fit':
+            if sample_weight is not None:
+                sample_weight = _check_sample_weight(sample_weight, X)
             if not (self.oob_score and daal_check_version(
                     (2021, 'P', 500)) or not self.oob_score):
                 return False

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -39,7 +39,8 @@ from sklearn.ensemble import RandomForestRegressor as sklearn_RandomForestRegres
 from sklearn.utils.validation import (
     check_is_fitted,
     check_consistent_length,
-    check_array)
+    check_array,
+    _check_sample_weight)
 
 from onedal.datatypes import _check_array, _num_features, _num_samples
 
@@ -340,7 +341,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
         else:
             self._check_parameters()
         if sample_weight is not None:
-            sample_weight = self.check_sample_weight(sample_weight, X)
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         correct_sparsity = not sp.issparse(X)
         correct_ccp_alpha = self.ccp_alpha == 0.0
@@ -947,7 +948,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
         else:
             self._check_parameters()
         if sample_weight is not None:
-            sample_weight = self.check_sample_weight(sample_weight, X)
+            sample_weight = _check_sample_weight(sample_weight, X)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         X = check_array(X, dtype=[np.float64, np.float32])

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -701,11 +701,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
     def _onedal_predict(self, X, queue=None):
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
-        X = check_array(
-            X,
-            accept_sparse=False,  # is not supported
-            dtype=[np.float64, np.float32]
-        )
+        X = self._validate_X_predict(X)
 
         res = self._onedal_estimator.predict(X, queue=queue)
         return np.take(self.classes_,
@@ -717,11 +713,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             self._check_n_features(X, reset=False)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
-        X = check_array(
-            X,
-            accept_sparse=False,  # is not supported
-            dtype=[np.float64, np.float32]
-        )
+        X = self._validate_X_predict(X)
         return self._onedal_estimator.predict_proba(X, queue=queue)
 
 
@@ -1032,11 +1024,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     def _onedal_predict(self, X, queue=None):
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
-        X = check_array(
-            X,
-            accept_sparse=False,
-            dtype=[np.float64, np.float32]
-        )
+        X = self._validate_X_predict(X)
         return self._onedal_estimator.predict(X, queue=queue)
 
     @wrap_output_data

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -621,7 +621,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
 
         y = np.atleast_1d(y)
         if y.ndim == 2 and y.shape[1] == 1:
-            warn(
+            warnings.warn(
                 "A column-vector y was passed when a 1d array was"
                 " expected. Please change the shape of y to "
                 "(n_samples,), for example using ravel().",

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -39,8 +39,7 @@ from sklearn.ensemble import RandomForestRegressor as sklearn_RandomForestRegres
 from sklearn.utils.validation import (
     check_is_fitted,
     check_consistent_length,
-    check_array,
-    _check_sample_weight)
+    check_array)
 
 from onedal.datatypes import _check_array, _num_features, _num_samples
 
@@ -445,8 +444,6 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                     (f'X has {num_features} features, '
                      f'but RandomForestClassifier is expecting '
                      f'{self.n_features_in_} features as input'))
-        X = check_array(X, dtype=[np.float64, np.float32])
-        check_is_fitted(self)
         if sklearn_check_version('0.23'):
             self._check_n_features(X, reset=False)
         return dispatch(self, 'ensemble.RandomForestClassifier.predict_proba', {
@@ -614,7 +611,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
         y = check_array(y, ensure_2d=False)
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
+            sample_weight = self.check_sample_weight(sample_weight, X)
 
         y, expanded_class_weight = self._validate_y_class_weight(y)
 
@@ -963,7 +960,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
         else:
             self._check_parameters()
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
+            sample_weight = self.check_sample_weight(sample_weight, X)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         X = check_array(X, dtype=[np.float64, np.float32])

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -529,6 +529,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             ready, X, y, sample_weight = self._onedal_ready(*data)
             if not ready:
                 return False
+            elif sp.issparse(X):
+                return False
             elif sp.issparse(y):
                 return False
             elif sp.issparse(sample_weight):
@@ -566,7 +568,11 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             ready, X, y, sample_weight = self._onedal_ready(*data)
             if not ready:
                 return False
+            elif sp.issparse(X):
+                return False
             elif sp.issparse(y):
+                return False
+            elif sp.issparse(sample_weight):
                 return False
             elif not sample_weight:  # `sample_weight` is not supported.
                 return False

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -621,6 +621,20 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
         if sample_weight is not None:
             sample_weight = self.check_sample_weight(sample_weight, X)
 
+        y = np.atleast_1d(y)
+        if y.ndim == 2 and y.shape[1] == 1:
+            warn(
+                "A column-vector y was passed when a 1d array was"
+                " expected. Please change the shape of y to "
+                "(n_samples,), for example using ravel().",
+                DataConversionWarning,
+                stacklevel=2,
+            )
+        if y.ndim == 1:
+            # reshape is necessary to preserve the data contiguity against vs
+            # [:, np.newaxis] that does not.
+            y = np.reshape(y, (-1, 1))
+
         y, expanded_class_weight = self._validate_y_class_weight(y)
 
         n_classes_ = self.n_classes_[0]

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -445,8 +445,6 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                     (f'X has {num_features} features, '
                      f'but RandomForestClassifier is expecting '
                      f'{self.n_features_in_} features as input'))
-        if sklearn_check_version('0.23'):
-            self._check_n_features(X, reset=False)
         return dispatch(self, 'ensemble.RandomForestClassifier.predict_proba', {
             'onedal': self.__class__._onedal_predict_proba,
             'sklearn': sklearn_RandomForestClassifier.predict_proba,
@@ -699,21 +697,22 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
         return self
 
     def _onedal_predict(self, X, queue=None):
+        X = check_array(X, dtype=[np.float32, np.float64])
+        check_is_fitted(self)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
-        X = self._validate_X_predict(X)
 
         res = self._onedal_estimator.predict(X, queue=queue)
         return np.take(self.classes_,
                        res.ravel().astype(np.int64, casting='unsafe'))
 
     def _onedal_predict_proba(self, X, queue=None):
+        X = check_array(X, dtype=[np.float64, np.float32])
         check_is_fitted(self)
         if sklearn_check_version('0.23'):
             self._check_n_features(X, reset=False)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=False)
-        X = self._validate_X_predict(X)
         return self._onedal_estimator.predict_proba(X, queue=queue)
 
 

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -697,6 +697,13 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
 class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
     __doc__ = sklearn_RandomForestRegressor.__doc__
 
+    if sklearn_check_version('1.2'):
+        _parameter_constraints: dict = {
+            **sklearn_RandomForestRegressor._parameter_constraints,
+            "max_bins": [Interval(numbers.Integral, 2, None, closed="left")],
+            "min_bin_size": [Interval(numbers.Integral, 1, None, closed="left")]
+        }
+
     if sklearn_check_version('1.0'):
         def __init__(
                 self,

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -446,6 +446,10 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                     (f'X has {num_features} features, '
                      f'but RandomForestClassifier is expecting '
                      f'{self.n_features_in_} features as input'))
+        X = check_array(X, dtype=[np.float64, np.float32])
+        check_is_fitted(self)
+        if sklearn_check_version('0.23'):
+            self._check_n_features(X, reset=False)
         return dispatch(self, 'ensemble.RandomForestClassifier.predict_proba', {
             'onedal': self.__class__._onedal_predict_proba,
             'sklearn': sklearn_RandomForestClassifier.predict_proba,

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -620,7 +620,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                 "Training data only contain information about one class.")
 
         if self.oob_score:
-            err = 'out_of_bag_error|out_of_bag_error_per_observation'
+            err = 'out_of_bag_error_accuracy|out_of_bag_error_decision_function'
         else:
             err = 'none'
 
@@ -949,7 +949,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
         rs_ = check_random_state(self.random_state)
 
         if self.oob_score:
-            err = 'out_of_bag_error|out_of_bag_error_per_observation'
+            err = 'out_of_bag_error_r2|out_of_bag_error_prediction'
         else:
             err = 'none'
 

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -39,7 +39,8 @@ from sklearn.ensemble import RandomForestRegressor as sklearn_RandomForestRegres
 from sklearn.utils.validation import (
     check_is_fitted,
     check_consistent_length,
-    check_array)
+    check_array,
+    check_X_y)
 
 from onedal.datatypes import _check_array, _num_features, _num_samples
 
@@ -606,9 +607,16 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             f'Unknown method {method_name} in {self.__class__.__name__}')
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        X, y = make2d(np.asarray(X)), make2d(np.asarray(y))
-
-        y = check_array(y, ensure_2d=False)
+        if sklearn_check_version('1.2'):
+            X, y = self._validate_data(
+                X, y, multi_output=False, accept_sparse=False,
+                dtype=[np.float64, np.float32]
+            )
+        else:
+            X, y = check_X_y(
+                X, y, accept_sparse=False, dtype=[np.float64, np.float32],
+                multi_output=False
+            )
 
         if sample_weight is not None:
             sample_weight = self.check_sample_weight(sample_weight, X)

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -30,7 +30,7 @@ if daal_check_version((2023, 'P', 100)):
     if sklearn_check_version('1.0') and not sklearn_check_version('1.2'):
         from sklearn.linear_model._base import _deprecate_normalize
 
-    from sklearn.utils.validation import _deprecate_positional_args
+    from sklearn.utils.validation import _deprecate_positional_args, check_X_y
     from sklearn.exceptions import NotFittedError
     from scipy.sparse import issparse
 
@@ -232,6 +232,17 @@ if daal_check_version((2023, 'P', 100)):
 
         def _onedal_fit(self, X, y, sample_weight, queue=None):
             assert sample_weight is None
+
+            if sklearn_check_version('1.2'):
+                X, y = self._validate_data(
+                    X, y, accept_sparse=False, y_numeric=True,
+                    multi_output=False, force_all_finite=False
+                )
+            else:
+                X, y = check_X_y(
+                    X, y, accept_sparse=False, dtype=[np.float64, np.float32],
+                    multi_output=False, y_numeric=True
+                )
 
             if sklearn_check_version(
                     '1.0') and not sklearn_check_version('1.2'):

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -258,6 +258,7 @@ if daal_check_version((2023, 'P', 100)):
             self._save_attributes()
 
         def _onedal_predict(self, X, queue=None):
+            X = self._validate_data(X, accept_sparse=False, reset=False)
             if not hasattr(self, '_onedal_estimator'):
                 self._initialize_onedal_estimator()
                 self._onedal_estimator.coef_ = self.coef_

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -244,11 +244,10 @@ if daal_check_version((2023, 'P', 100)):
 
             if sklearn_check_version('0.23'):
                 X, y = self._validate_data(
-                    X, y, accept_sparse=accept_sparse, y_numeric=True, multi_output=True
+                    X, y, accept_sparse=False, y_numeric=True, multi_output=True
                 )
             else:
-                X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
-                         y_numeric=True, multi_output=True)
+                X, y = check_X_y(X, y, accept_sparse=False, y_numeric=True, multi_output=True)
 
             self._initialize_onedal_estimator()
             self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -30,6 +30,7 @@ if daal_check_version((2023, 'P', 100)):
     if sklearn_check_version('1.0') and not sklearn_check_version('1.2'):
         from sklearn.linear_model._base import _deprecate_normalize
 
+    from sklearn.utils import check_X_y
     from sklearn.utils.validation import _deprecate_positional_args
     from sklearn.exceptions import NotFittedError
     from scipy.sparse import issparse
@@ -240,6 +241,14 @@ if daal_check_version((2023, 'P', 100)):
                     default=False,
                     estimator_name=self.__class__.__name__,
                 )
+
+            if sklearn_check_version('0.23'):
+                X, y = self._validate_data(
+                    X, y, accept_sparse=accept_sparse, y_numeric=True, multi_output=True
+                )
+            else:
+                X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                         y_numeric=True, multi_output=True)
 
             self._initialize_onedal_estimator()
             self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -233,16 +233,19 @@ if daal_check_version((2023, 'P', 100)):
         def _onedal_fit(self, X, y, sample_weight, queue=None):
             assert sample_weight is None
 
+            check_params = {
+                'X': X,
+                'y': y,
+                'dtype': [np.float64, np.float32],
+                'accept_sparse': ['csr', 'csc', 'coo'],
+                'y_numeric': True,
+                'multi_output': True,
+                'force_all_finite': False
+            }
             if sklearn_check_version('1.2'):
-                X, y = self._validate_data(
-                    X, y, accept_sparse=False, y_numeric=True,
-                    multi_output=False, force_all_finite=False
-                )
+                X, y = self._validate_data(**check_params)
             else:
-                X, y = check_X_y(
-                    X, y, accept_sparse=False, dtype=[np.float64, np.float32],
-                    multi_output=False, y_numeric=True
-                )
+                X, y = check_X_y(**check_params)
 
             if sklearn_check_version(
                     '1.0') and not sklearn_check_version('1.2'):

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -30,7 +30,6 @@ if daal_check_version((2023, 'P', 100)):
     if sklearn_check_version('1.0') and not sklearn_check_version('1.2'):
         from sklearn.linear_model._base import _deprecate_normalize
 
-    from sklearn.utils import check_X_y
     from sklearn.utils.validation import _deprecate_positional_args
     from sklearn.exceptions import NotFittedError
     from scipy.sparse import issparse
@@ -241,13 +240,6 @@ if daal_check_version((2023, 'P', 100)):
                     default=False,
                     estimator_name=self.__class__.__name__,
                 )
-
-            if sklearn_check_version('0.23'):
-                X, y = self._validate_data(
-                    X, y, accept_sparse=False, y_numeric=True, multi_output=True
-                )
-            else:
-                X, y = check_X_y(X, y, accept_sparse=False, y_numeric=True, multi_output=True)
 
             self._initialize_onedal_estimator()
             self._onedal_estimator.fit(X, y, queue=queue)


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix OOB scores in preview Random Forest: assign correct oob_error flags for oneDAL call
- Fix input data checks in preview algorithms
- Temporary fix for conversion of specific np.ndarray with OWNDATA=False flag to oneDAL table

 
