### PR TITLE
feat: Provide averages binning to improve RF accuracy for some datasets

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -56,7 +56,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools
       pip install flake8
-      flake8 --ignore=E265,E722,E402,F401,F403 --max-line-length=90 --count
+      flake8 --ignore=E265,E722,E402,F401,F403,W503 --max-line-length=90 --count
     displayName: 'PEP 8 check'
 
 - job: Linux

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -52,7 +52,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools
       pip install flake8
-      flake8 --ignore=E265,E722,E402,F401,F403 --max-line-length=90 --count
+      flake8 --ignore=E265,E722,E402,F401,F403,W503 --max-line-length=90 --count
     displayName: 'PEP 8 check'
 - job: Docs
   pool:

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -22,24 +22,20 @@ from math import ceil
 import numpy as np
 from scipy import sparse as sp
 from sklearn.base import clone
-from sklearn.ensemble import RandomForestClassifier as RandomForestClassifier_original
-from sklearn.ensemble import RandomForestRegressor as RandomForestRegressor_original
+from sklearn.ensemble import \
+    RandomForestClassifier as RandomForestClassifier_original
+from sklearn.ensemble import \
+    RandomForestRegressor as RandomForestRegressor_original
 from sklearn.exceptions import DataConversionWarning
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree._tree import Tree
 from sklearn.utils import check_array, check_random_state, deprecated
-from sklearn.utils.validation import (
-    _num_samples,
-    check_consistent_length,
-    check_is_fitted,
-)
+from sklearn.utils.validation import (_num_samples, check_consistent_length,
+                                      check_is_fitted)
 
 import daal4py
-from daal4py.sklearn._utils import (
-    PatchingConditionsChain,
-    daal_check_version,
-    sklearn_check_version,
-)
+from daal4py.sklearn._utils import (PatchingConditionsChain,
+                                    daal_check_version, sklearn_check_version)
 
 from .._device_offload import support_usm_ndarray
 from .._utils import getFPType
@@ -199,17 +195,21 @@ class RandomForestBase:
             )
 
             if self.min_impurity_split < 0.0:
-                raise ValueError("min_impurity_split must be greater than or equal to 0")
+                raise ValueError(
+                    "min_impurity_split must be greater " "than or equal to 0"
+                )
         if self.min_impurity_decrease < 0.0:
             raise ValueError("min_impurity_decrease must be greater than or equal to 0")
         if self.max_leaf_nodes is not None:
             if not isinstance(self.max_leaf_nodes, numbers.Integral):
                 raise ValueError(
-                    f"max_leaf_nodes must be integral number but was {self.max_leaf_nodes}"
+                    "max_leaf_nodes must be integral number but was "
+                    f"{self.max_leaf_nodes}"
                 )
             if self.max_leaf_nodes < 2:
                 raise ValueError(
-                    f"max_leaf_nodes {self.max_leaf_nodes} must be either None or larger than 1"
+                    f"max_leaf_nodes {self.max_leaf_nodes} must be either None "
+                    "or larger than 1"
                 )
         if isinstance(self.maxBins, numbers.Integral):
             if not 2 <= self.maxBins:
@@ -370,7 +370,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
         if sklearn_check_version("1.2"):
             self._validate_params()
         else:
-            _check_parameters(self)
+            self._check_parameters()
         if sample_weight is not None:
             sample_weight = check_sample_weight(sample_weight, X)
 
@@ -932,7 +932,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
         if sklearn_check_version("1.2"):
             self._validate_params()
         else:
-            _check_parameters(self)
+            self._check_parameters()
         if sample_weight is not None:
             sample_weight = check_sample_weight(sample_weight, X)
 

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -22,27 +22,31 @@ from math import ceil
 import numpy as np
 from scipy import sparse as sp
 from sklearn.base import clone
-from sklearn.ensemble import \
-    RandomForestClassifier as RandomForestClassifier_original
-from sklearn.ensemble import \
-    RandomForestRegressor as RandomForestRegressor_original
+from sklearn.ensemble import RandomForestClassifier as RandomForestClassifier_original
+from sklearn.ensemble import RandomForestRegressor as RandomForestRegressor_original
 from sklearn.exceptions import DataConversionWarning
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree._tree import Tree
 from sklearn.utils import check_array, check_random_state, deprecated
