### PR TITLE
Update Azure pipelines scope

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -1,0 +1,69 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+steps:
+  - script: sudo apt-get update && sudo apt-get install -y clang-format
+    displayName: 'apt-get'
+  - script: |
+      bash .ci/scripts/install_dpcpp.sh
+    displayName: 'dpcpp installation'
+  - script: |
+      bash .ci/scripts/describe_system.sh
+    displayName: 'System info'
+  - script: |
+      conda update -y -q conda
+      if [ $(echo $(PYTHON_VERSION) | grep '3.7') ] || [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCPP_PACKAGE="dpcpp-cpp-rt>=2023.0.0"; else export DPCPP_PACKAGE="dpctl>=0.14"; fi
+      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE
+    displayName: 'Conda create'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      pip install -r requirements-dev.txt
+      pip list
+    displayName: 'Install develop requirements'
+  - script: |
+      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      export DALROOT=$CONDA_PREFIX
+      ./conda-recipe/build.sh
+      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
+    displayName: 'Build daal4py/sklearnex'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
+      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
+      pip list
+    displayName: 'Install testing requirements'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      cd ..
+      ./s/conda-recipe/run_test.sh
+    displayName: 'Sklearnex testing'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      export SELECTED_TESTS=all
+      bash .ci/scripts/run_sklearn_tests.sh
+    displayName: 'Sklearn testing'
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      export SELECTED_TESTS=all
+      bash .ci/scripts/run_sklearn_tests.sh cpu
+    displayName: 'Sklearn testing [device=cpu]'

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -14,54 +14,42 @@
 # limitations under the License.
 #===============================================================================
 steps:
-  - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: 'apt-get'
   - script: |
-      bash .ci/scripts/install_dpcpp.sh
-    displayName: 'dpcpp installation'
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal dal-include mpich clang-format pyyaml
+    displayName: Create Anaconda environment
   - script: |
+      source activate CB
+      pip install -q cpufeature
       bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
+    displayName: "System info"
   - script: |
-      conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.7') ] || [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCPP_PACKAGE="dpcpp-cpp-rt>=2023.0.0"; else export DPCPP_PACKAGE="dpctl>=0.14"; fi
-      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE
-    displayName: 'Conda create'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      source activate CB
       pip install -r requirements-dev.txt
       pip list
     displayName: 'Install develop requirements'
   - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      source activate CB
       export DALROOT=$CONDA_PREFIX
       ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
+    displayName: Conda build
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      source activate CB
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
     displayName: 'Install testing requirements'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      source activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
     displayName: 'Sklearnex testing'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      bash .ci/scripts/run_sklearn_tests.sh cpu
-    displayName: 'Sklearn testing [device=cpu]'

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -1,0 +1,60 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+steps:
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+  - script: conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel impi-devel clang-format pyyaml
+    displayName: 'Create Anaconda environment'
+  - script: |
+      call activate CB
+      pip install --upgrade setuptools
+      pip install cpufeature
+      pip install -r requirements-dev.txt
+      pip list
+    displayName: 'Install develop requirements'
+  - script: |
+      set PATH=C:\msys64\usr\bin;%PATH%
+      call activate CB
+      bash .ci/scripts/describe_system.sh
+    displayName: 'System info'
+  - script: |
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
+      call activate CB
+      set PREFIX=%CONDA_PREFIX%
+      set PYTHON=python
+      call conda-recipe\bld.bat
+      set DALROOT=%CONDA_PREFIX%
+      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
+    displayName: 'Build daal4py/sklearnex'
+  - script: |
+      set PATH=C:\msys64\usr\bin;%PATH%
+      call activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
+      cd ..
+      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
+      pip install %SCIPY_VERSION%
+      pip list
+    displayName: 'Install testing requirements'
+  - script: |
+      call activate CB
+      cd ..
+      call s\conda-recipe\run_test.bat s
+    displayName: 'Sklearnex testing'
+  - script: |
+      call activate CB
+      bash .ci/scripts/run_sklearn_tests.sh
+    displayName: 'Sklearn testing'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -127,12 +127,14 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      export SELECTED_TESTS=all
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     continueOnError: true
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      export SELECTED_TESTS=all
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
     continueOnError: true
@@ -197,6 +199,7 @@ jobs:
     displayName: 'Sklearnex testing'
   - script: |
       source activate CB
+      export SELECTED_TESTS=all
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     continueOnError: true
@@ -266,6 +269,7 @@ jobs:
     displayName: 'Sklearnex testing'
   - script: |
       call activate CB
+      set SELECTED_TESTS=all
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     continueOnError: true

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -139,13 +139,13 @@ jobs:
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq($(SKLEARN_VERSION), 'main')
+    continueOnError: true
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
-    continueOnError: eq($(SKLEARN_VERSION), 'main')
+    continueOnError: true
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -218,7 +218,7 @@ jobs:
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq($(SKLEARN_VERSION), 'main')
+    continueOnError: true
   - script: |
       source activate CB
       cd ..
@@ -295,7 +295,7 @@ jobs:
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq($(SKLEARN_VERSION), 'main')
+    continueOnError: true
   - script: |
       call activate CB
       cd ..

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -85,15 +85,7 @@ jobs:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
     displayName: 'apt-get'
   - script: |
-      wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-      sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-      rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-      echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-      sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
-      sudo apt-get update
-      sudo apt-get install -y intel-dpcpp-cpp-compiler-2023.0.0
-      sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
-      sudo mv -f /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga_
+      bash .ci/scripts/install_dpcpp.sh
     displayName: 'dpcpp installation'
   - script: |
       bash .ci/scripts/describe_system.sh

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -103,11 +103,6 @@ jobs:
       pip list
     displayName: 'Install develop requirements'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-    displayName: 'Setup sklearn version'
-  - script: |
       export DPCPPROOT=/opt/intel/oneapi/compiler/latest
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -118,6 +113,7 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
@@ -183,16 +179,13 @@ jobs:
     displayName: 'Install develop requirements'
   - script: |
       source activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-    displayName: 'Setup sklearn version'
-  - script: |
-      source activate CB
       export DALROOT=$CONDA_PREFIX
       ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: Conda build
   - script: |
       source activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
@@ -243,10 +236,6 @@ jobs:
       pip list
     displayName: 'Install develop requirements'
   - script: |
-      call activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-    displayName: 'Setup sklearn version'
-  - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
       bash .ci/scripts/describe_system.sh
@@ -263,6 +252,7 @@ jobs:
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       cd ..
       for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -139,13 +139,13 @@ jobs:
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
+    continueOnError: eq($(SKLEARN_VERSION), 'main')
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
-    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
+    continueOnError: eq($(SKLEARN_VERSION), 'main')
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -218,7 +218,7 @@ jobs:
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
+    continueOnError: eq($(SKLEARN_VERSION), 'main')
   - script: |
       source activate CB
       cd ..
@@ -295,7 +295,7 @@ jobs:
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
+    continueOnError: eq($(SKLEARN_VERSION), 'main')
   - script: |
       call activate CB
       cd ..

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -68,61 +68,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
-  - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: 'apt-get'
-  - script: |
-      bash .ci/scripts/install_dpcpp.sh
-    displayName: 'dpcpp installation'
-  - script: |
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.7') ] || [ $(echo $(PYTHON_VERSION) | grep '3.11') ]; then export DPCPP_PACKAGE="dpcpp-cpp-rt>=2023.0.0"; else export DPCPP_PACKAGE="dpctl>=0.14"; fi
-      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE
-    displayName: 'Conda create'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      pip install -r requirements-dev.txt
-      pip list
-    displayName: 'Install develop requirements'
-  - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      export DALROOT=$CONDA_PREFIX
-      ./conda-recipe/build.sh
-      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      pip list
-    displayName: 'Install testing requirements'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      cd ..
-      ./s/conda-recipe/run_test.sh
-    displayName: 'Sklearnex testing'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      export SELECTED_TESTS=all
-      bash .ci/scripts/run_sklearn_tests.sh
-    displayName: 'Sklearn testing'
-    continueOnError: true
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      export SELECTED_TESTS=all
-      bash .ci/scripts/run_sklearn_tests.sh cpu
-    displayName: 'Sklearn testing [device=cpu]'
-    continueOnError: true
+  - template: build-and-test-lnx.yml
 - job: MacOS
   strategy:
     matrix:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -62,24 +62,9 @@ jobs:
 - job: Linux
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
-        PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
-        SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
-        SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: '1.2'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -141,24 +126,9 @@ jobs:
 - job: MacOS
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
-        PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
-        SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
-        SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: '1.2'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'macos-12'
   steps:
@@ -206,24 +176,9 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
-        PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
-        SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
-        SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: '1.2'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'windows-latest'
   steps:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -118,12 +118,6 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
-      export DALROOT=$CONDA_PREFIX
-      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build sklearnex'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -127,6 +127,7 @@ jobs:
       conda activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
+      python s/.ci/scripts/test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -140,12 +141,6 @@ jobs:
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
     continueOnError: true
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      cd ..
-      python s/.ci/scripts/test_global_patch.py
-    displayName: global patching testing
 - job: MacOS
   strategy:
     matrix:
@@ -207,17 +202,13 @@ jobs:
       source activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
+      s/.ci/scripts/test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     continueOnError: true
-  - script: |
-      source activate CB
-      cd ..
-      python s/.ci/scripts/test_global_patch.py
-    displayName: global patching testing
 - job: Windows
   strategy:
     matrix:
@@ -284,14 +275,10 @@ jobs:
       call activate CB
       cd ..
       call s\conda-recipe\run_test.bat s
+      python s\.ci\scripts\test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     continueOnError: true
-  - script: |
-      call activate CB
-      cd ..
-      python s\.ci\scripts\test_global_patch.py
-    displayName: global patching testing

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -139,13 +139,13 @@ jobs:
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
+    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
-    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
+    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -218,7 +218,7 @@ jobs:
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
+    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
   - script: |
       source activate CB
       cd ..
@@ -295,7 +295,7 @@ jobs:
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
-    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
+    continueOnError: ${{ if eq($(SKLEARN_VERSION), 'main') }}
   - script: |
       call activate CB
       cd ..

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -127,7 +127,6 @@ jobs:
       conda activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
-      python s/.ci/scripts/test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -202,7 +201,6 @@ jobs:
       source activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
-      s/.ci/scripts/test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       source activate CB
@@ -275,7 +273,6 @@ jobs:
       call activate CB
       cd ..
       call s\conda-recipe\run_test.bat s
-      python s\.ci\scripts\test_global_patch.py
     displayName: 'Sklearnex testing'
   - script: |
       call activate CB

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -24,6 +24,7 @@ trigger:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
+    - .circleci/config.yml
 
 pr:
   branches:
@@ -35,6 +36,7 @@ pr:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
+    - .circleci/config.yml
 
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -62,9 +62,21 @@ jobs:
 - job: Linux
   strategy:
     matrix:
+      Python3.7_Sklearn1.0:
+        PYTHON_VERSION: '3.7'
+        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
+      Python3.9_Sklearn1.0:
+        PYTHON_VERSION: '3.9'
+        SKLEARN_VERSION: '1.0'
+      Python3.10_Sklearn1.1:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: '1.1'
+      Python3.11_Sklearn1.2:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: '1.2'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -72,105 +84,44 @@ jobs:
 - job: MacOS
   strategy:
     matrix:
+      Python3.7_Sklearn1.0:
+        PYTHON_VERSION: '3.7'
+        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
+      Python3.9_Sklearn1.0:
+        PYTHON_VERSION: '3.9'
+        SKLEARN_VERSION: '1.0'
+      Python3.10_Sklearn1.1:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: '1.1'
+      Python3.11_Sklearn1.2:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: '1.2'
   pool:
     vmImage: 'macos-12'
   steps:
-  - script: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-      conda config --set always_yes yes --set changeps1 no
-      conda update -q conda
-      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal dal-include mpich clang-format pyyaml
-    displayName: Create Anaconda environment
-  - script: |
-      source activate CB
-      pip install -q cpufeature
-      bash .ci/scripts/describe_system.sh
-    displayName: "System info"
-  - script: |
-      source activate CB
-      pip install -r requirements-dev.txt
-      pip list
-    displayName: 'Install develop requirements'
-  - script: |
-      source activate CB
-      export DALROOT=$CONDA_PREFIX
-      ./conda-recipe/build.sh
-      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: Conda build
-  - script: |
-      source activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      pip list
-    displayName: 'Install testing requirements'
-  - script: |
-      source activate CB
-      cd ..
-      ./s/conda-recipe/run_test.sh
-    displayName: 'Sklearnex testing'
-  - script: |
-      source activate CB
-      export SELECTED_TESTS=all
-      bash .ci/scripts/run_sklearn_tests.sh
-    displayName: 'Sklearn testing'
-    continueOnError: true
+  - template: build-and-test-mac.yml
 - job: Windows
   strategy:
     matrix:
+      Python3.7_Sklearn1.0:
+        PYTHON_VERSION: '3.7'
+        SKLEARN_VERSION: '1.0'
       Python3.8_Sklearn0.24:
         PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
+      Python3.9_Sklearn1.0:
+        PYTHON_VERSION: '3.9'
+        SKLEARN_VERSION: '1.0'
+      Python3.10_Sklearn1.1:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: '1.1'
+      Python3.11_Sklearn1.2:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: '1.2'
   pool:
     vmImage: 'windows-latest'
   steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Add conda to PATH
-  - script: conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel impi-devel clang-format pyyaml
-    displayName: 'Create Anaconda environment'
-  - script: |
-      call activate CB
-      pip install --upgrade setuptools
-      pip install cpufeature
-      pip install -r requirements-dev.txt
-      pip list
-    displayName: 'Install develop requirements'
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-      call activate CB
-      set PREFIX=%CONDA_PREFIX%
-      set PYTHON=python
-      call conda-recipe\bld.bat
-      set DALROOT=%CONDA_PREFIX%
-      python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      cd ..
-      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
-      pip install %SCIPY_VERSION%
-      pip list
-    displayName: 'Install testing requirements'
-  - script: |
-      call activate CB
-      cd ..
-      call s\conda-recipe\run_test.bat s
-    displayName: 'Sklearnex testing'
-  - script: |
-      call activate CB
-      set SELECTED_TESTS=all
-      bash .ci/scripts/run_sklearn_tests.sh
-    displayName: 'Sklearn testing'
-    continueOnError: true
+  - template: build-and-test-win.yml

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -24,7 +24,6 @@ trigger:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
-    - .circleci/config.yml
 
 pr:
   branches:
@@ -36,7 +35,6 @@ pr:
     - requirements-doc.txt
     - doc/
     - .ci/pipeline/docs.yml
-    - .circleci/config.yml
 
 variables:
   - name: MACOSX_DEPLOYMENT_TARGET

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -77,6 +77,9 @@ jobs:
       Python3.11_Sklearn1.2:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.2'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -100,6 +103,11 @@ jobs:
       pip list
     displayName: 'Install develop requirements'
   - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+    displayName: 'Setup sklearn version'
+  - script: |
       export DPCPPROOT=/opt/intel/oneapi/compiler/latest
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -116,8 +124,6 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
-      sed -i -e "s/scikit-learn==1.2.0/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
-      sed -i -e "s/scikit-learn==1.0.2/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
@@ -133,11 +139,13 @@ jobs:
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
+    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
     displayName: 'Sklearn testing [device=cpu]'
+    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -162,6 +170,9 @@ jobs:
       Python3.11_Sklearn1.2:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.2'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'macos-12'
   steps:
@@ -184,14 +195,16 @@ jobs:
     displayName: 'Install develop requirements'
   - script: |
       source activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+    displayName: 'Setup sklearn version'
+  - script: |
+      source activate CB
       export DALROOT=$CONDA_PREFIX
       ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: Conda build
   - script: |
       source activate CB
-      sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
-      sed -i.bak -e "s/scikit-learn==1.0.2/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
@@ -205,6 +218,7 @@ jobs:
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
+    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
   - script: |
       source activate CB
       cd ..
@@ -228,6 +242,9 @@ jobs:
       Python3.11_Sklearn1.2:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.2'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'windows-latest'
   steps:
@@ -241,7 +258,11 @@ jobs:
       pip install cpufeature
       pip install -r requirements-dev.txt
       pip list
-    displayName: 'Install requirements'
+    displayName: 'Install develop requirements'
+  - script: |
+      call activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+    displayName: 'Setup sklearn version'
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
@@ -259,8 +280,6 @@ jobs:
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
-      sed -i -e "s/scikit-learn==1.2.0/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
-      sed -i -e "s/scikit-learn==1.0.2/scikit-learn==$(SKLEARN_VERSION).*/" requirements-test.txt
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       cd ..
       for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
@@ -276,6 +295,7 @@ jobs:
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
+    continueOnError: eq(variables['SKLEARN_VERSION'], 'main')
   - script: |
       call activate CB
       cd ..

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -20,6 +20,7 @@ variables:
   python.version: '3.10'
   PYTHON: 'python'
   ARGS: '1'
+  SELECTED_TESTS: 'all'
 
 jobs:
 - job: Coverity
@@ -76,3 +77,34 @@ jobs:
       jupyter nbconvert --execute --ExecutePreprocessor.timeout=10900 --to notebook $(ls | grep -E '.*\.ipynb' | grep -v "dbscan.*")
     timeoutInMinutes: 180
     displayName: 'Run jupyter notebook demo'
+
+- job: LinuxNightly
+  strategy:
+    matrix:
+      Python3.10_SklearnMain:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: 'main'
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:
+  - template: build-and-test-lnx.yml
+- job: MacOSNightly
+  strategy:
+    matrix:
+      Python3.10_SklearnMain:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: 'main'
+  pool:
+    vmImage: 'macos-12'
+  steps:
+  - template: build-and-test-mac.yml
+- job: WindowsNightly
+  strategy:
+    matrix:
+      Python3.10_SklearnMain:
+        PYTHON_VERSION: '3.10'
+        SKLEARN_VERSION: 'main'
+  pool:
+    vmImage: 'windows-latest'
+  steps:
+  - template: build-and-test-win.yml

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -14,6 +14,17 @@
 # limitations under the License.
 #===============================================================================
 
+trigger:
+  branches:
+    include:
+    - master
+    - rls/*
+pr:
+  branches:
+    include:
+    - master
+    - rls/*
+
 variables:
   COVERITY_TOOL_HOME: $(Agent.BuildDirectory)/cov-analysis
   DESCRIPTION: Nightly

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -24,7 +24,7 @@ variables:
 jobs:
 - job: Coverity
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - script: |
       cd $(Agent.BuildDirectory)
@@ -48,42 +48,31 @@ jobs:
 - job: Jupyter
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-latest'
   steps:
-  - task: UsePythonVersion@0
-    displayName: 'Use Python $(python.version)'
-    inputs:
-      versionSpec: '$(python.version)'
   - script: |
       conda update -y -q conda
-      conda create -q -y -n CB -c intel python=$(python.version) dal-devel impi-devel
+      conda create -y -q -n CB -c intel python=$(python.version) dal-devel impi-devel
     displayName: 'Conda create'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       pip install -r requirements-dev.txt
       pip install -r requirements-doc.txt
-      pip install -r requirements-test.txt
-      pip install -r requirements-test-optional.txt
-      pip install requests
+      pip install -r requirements-test.txt -r requirements-test-optional.txt
+      pip install jupyter matplotlib requests
     displayName: 'Install requirements'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       export DALROOT=$CONDA_PREFIX
       ./conda-recipe/build.sh
-    displayName: 'Build daal4py'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      export DALROOT=$CONDA_PREFIX
       python setup_sklearnex.py install --single-version-externally-managed --record=record.txt
-    displayName: 'Build slearnex'
+    displayName: 'Build daal4py/sklearnex'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       cd examples/notebooks
-      pip install jupyter matplotlib
       jupyter nbconvert --execute --ExecutePreprocessor.timeout=10900 --to notebook $(ls | grep -E '.*\.ipynb' | grep -v "dbscan.*")
     timeoutInMinutes: 180
     displayName: 'Run jupyter notebook demo'

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -14,17 +14,6 @@
 # limitations under the License.
 #===============================================================================
 
-trigger:
-  branches:
-    include:
-    - master
-    - rls/*
-pr:
-  branches:
-    include:
-    - master
-    - rls/*
-
 variables:
   COVERITY_TOOL_HOME: $(Agent.BuildDirectory)/cov-analysis
   DESCRIPTION: Nightly

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -17,14 +17,14 @@
 variables:
   COVERITY_TOOL_HOME: $(Agent.BuildDirectory)/cov-analysis
   DESCRIPTION: Nightly
-  python.version: '3.9'
+  python.version: '3.10'
   PYTHON: 'python'
   ARGS: '1'
 
 jobs:
 - job: Coverity
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - script: |
       cd $(Agent.BuildDirectory)
@@ -48,7 +48,7 @@ jobs:
 - job: Jupyter
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python $(python.version)'

--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -16,8 +16,6 @@
 
 variables:
   DESCRIPTION: ReleaseTesting
-  DESELECT: --deselect ::test_svc_clone_with_callable_kernel --deselect ::test_precomputed --deselect ::test_tweak_params --deselect ::test_custom_kernel_not_array_input --deselect ::test_svc_raises_error_internal_representation --deselect ::test_svc_ovr_tie_breaking[SVC] --deselect ::test_svc_ovr_tie_breaking[NuSVC] --deselect ::test_gamma_auto --deselect ::test_gamma_scale
-  TEST_COMMAND: python -m sklearnex -m pytest -ra --disable-warnings --pyargs sklearn.svm.tests.test_svm $(DESELECT)
 
 jobs:
 - job: GeneratorPyPi
@@ -40,13 +38,8 @@ jobs:
       pip install scikit-learn-intelex pandas pytest
     displayName: 'Install scikit-learn-intelex'
   - script: |
-      cd ..
-      python -c "import sklearnex"
-    displayName: 'Testing of import'
-  - script: |
-      cd ..
-      $(TEST_COMMAND)
-    displayName: 'Testing of scikit-learn-intelex'
+      bash .ci/scripts/run_sklearn_tests.sh
+    displayName: 'Sklearn testing'
 - job: GeneratorConda
   steps:
   - bash: python .ci/scripts/gen_release_jobs.py --channels main conda-forge
@@ -78,12 +71,5 @@ jobs:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       $(conda.activate) CB
-      cd ..
-      python -c "import sklearnex"
-    displayName: 'Testing of import'
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      $(conda.activate) CB
-      cd ..
-      $(TEST_COMMAND)
-    displayName: 'Testing of scikit-learn-intelex'
+      bash .ci/scripts/run_sklearn_tests.sh
+    displayName: 'Sklearn testing'

--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -30,7 +30,7 @@ elif sklearn_check_version('1.0'):
     print('scipy==1.7.*')
 elif sklearn_check_version('0.24'):
     # scipy 1.6 is compatible with pandas versions lower than 1.4
-    print('scipy==1.6.* "pandas<1.4"')
+    print('scipy==1.6.* pandas==1.3')
 else:
     print('Scipy version defaults to not specified '
           'for this outdated sklearn/python version.', file=stderr)

--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -21,7 +21,7 @@ from sys import exit, stderr
 
 if sklearn_check_version('1.3') or python_version[1] > 11:
     print('Scipy version is not specified for this sklearn/python version.', file=stderr)
-    exit(1)
+    print('scipy')
 elif sklearn_check_version('1.2') or python_version[1] > 10:
     print('scipy==1.9.*')
 elif sklearn_check_version('1.1'):

--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -29,7 +29,8 @@ elif sklearn_check_version('1.1'):
 elif sklearn_check_version('1.0'):
     print('scipy==1.7.*')
 elif sklearn_check_version('0.24'):
-    print('scipy==1.6.*')
+    # scipy 1.6 is compatible with pandas versions lower than 1.4
+    print('scipy==1.6.* "pandas<1.4"')
 else:
     print('Scipy version defaults to not specified '
           'for this outdated sklearn/python version.', file=stderr)

--- a/.ci/scripts/install_dpcpp.sh
+++ b/.ci/scripts/install_dpcpp.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
+sudo apt-get update
+sudo apt-get install -y intel-dpcpp-cpp-compiler-2023.0.0
+sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
+sudo mv -f /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga_

--- a/.ci/scripts/run_sklearn_tests.py
+++ b/.ci/scripts/run_sklearn_tests.py
@@ -37,8 +37,13 @@ if __name__ == '__main__':
 
     os.chdir(os.path.dirname(sklearn.__file__))
 
+    if os.environ["SELECTED_TESTS"] == 'all':
+        os.environ["SELECTED_TESTS"] = ''
+
     pytest_args = '--verbose --pyargs --durations=100 --durations-min=0.01 ' \
         f'{os.environ["DESELECTED_TESTS"]} {os.environ["SELECTED_TESTS"]}'.split(' ')
+    while '' in pytest_args:
+        pytest_args.remove('')
 
     if args.device != 'none':
         with sklearn.config_context(target_offload=args.device):

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -21,7 +21,9 @@
 ci_dir=$( dirname $( dirname "${BASH_SOURCE[0]}" ) )
 cd $ci_dir
 
-export SELECTED_TESTS=$(python scripts/select_sklearn_tests.py)
+# selected tests might be set externally
+# ('all' - special value to run all tests)
+export SELECTED_TESTS=${SELECTED_TESTS:-$(python scripts/select_sklearn_tests.py)}
 export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_tests.yaml)
 
 python scripts/run_sklearn_tests.py -d ${1:-none}

--- a/.ci/scripts/setup_sklearn.sh
+++ b/.ci/scripts/setup_sklearn.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+# Args:
+# 1 - sklearn version (optional, default=main)
+
+repo_dir=$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" ) ) )
+cd $repo_dir
+
+sklearn_version=${1:-main}
+
+if [ "$sklearn_version" == "main" ]; then
+	# delete sklearn from test requirements file
+	sed -i.bak -e "s/scikit-learn==1.2.0//" requirements-test.txt
+    sed -i.bak -e "s/scikit-learn==1.0.2//" requirements-test.txt
+    # install sklearn build dependencies
+	pip install threadpoolctl joblib scipy
+    # clone, build and install sklearn
+	git clone https://github.com/scikit-learn/scikit-learn.git
+	cd scikit-learn
+	git log -n 1
+	python setup.py install --single-version-externally-managed --record=record.txt
+	cd ..
+	rm -rf scikit-learn
+else
+	sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn==${sklearn_version}.*/" requirements-test.txt
+    sed -i.bak -e "s/scikit-learn==1.0.2/scikit-learn==${sklearn_version}.*/" requirements-test.txt
+fi

--- a/.ci/scripts/setup_sklearn.sh
+++ b/.ci/scripts/setup_sklearn.sh
@@ -34,8 +34,6 @@ if [ "$sklearn_version" == "main" ]; then
 	cd scikit-learn
 	git log -n 1
 	python setup.py install --single-version-externally-managed --record=record.txt
-	cd ..
-	rm -rf scikit-learn
 else
 	sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn==${sklearn_version}.*/" requirements-test.txt
     sed -i.bak -e "s/scikit-learn==1.0.2/scikit-learn==${sklearn_version}.*/" requirements-test.txt

--- a/.ci/scripts/setup_sklearn.sh
+++ b/.ci/scripts/setup_sklearn.sh
@@ -24,17 +24,17 @@ cd $repo_dir
 sklearn_version=${1:-main}
 
 if [ "$sklearn_version" == "main" ]; then
-	# delete sklearn from test requirements file
-	sed -i.bak -e "s/scikit-learn==1.2.0//" requirements-test.txt
-    sed -i.bak -e "s/scikit-learn==1.0.2//" requirements-test.txt
+    # remove sklearn version from test requirements file
+    sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn/" requirements-test.txt
+    sed -i.bak -e "s/scikit-learn==1.0.2/scikit-learn/" requirements-test.txt
     # install sklearn build dependencies
-	pip install threadpoolctl joblib scipy
+    pip install threadpoolctl joblib scipy
     # clone, build and install sklearn
-	git clone https://github.com/scikit-learn/scikit-learn.git
-	cd scikit-learn
-	git log -n 1
-	python setup.py install --single-version-externally-managed --record=record.txt
+    git clone https://github.com/scikit-learn/scikit-learn.git
+    cd scikit-learn
+    git log -n 1
+    python setup.py install --single-version-externally-managed --record=record.txt
 else
-	sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn==${sklearn_version}.*/" requirements-test.txt
+    sed -i.bak -e "s/scikit-learn==1.2.0/scikit-learn==${sklearn_version}.*/" requirements-test.txt
     sed -i.bak -e "s/scikit-learn==1.0.2/scikit-learn==${sklearn_version}.*/" requirements-test.txt
 fi

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -38,8 +38,8 @@ err_code = subprocess.call([sys.executable, "-m",
 assert not err_code
 unpatch_sklearn()
 from sklearn.svm import SVC, SVR
-assert not SVR.__module__.startswith('daal4py') and \
-       not SVR.__module__.startswith('sklearnex')
+assert not SVC.__module__.startswith('daal4py') and \
+       not SVC.__module__.startswith('sklearnex')
 assert not SVR.__module__.startswith('daal4py') and \
        not SVR.__module__.startswith('sklearnex')
 
@@ -56,7 +56,7 @@ assert not SVR.__module__.startswith('daal4py') and \
 # test unpatching from function
 unpatch_sklearn(global_unpatch=True)
 from sklearn.svm import SVC, SVR
-assert not SVR.__module__.startswith('daal4py') and \
-       not SVR.__module__.startswith('sklearnex')
+assert not SVC.__module__.startswith('daal4py') and \
+       not SVC.__module__.startswith('sklearnex')
 assert not SVR.__module__.startswith('daal4py') and \
        not SVR.__module__.startswith('sklearnex')

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -45,3 +45,4 @@ IF DEFINED TBBROOT (
 pytest --verbose --pyargs %1\daal4py\sklearn --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_classifier_big_estimators_iris[8000]" --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_mse_regressor_big_estimators_iris[8000]"
 pytest --verbose --pyargs %1\sklearnex
 pytest --verbose --pyargs %1\onedal --deselect="onedal/common/tests/test_policy.py"
+python %1\.ci\scripts\test_global_patch.py

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -42,7 +42,7 @@ IF DEFINED TBBROOT (
 
 %PYTHON% -m unittest discover -v -s %1\tests -p test*.py
 
-pytest --verbose --pyargs %1\daal4py\sklearn --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_classifier_big_estimators_iris[8000]" --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_mse_regressor_big_estimators_iris[8000]"
+pytest --verbose --pyargs %1\daal4py\sklearn
 pytest --verbose --pyargs %1\sklearnex
 pytest --verbose --pyargs %1\onedal --deselect="onedal/common/tests/test_policy.py"
 python %1\.ci\scripts\test_global_patch.py

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -64,4 +64,8 @@ echo "Pytest of onedal running ..."
 pytest --verbose --pyargs ${daal4py_dir}/onedal
 return_code=$(($return_code + $?))
 
+echo "Global patching test running ..."
+python --verbose --pyargs ${daal4py_dir}/.ci/scripts/test_global_patch.py
+return_code=$(($return_code + $?))
+
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -62,7 +62,7 @@ pytest --verbose --pyargs ${daal4py_dir}/onedal
 return_code=$(($return_code + $?))
 
 echo "Global patching test running ..."
-python --verbose --pyargs ${daal4py_dir}/.ci/scripts/test_global_patch.py
+python ${daal4py_dir}/.ci/scripts/test_global_patch.py
 return_code=$(($return_code + $?))
 
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -50,10 +50,7 @@ python -m unittest discover -v -s ${daal4py_dir}/tests -p test*.py
 return_code=$(($return_code + $?))
 
 echo "Pytest of daal4py running ..."
-# TODO: remove deselect after fix
-pytest --verbose --pyargs ${daal4py_dir}/daal4py/sklearn \
-    --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_classifier_big_estimators_iris[8000]" \
-    --deselect="daal4py/sklearn/ensemble/tests/test_decision_forest.py::test_mse_regressor_big_estimators_iris[8000]"
+pytest --verbose --pyargs ${daal4py_dir}/daal4py/sklearn
 return_code=$(($return_code + $?))
 
 echo "Pytest of sklearnex running ..."

--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -78,7 +78,9 @@ def parse_auto_method(estimator, method, n_samples, n_features):
         if estimator.metric == 'precomputed' or n_features > 11 or condition:
             result_method = 'brute'
         else:
-            if estimator.effective_metric_ in KDTree.valid_metrics:
+            kdtree_valid_metrics = KDTree.valid_metrics() \
+                if sklearn_check_version('1.3') else KDTree.valid_metrics
+            if estimator.effective_metric_ in kdtree_valid_metrics:
                 result_method = 'kd_tree'
             else:
                 result_method = 'brute'

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -50,6 +50,12 @@ deselected_tests:
   - neighbors/tests/test_lof.py::test_lof_dtype_equivalence[auto-True-ball_tree] >=1.2 darwin
   - neighbors/tests/test_lof.py::test_lof_dtype_equivalence[auto-True-kd_tree] >=1.2 darwin
 
+  # TODO: fix for Linear Regression failed to converge on MacOS only
+  - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est0] >=0.23 darwin
+  - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est1] >=0.23 darwin
+  - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est2] >=0.23 darwin
+  - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est3] >=0.23 darwin
+
   # random forest classifier selects different most important feature
   # Feature importances:
   # sklearnex  [0.             0.00553064     0.71323666     0.2812327 ]


### PR DESCRIPTION
Changes:
- Move CI steps to os-specific templates
- Add nightly jobs with run of all tests on sklearn `main` branch
- Update Ubuntu and Python versions in nightly
- Use run_sklearn_tests.sh script for testing in release jobs
- Pin pandas version to 1.3 for sklearn 0.24 and scipy 1.6 to fix compatibility of sparse formats
- Add option to run sklearn tests in run_sklearn_tests.sh script
- Move dpcpp installation to separate script
- Fix typo in test_global_patch.py
- Fix KDTree valid metrics getting for sklearn>=1.3
- Deselect LinReg tests failure on MacOS because of impossibility to converge