### PR TITLE
ENH: added splitter_mode for Random Forest

### DIFF
--- a/onedal/ensemble/forest.cpp
+++ b/onedal/ensemble/forest.cpp
@@ -109,6 +109,21 @@ auto get_infer_mode(const py::dict& params) {
     return result_mode;
 }
 
+#if defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20230101
+auto get_splitter_mode(const py::dict& params) {
+    using namespace decision_forest;
+    auto mode = params["splitter_mode"].cast<std::string>();
+    if (mode == "best") {
+        return splitter_mode::best;
+    }
+    else if (mode == "random") {
+        return splitter_mode::random;
+    }
+    else
+        ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(mode);
+}
+#endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20230101
+
 auto get_variable_importance_mode(const py::dict& params) {
     using namespace decision_forest;
 
@@ -171,6 +186,9 @@ struct params2desc {
                         .set_min_bin_size(params["min_bin_size"].cast<std::int64_t>())
                         .set_memory_saving_mode(params["memory_saving_mode"].cast<bool>())
                         .set_bootstrap(params["bootstrap"].cast<bool>())
+#if defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20230101
+                        .set_splitter_mode(get_splitter_mode(params));
+#endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20230101
                         .set_error_metric_mode(get_error_metric_mode(params))
                         .set_variable_importance_mode(get_variable_importance_mode(params));
 

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -77,6 +77,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
             max_bins,
             min_bin_size,
             infer_mode,
+            splitter_mode,
             voting_mode,
             error_metric_mode,
             variable_importance_mode,
@@ -102,6 +103,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
         self.max_bins = max_bins
         self.min_bin_size = min_bin_size
         self.infer_mode = infer_mode
+        self.splitter_mode = splitter_mode,
         self.voting_mode = voting_mode
         self.error_metric_mode = error_metric_mode
         self.variable_importance_mode = variable_importance_mode
@@ -208,6 +210,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
             'fptype': 'float' if data.dtype == np.float32 else 'double',
             'method': self.algorithm,
             'infer_mode': self.infer_mode,
+            'splitter_mode': self.splitter_mode,
             'voting_mode': self.voting_mode,
             'observations_per_tree_fraction': observations_per_tree_fraction,
             'impurity_threshold': float(
@@ -434,6 +437,7 @@ class RandomForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
                  max_bins=256,
                  min_bin_size=1,
                  infer_mode='class_responses',
+                 splitter_mode='best',
                  voting_mode='weighted',
                  error_metric_mode='none',
                  variable_importance_mode='none',
@@ -460,6 +464,7 @@ class RandomForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             max_bins=max_bins,
             min_bin_size=min_bin_size,
             infer_mode=infer_mode,
+            splitter_mode=splitter_mode,
             voting_mode=voting_mode,
             error_metric_mode=error_metric_mode,
             variable_importance_mode=variable_importance_mode,
@@ -516,6 +521,7 @@ class RandomForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
                  max_bins=256,
                  min_bin_size=1,
                  infer_mode='class_responses',
+                 splitter_mode='best',
                  voting_mode='weighted',
                  error_metric_mode='none',
                  variable_importance_mode='none',
@@ -542,6 +548,7 @@ class RandomForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
             max_bins=max_bins,
             min_bin_size=min_bin_size,
             infer_mode=infer_mode,
+            splitter_mode=splitter_mode,
             voting_mode=voting_mode,
             error_metric_mode=error_metric_mode,
             variable_importance_mode=variable_importance_mode,

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -212,7 +212,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                 ccp_alpha=0.0,
                 max_samples=None,
                 max_bins=256,
-                min_bin_size=1):
+                min_bin_size=1,
+                splitter_mode='best'):
             super(RandomForestClassifier, self).__init__(
                 n_estimators=n_estimators,
                 criterion=criterion,
@@ -237,6 +238,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
             self.min_impurity_split = None
+            self.splitter_mode = splitter_mode
             # self._estimator = DecisionTreeClassifier()
     else:
         def __init__(self,
@@ -260,7 +262,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                      ccp_alpha=0.0,
                      max_samples=None,
                      max_bins=256,
-                     min_bin_size=1):
+                     min_bin_size=1,
+                     splitter_mode='best'):
             super(RandomForestClassifier, self).__init__(
                 n_estimators=n_estimators,
                 criterion=criterion,
@@ -288,6 +291,7 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
             self.min_impurity_split = None
+            self.splitter_mode = splitter_mode
             # self._estimator = DecisionTreeClassifier()
 
     def fit(self, X, y, sample_weight=None):
@@ -681,6 +685,8 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             'min_bin_size': self.min_bin_size,
             'max_samples': self.max_samples
         }
+        if daal_check_version((2023, 'P', 101)):
+            onedal_params['splitter_mode'] = self.splitter_mode
         self._cached_estimators_ = None
 
         # Compute
@@ -748,7 +754,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
                 ccp_alpha=0.0,
                 max_samples=None,
                 max_bins=256,
-                min_bin_size=1):
+                min_bin_size=1,
+                splitter_mode='best'):
             super(RandomForestRegressor, self).__init__(
                 n_estimators=n_estimators,
                 criterion=criterion,
@@ -772,6 +779,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
             self.min_impurity_split = None
+            self.splitter_mode = splitter_mode
     else:
         def __init__(self,
                      n_estimators=100, *,
@@ -793,7 +801,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
                      ccp_alpha=0.0,
                      max_samples=None,
                      max_bins=256,
-                     min_bin_size=1):
+                     min_bin_size=1,
+                     splitter_mode='best'):
             super(RandomForestRegressor, self).__init__(
                 n_estimators=n_estimators,
                 criterion=criterion,
@@ -820,6 +829,7 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
             self.min_impurity_split = None
+            self.splitter_mode = splitter_mode
 
     @property
     def _estimators_(self):
@@ -1010,6 +1020,8 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
             'variable_importance_mode': 'mdi',
             'max_samples': self.max_samples
         }