-from sklearn.utils.validation import (_num_samples, check_consistent_length,
-                                      check_is_fitted)
+from sklearn.utils.validation import (
+    _num_samples,
+    check_consistent_length,
+    check_is_fitted,
+)
 
 import daal4py
-from daal4py.sklearn._utils import (PatchingConditionsChain,
-                                    daal_check_version, sklearn_check_version)
+from daal4py.sklearn._utils import (
+    PatchingConditionsChain,
+    daal_check_version,
+    sklearn_check_version,
+)
 
 from .._device_offload import support_usm_ndarray
 from .._utils import getFPType
 from ..utils.validation import _daal_num_features
 
 if sklearn_check_version("1.2"):
-    from sklearn.utils._param_validation import Interval
+    from sklearn.utils._param_validation import Interval, StrOptions
 
 
 def _to_absolute_max_features(max_features, n_features, is_classification=False):
@@ -233,6 +237,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             **RandomForestClassifier_original._parameter_constraints,
             "maxBins": [Interval(numbers.Integral, 0, None, closed="left")],
             "minBinSize": [Interval(numbers.Integral, 1, None, closed="left")],
+            "binningStrategy": [StrOptions({"quantiles", "averages"})],
         }
 
     if sklearn_check_version("1.0"):
@@ -797,6 +802,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             **RandomForestRegressor_original._parameter_constraints,
             "maxBins": [Interval(numbers.Integral, 0, None, closed="left")],
             "minBinSize": [Interval(numbers.Integral, 1, None, closed="left")],
+            "binningStrategy": [StrOptions({"quantiles", "averages"})],
         }
 
     if sklearn_check_version("1.0"):

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -14,33 +14,32 @@
 # limitations under the License.
 # ===============================================================================
 
-import numpy as np
-
+import logging
 import numbers
 import warnings
+from math import ceil
 
-import daal4py
-from .._utils import getFPType, check_tree_nodes
-from .._device_offload import support_usm_ndarray
-from daal4py.sklearn._utils import (
-    daal_check_version, sklearn_check_version,
-    PatchingConditionsChain)
-
+import numpy as np
+from scipy import sparse as sp
+from sklearn.base import clone
+from sklearn.ensemble import \
+    RandomForestClassifier as RandomForestClassifier_original
+from sklearn.ensemble import \
+    RandomForestRegressor as RandomForestRegressor_original
+from sklearn.exceptions import DataConversionWarning
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.tree._tree import Tree
-from sklearn.ensemble import RandomForestClassifier as RandomForestClassifier_original
-from sklearn.ensemble import RandomForestRegressor as RandomForestRegressor_original
-from sklearn.utils import (check_random_state, check_array, deprecated)
-from sklearn.utils.validation import (
-    check_is_fitted,
-    check_consistent_length,
-    _num_samples)
-from ..utils.validation import _daal_num_features
-from sklearn.base import clone
-from sklearn.exceptions import DataConversionWarning
+from sklearn.utils import check_array, check_random_state, deprecated
+from sklearn.utils.validation import (_num_samples, check_consistent_length,
+                                      check_is_fitted)
 
-from math import ceil
-from scipy import sparse as sp
+import daal4py
+from daal4py.sklearn._utils import (PatchingConditionsChain,
+                                    daal_check_version, sklearn_check_version)
+
+from .._device_offload import support_usm_ndarray
+from .._utils import getFPType
+from ..utils.validation import _daal_num_features
 
 if sklearn_check_version('1.2'):
     from sklearn.utils._param_validation import Interval
