### PR TITLE
sklearnex GPU CI updates

### DIFF
--- a/examples/daal4py/sycl/sklearn_sycl.py
+++ b/examples/daal4py/sycl/sklearn_sycl.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     if dpctl_available:
         devices.append(None)
         devices.append(dpctl.SyclQueue('cpu'))
-        if dpctl.has_gpu_devices:
+        if dpctl.has_gpu_devices():
             devices.append(dpctl.SyclQueue('gpu'))
 
     else:


### PR DESCRIPTION
# Description
Fixing dpctl has_gpu_devices to be function call (it is not an attribute so currently always returns true)
 