+        if daal_check_version((2023, 'P', 101)):
+            onedal_params['splitter_mode'] = self.splitter_mode
         self._cached_estimators_ = None
         self._onedal_estimator = onedal_RandomForestRegressor(**onedal_params)
         self._onedal_estimator.fit(X, y, sample_weight, queue=queue)

--- a/sklearnex/preview/ensemble/tests/test_random_preview_forest.py
+++ b/sklearnex/preview/ensemble/tests/test_random_preview_forest.py
@@ -15,9 +15,13 @@
 # limitations under the License.
 #===============================================================================
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_allclose
+from daal4py.sklearn._utils import daal_check_version
 from sklearn.datasets import make_classification, make_regression
+from sklearn.model_selection import train_test_split
 
 
 def test_sklearnex_import_rf_classifier():
@@ -38,3 +42,44 @@ def test_sklearnex_import_rf_regression():
     assert 'sklearnex.preview' in rf.__module__
     pred = rf.predict([[0, 0, 0, 0]])
     assert_allclose([-6.839], pred, atol=1e-2)
+
+
+@pytest.mark.skipif(not daal_check_version((2023, 'P', 101)),
+                    reason='requires OneDAL 2023.1.1')
+def test_sklearnex_rf_classifier_splitter_mode():
+    from sklearnex.preview.ensemble import RandomForestClassifier
+    X, y = make_classification(n_samples=100, n_features=4,
+                               n_informative=2, n_redundant=0,
+                               random_state=0, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                        test_size=0.33,
+                                                        random_state=0)
+    rf_b = RandomForestClassifier(max_depth=2,
+                                  random_state=0,
+                                  splitter_mode='best').fit(X_train, y_train)
+    rf_r = RandomForestClassifier(max_depth=2,
+                                  random_state=0,
+                                  splitter_mode='random').fit(X_train, y_train)
+    pred_b = rf_b.predict(X_test)
+    pred_r = rf_r.predict(X_test)
+    assert_allclose(pred_b, pred_r)
+
+
+@pytest.mark.skipif(not daal_check_version((2023, 'P', 101)),
+                    reason='requires OneDAL 2023.1.1')
+def test_sklearnex_rf_regressor_splitter_mode():
+    from sklearnex.preview.ensemble import RandomForestRegressor
+    X, y = make_regression(n_samples=1000, n_features=4, n_informative=2,
+                           random_state=0, shuffle=False)
+    X_train, X_test, y_train, y_test = train_test_split(X, y,
+                                                        test_size=0.33,
+                                                        random_state=0)
+    rf_b = RandomForestRegressor(max_depth=2,
+                                 random_state=0,
+                                 splitter_mode='best').fit(X_train, y_train)
+    rf_r = RandomForestRegressor(max_depth=2,
+                                 random_state=0,
+                                 splitter_mode='random').fit(X_train, y_train)
+    pred_b = rf_b.predict(X_test)
+    pred_r = rf_r.predict(X_test)
+    assert_allclose(pred_b, pred_r)


### PR DESCRIPTION
# Description
added `splitter_mode` for preview `RandomForestClassifier` and `RandomForestRegressor`. Following changes on https://github.com/oneapi-src/oneDAL/pull/2270

 