@@ -883,7 +882,7 @@ class RandomForestClassifier(RandomForestClassifier_original):
             tree_i_state_dict = {
                 'max_depth': tree_i_state_class.max_depth,
                 'node_count': tree_i_state_class.node_count,
-                'nodes': check_tree_nodes(tree_i_state_class.node_ar),
+                'nodes': tree_i_state_class.node_ar,
                 'values': tree_i_state_class.value_ar}
             est_i.tree_ = Tree(
                 self.n_features_in_,
@@ -1125,7 +1124,7 @@ class RandomForestRegressor(RandomForestRegressor_original):
             tree_i_state_dict = {
                 'max_depth': tree_i_state_class.max_depth,
                 'node_count': tree_i_state_class.node_count,
-                'nodes': check_tree_nodes(tree_i_state_class.node_ar),
+                'nodes': tree_i_state_class.node_ar,
                 'values': tree_i_state_class.value_ar}
 
             est_i.tree_ = Tree(

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -39,10 +39,11 @@ from daal4py.sklearn._utils import (
     PatchingConditionsChain,
     daal_check_version,
     sklearn_check_version,
+    getFPType,
+    check_tree_nodes,
 )
 
 from .._device_offload import support_usm_ndarray
-from .._utils import getFPType
 from ..utils.validation import _daal_num_features
 
 if sklearn_check_version("1.2"):
@@ -642,7 +643,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             tree_i_state_dict = {
                 "max_depth": tree_i_state_class.max_depth,
                 "node_count": tree_i_state_class.node_count,
-                "nodes": tree_i_state_class.node_ar,
+                "nodes": check_tree_nodes(tree_i_state_class.node_ar),
                 "values": tree_i_state_class.value_ar,
             }
             est_i.tree_ = Tree(
@@ -1125,7 +1126,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             tree_i_state_dict = {
                 "max_depth": tree_i_state_class.max_depth,
                 "node_count": tree_i_state_class.node_count,
-                "nodes": tree_i_state_class.node_ar,
+                "nodes": check_tree_nodes(tree_i_state_class.node_ar),
                 "values": tree_i_state_class.value_ar,
             }
 

--- a/daal4py/sklearn/ensemble/tests/test_decision_forest.py
+++ b/daal4py/sklearn/ensemble/tests/test_decision_forest.py
@@ -36,14 +36,24 @@ RNG = np.random.RandomState(0)
 IRIS = load_iris()
 
 
-def _compare_with_sklearn_classifier_iris(n_estimators=99, class_weight=None, sample_weight=None, description=""):
-    x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
+def _compare_with_sklearn_classifier_iris(
+    n_estimators=99, class_weight=None, sample_weight=None, description=""
+):
+    x_train, x_test, y_train, y_test = train_test_split(
+        IRIS.data, IRIS.target, test_size=0.33, random_state=31
+    )
     # models
     scikit_model = ScikitRandomForestClassifier(
-        n_estimators=n_estimators, class_weight=class_weight, max_depth=None, random_state=777
+        n_estimators=n_estimators,
+        class_weight=class_weight,
+        max_depth=None,
+        random_state=777,
     )
     daal4py_model = DaalRandomForestClassifier(
-        n_estimators=n_estimators, class_weight=class_weight, max_depth=None, random_state=777
+        n_estimators=n_estimators,
+        class_weight=class_weight,
+        max_depth=None,
+        random_state=777,
     )
     # training
     scikit_model.fit(x_train, y_train, sample_weight=sample_weight)
@@ -55,7 +65,10 @@ def _compare_with_sklearn_classifier_iris(n_estimators=99, class_weight=None, sa
     scikit_accuracy = accuracy_score(scikit_predict, y_test)
     daal4py_accuracy = accuracy_score(daal4py_predict, y_test)
     ratio = daal4py_accuracy / scikit_accuracy
-    reason = description + f"scikit_accuracy={scikit_accuracy}, daal4py_accuracy={daal4py_accuracy}"
+    reason = (
+        description
+        + f"scikit_accuracy={scikit_accuracy}, daal4py_accuracy={daal4py_accuracy}"
+    )
     assert ratio >= ACCURACY_RATIO, reason
 
     # predict_proba
@@ -66,7 +79,10 @@ def _compare_with_sklearn_classifier_iris(n_estimators=99, class_weight=None, sa
     daal4py_log_loss = log_loss(y_test, daal4py_predict_proba)
     ratio = daal4py_log_loss / scikit_log_loss
 
-    reason = description + f"scikit_log_loss={scikit_log_loss}, daal4py_log_loss={daal4py_log_loss}"
+    reason = (
+        description
+        + f"scikit_log_loss={scikit_log_loss}, daal4py_log_loss={daal4py_log_loss}"
+    )
     assert ratio <= LOG_LOSS_RATIO, reason
 
     # ROC AUC
@@ -74,7 +90,10 @@ def _compare_with_sklearn_classifier_iris(n_estimators=99, class_weight=None, sa
     daal4py_roc_auc = roc_auc_score(y_test, daal4py_predict_proba, multi_class="ovr")
     ratio = daal4py_roc_auc / scikit_roc_auc
 
-    reason = description + f"scikit_roc_auc={scikit_roc_auc}, daal4py_roc_auc={daal4py_roc_auc}"
+    reason = (
+        description
+        + f"scikit_roc_auc={scikit_roc_auc}, daal4py_roc_auc={daal4py_roc_auc}"
+    )
     assert ratio >= ROC_AUC_RATIO, reason
 
 
@@ -104,7 +123,9 @@ CLASS_WEIGHTS_IRIS = [
 
 @pytest.mark.parametrize("class_weight", CLASS_WEIGHTS_IRIS)
 def test_classifier_class_weight_iris(class_weight):
-    _compare_with_sklearn_classifier_iris(class_weight=class_weight, description="Classifier class weight: ")
+    _compare_with_sklearn_classifier_iris(
+        class_weight=class_weight, description="Classifier class weight: "
+    )
 
 
 SAMPLE_WEIGHTS_IRIS = [
@@ -121,7 +142,8 @@ SAMPLE_WEIGHTS_IRIS = [
 def test_classifier_sample_weight_iris(sample_weight):
     sample_weight, description = sample_weight
     _compare_with_sklearn_classifier_iris(
-        sample_weight=sample_weight, description=f"Classifier sample_weight_type={description}: "
+        sample_weight=sample_weight,
+        description=f"Classifier sample_weight_type={description}: ",
     )
 
 
@@ -138,14 +160,26 @@ def test_classifier_big_estimators_iris(n_estimators):
     )
 
 
-def _compare_with_sklearn_mse_regressor_iris(n_estimators=99, sample_weight=None, description=""):
-    x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
+def _compare_with_sklearn_mse_regressor_iris(
+    n_estimators=99, sample_weight=None, description=""
+):
+    x_train, x_test, y_train, y_test = train_test_split(
+        IRIS.data, IRIS.target, test_size=0.33, random_state=31
+    )
 
-    scikit_model = ScikitRandomForestRegressor(n_estimators=n_estimators, max_depth=None, random_state=777)
-    daal4py_model = DaalRandomForestRegressor(n_estimators=n_estimators, max_depth=None, random_state=777)
+    scikit_model = ScikitRandomForestRegressor(
+        n_estimators=n_estimators, max_depth=None, random_state=777
+    )
+    daal4py_model = DaalRandomForestRegressor(
+        n_estimators=n_estimators, max_depth=None, random_state=777
+    )
 
-    scikit_predict = scikit_model.fit(x_train, y_train, sample_weight=sample_weight).predict(x_test)
-    daal4py_predict = daal4py_model.fit(x_train, y_train, sample_weight=sample_weight).predict(x_test)
+    scikit_predict = scikit_model.fit(
+        x_train, y_train, sample_weight=sample_weight
+    ).predict(x_test)
+    daal4py_predict = daal4py_model.fit(
+        x_train, y_train, sample_weight=sample_weight
+    ).predict(x_test)
 
     scikit_mse = mean_squared_error(scikit_predict, y_test)
     daal4py_mse = mean_squared_error(daal4py_predict, y_test)
@@ -159,12 +193,14 @@ def _compare_with_sklearn_mse_regressor_iris(n_estimators=99, sample_weight=None
 def test_mse_regressor_sample_weight_iris(weight):
     sample_weight, description = weight
     _compare_with_sklearn_mse_regressor_iris(
-        sample_weight=sample_weight, description=f"Regression sample weights: sample_weight_type={description}: "
+        sample_weight=sample_weight,
+        description=f"Regression sample weights: sample_weight_type={description}: ",
     )
 
 
 @pytest.mark.parametrize("n_estimators", N_ESTIMATORS_IRIS)
 def test_mse_regressor_big_estimators_iris(n_estimators):
     _compare_with_sklearn_mse_regressor_iris(
-        n_estimators=n_estimators, description=f"Regression: n_estimators={n_estimators}: "
+        n_estimators=n_estimators,
+        description=f"Regression: n_estimators={n_estimators}: ",
     )

--- a/daal4py/sklearn/ensemble/tests/test_decision_forest.py
+++ b/daal4py/sklearn/ensemble/tests/test_decision_forest.py
@@ -36,7 +36,7 @@ RNG = np.random.RandomState(0)
 IRIS = load_iris()
 
 
-def _compare_with_sklearn_classifier_iris(n_estimators=100, class_weight=None, sample_weight=None, description=""):
+def _compare_with_sklearn_classifier_iris(n_estimators=99, class_weight=None, sample_weight=None, description=""):
     x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
     # models
     scikit_model = ScikitRandomForestClassifier(
@@ -138,7 +138,7 @@ def test_classifier_big_estimators_iris(n_estimators):
     )
 
 
-def _compare_with_sklearn_mse_regressor_iris(n_estimators=100, sample_weight=None, description=""):
+def _compare_with_sklearn_mse_regressor_iris(n_estimators=99, sample_weight=None, description=""):
     x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
 
     scikit_model = ScikitRandomForestRegressor(n_estimators=n_estimators, max_depth=None, random_state=777)

--- a/daal4py/sklearn/ensemble/tests/test_decision_forest.py
+++ b/daal4py/sklearn/ensemble/tests/test_decision_forest.py
@@ -1,4 +1,4 @@
-#===============================================================================
+# ===============================================================================
 # Copyright 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,25 +12,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#===============================================================================
+# ===============================================================================
+
+import random
 
 import numpy as np
 import pytest
 from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier as ScikitRandomForestClassifier
+from sklearn.ensemble import RandomForestRegressor as ScikitRandomForestRegressor
+from sklearn.metrics import accuracy_score, log_loss, mean_squared_error, roc_auc_score
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import (accuracy_score, roc_auc_score,
-                             mean_squared_error, log_loss)
-from sklearn.ensemble \
-    import RandomForestClassifier as ScikitRandomForestClassifier
-from daal4py.sklearn.ensemble \
-    import RandomForestClassifier as DaalRandomForestClassifier
-from sklearn.ensemble \
-    import RandomForestRegressor as ScikitRandomForestRegressor
-from daal4py.sklearn.ensemble \
-    import RandomForestRegressor as DaalRandomForestRegressor
-from daal4py.sklearn._utils import daal_check_version
 
-ACCURACY_RATIO = 0.95 if daal_check_version((2021, 'P', 400)) else 0.85
+from daal4py.sklearn._utils import daal_check_version
+from daal4py.sklearn.ensemble import RandomForestClassifier as DaalRandomForestClassifier
+from daal4py.sklearn.ensemble import RandomForestRegressor as DaalRandomForestRegressor
+
+ACCURACY_RATIO = 0.95 if daal_check_version((2021, "P", 400)) else 0.85
 MSE_RATIO = 1.07
 LOG_LOSS_RATIO = 1.55
 ROC_AUC_RATIO = 0.96
@@ -38,53 +36,45 @@ RNG = np.random.RandomState(0)
 IRIS = load_iris()
 
 
-def _compare_with_sklearn_classifier_iris(n_estimators=100, class_weight=None,
-                                          sample_weight=None, description=""):
-    x_train, x_test, y_train, y_test = \
-        train_test_split(IRIS.data, IRIS.target,
-                         test_size=0.33, random_state=31)
+def _compare_with_sklearn_classifier_iris(n_estimators=100, class_weight=None, sample_weight=None, description=""):
+    x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
     # models
-    scikit_model = ScikitRandomForestClassifier(n_estimators=n_estimators,
-                                                class_weight=class_weight,
-                                                max_depth=None,
-                                                random_state=777)
-    daal4py_model = DaalRandomForestClassifier(n_estimators=n_estimators,
-                                               class_weight=class_weight,
-                                               max_depth=None,
-                                               random_state=777)
+    scikit_model = ScikitRandomForestClassifier(
+        n_estimators=n_estimators, class_weight=class_weight, max_depth=None, random_state=777
+    )
+    daal4py_model = DaalRandomForestClassifier(
+        n_estimators=n_estimators, class_weight=class_weight, max_depth=None, random_state=777
+    )
     # training
     scikit_model.fit(x_train, y_train, sample_weight=sample_weight)
     daal4py_model.fit(x_train, y_train, sample_weight=sample_weight)
-    #predict
+    # predict
     scikit_predict = scikit_model.predict(x_test)
     daal4py_predict = daal4py_model.predict(x_test)
-    #accuracy
+    # accuracy
     scikit_accuracy = accuracy_score(scikit_predict, y_test)
     daal4py_accuracy = accuracy_score(daal4py_predict, y_test)
     ratio = daal4py_accuracy / scikit_accuracy
-    reason = description + \
-        f"scikit_accuracy={scikit_accuracy}, daal4py_accuracy={daal4py_accuracy}"
+    reason = description + f"scikit_accuracy={scikit_accuracy}, daal4py_accuracy={daal4py_accuracy}"
     assert ratio >= ACCURACY_RATIO, reason
 
     # predict_proba
     scikit_predict_proba = scikit_model.predict_proba(x_test)
     daal4py_predict_proba = daal4py_model.predict_proba(x_test)
-    #log_loss
+    # log_loss
     scikit_log_loss = log_loss(y_test, scikit_predict_proba)
     daal4py_log_loss = log_loss(y_test, daal4py_predict_proba)
     ratio = daal4py_log_loss / scikit_log_loss
 
-    reason = description +\
-        f"scikit_log_loss={scikit_log_loss}, daal4py_log_loss={daal4py_log_loss}"
+    reason = description + f"scikit_log_loss={scikit_log_loss}, daal4py_log_loss={daal4py_log_loss}"
     assert ratio <= LOG_LOSS_RATIO, reason
 
     # ROC AUC
-    scikit_roc_auc = roc_auc_score(y_test, scikit_predict_proba, multi_class='ovr')
-    daal4py_roc_auc = roc_auc_score(y_test, daal4py_predict_proba, multi_class='ovr')
+    scikit_roc_auc = roc_auc_score(y_test, scikit_predict_proba, multi_class="ovr")
+    daal4py_roc_auc = roc_auc_score(y_test, daal4py_predict_proba, multi_class="ovr")
     ratio = daal4py_roc_auc / scikit_roc_auc
 
-    reason = description + \
-        f"scikit_roc_auc={scikit_roc_auc}, daal4py_roc_auc={daal4py_roc_auc}"
+    reason = description + f"scikit_roc_auc={scikit_roc_auc}, daal4py_roc_auc={daal4py_roc_auc}"
     assert ratio >= ROC_AUC_RATIO, reason
 
 
@@ -108,34 +98,30 @@ CLASS_WEIGHTS_IRIS = [
         2: RNG.uniform(1, 100),
     },
     {0: 50, 1: 50, 2: 50},
-    'balanced',
+    "balanced",
 ]
 
 
-@pytest.mark.parametrize('class_weight', CLASS_WEIGHTS_IRIS)
+@pytest.mark.parametrize("class_weight", CLASS_WEIGHTS_IRIS)
 def test_classifier_class_weight_iris(class_weight):
-    _compare_with_sklearn_classifier_iris(
-        class_weight=class_weight,
-        description='Classifier class weight: '
-    )
+    _compare_with_sklearn_classifier_iris(class_weight=class_weight, description="Classifier class weight: ")
 
 
 SAMPLE_WEIGHTS_IRIS = [
-    (np.full_like(range(100), 1), 'Only 1'),
-    (np.full_like(range(100), 50), 'Only 50'),
-    (RNG.rand(100), 'Uniform distribution'),
-    (RNG.normal(1000, 10, 100), 'Gaussian distribution'),
-    (RNG.poisson(lam=10, size=100), 'Poisson distribution'),
-    (RNG.rayleigh(scale=1, size=100), 'Rayleigh distribution'),
+    (np.full_like(range(100), 1), "Only 1"),
+    (np.full_like(range(100), 50), "Only 50"),
+    (RNG.rand(100), "Uniform distribution"),
+    (RNG.normal(1000, 10, 100), "Gaussian distribution"),
+    (RNG.poisson(lam=10, size=100), "Poisson distribution"),
+    (RNG.rayleigh(scale=1, size=100), "Rayleigh distribution"),
 ]
 
 
-@pytest.mark.parametrize('sample_weight', SAMPLE_WEIGHTS_IRIS)
+@pytest.mark.parametrize("sample_weight", SAMPLE_WEIGHTS_IRIS)
 def test_classifier_sample_weight_iris(sample_weight):
     sample_weight, description = sample_weight
     _compare_with_sklearn_classifier_iris(
-        sample_weight=sample_weight,
-        description=f'Classifier sample_weight_type={description}: '
+        sample_weight=sample_weight, description=f"Classifier sample_weight_type={description}: "
     )
 
 
@@ -145,33 +131,21 @@ N_ESTIMATORS_IRIS = [
 ]
 
 
-@pytest.mark.parametrize('n_estimators', N_ESTIMATORS_IRIS)
+@pytest.mark.parametrize("n_estimators", N_ESTIMATORS_IRIS)
 def test_classifier_big_estimators_iris(n_estimators):
     _compare_with_sklearn_classifier_iris(
-        n_estimators=n_estimators,
-        description=f'Classifier n_estimators={n_estimators}: '
+        n_estimators=n_estimators, description=f"Classifier n_estimators={n_estimators}: "
     )
 
 
-def _compare_with_sklearn_mse_regressor_iris(n_estimators=100, sample_weight=None,
-                                             description=""):
-    x_train, x_test, y_train, y_test = \
-        train_test_split(IRIS.data, IRIS.target,
-                         test_size=0.33, random_state=31)
+def _compare_with_sklearn_mse_regressor_iris(n_estimators=100, sample_weight=None, description=""):
+    x_train, x_test, y_train, y_test = train_test_split(IRIS.data, IRIS.target, test_size=0.33, random_state=31)
 
-    scikit_model = ScikitRandomForestRegressor(n_estimators=n_estimators,
-                                               max_depth=None,
-                                               random_state=777)
-    daal4py_model = DaalRandomForestRegressor(n_estimators=n_estimators,
-                                              max_depth=None,
-                                              random_state=777)
+    scikit_model = ScikitRandomForestRegressor(n_estimators=n_estimators, max_depth=None, random_state=777)
+    daal4py_model = DaalRandomForestRegressor(n_estimators=n_estimators, max_depth=None, random_state=777)
 
-    scikit_predict = scikit_model.fit(
-        x_train, y_train,
-        sample_weight=sample_weight).predict(x_test)
-    daal4py_predict = daal4py_model.fit(
-        x_train, y_train,
-        sample_weight=sample_weight).predict(x_test)
+    scikit_predict = scikit_model.fit(x_train, y_train, sample_weight=sample_weight).predict(x_test)
+    daal4py_predict = daal4py_model.fit(x_train, y_train, sample_weight=sample_weight).predict(x_test)
 
     scikit_mse = mean_squared_error(scikit_predict, y_test)
     daal4py_mse = mean_squared_error(daal4py_predict, y_test)
@@ -181,18 +155,16 @@ def _compare_with_sklearn_mse_regressor_iris(n_estimators=100, sample_weight=Non
     assert ratio <= MSE_RATIO, reason
 
 
-@pytest.mark.parametrize('weight', SAMPLE_WEIGHTS_IRIS)
+@pytest.mark.parametrize("weight", SAMPLE_WEIGHTS_IRIS)
 def test_mse_regressor_sample_weight_iris(weight):
     sample_weight, description = weight
     _compare_with_sklearn_mse_regressor_iris(
-        sample_weight=sample_weight,
-        description=f"Regression sample weights: sample_weight_type={description}: "
+        sample_weight=sample_weight, description=f"Regression sample weights: sample_weight_type={description}: "
     )
 
 
-@pytest.mark.parametrize('n_estimators', N_ESTIMATORS_IRIS)
+@pytest.mark.parametrize("n_estimators", N_ESTIMATORS_IRIS)
 def test_mse_regressor_big_estimators_iris(n_estimators):
     _compare_with_sklearn_mse_regressor_iris(
-        n_estimators=n_estimators,
-        description=f"Regression: n_estimators={n_estimators}: "
+        n_estimators=n_estimators, description=f"Regression: n_estimators={n_estimators}: "
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+
 [tool.black]
 line-length = 90
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.black]
 line-length = 90
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+extend-ignore = 'E203'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-line-length = 120
+line-length = 90
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,8 @@
 license_files =
    LICENSE
    doc/daal4py/third-party-programs.txt
+
+[flake8]
+ignore = E265, E722, E402, F401, F403, W503
+max-line-length = 90
+count = true


### PR DESCRIPTION
* Provide `binningStrategy` and `maxBins=0` options
* Updated test cases for RF with tigther log loss ratio constraints (1.55 -> 1.15)
* Refactored RF classes: putting class methods back to class body (remove them from global module scope)
* Added `pyproject.toml` with instructions for `black` - formatted the files I touched

Because of the formatting changes, (`black` and `CLRF` to `LF`), the diff is very large. The individual contributions are provided in dedicated commits which might be easier to review.