### PR TITLE
PEP8: Remove duplicate imports

### DIFF
--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -16,12 +16,10 @@
 
 import numpy as np
 import warnings
-import numpy as np
 
 from onedal import _is_dpc_backend
 from onedal import _backend
 from daal4py.sklearn._utils import make2d
-from onedal import _is_dpc_backend
 
 try:
     import dpctl


### PR DESCRIPTION
# Description
Duplicate imports from two PRs caused PEP8 failures
 
