### PR TITLE
FIX: Update incorrect documentation hyperlink

### DIFF
--- a/doc/sources/oneapi-gpu.rst
+++ b/doc/sources/oneapi-gpu.rst
@@ -48,7 +48,7 @@ Device offloading
 |intelex| offers two options for running an algorithm on a
 specific device with the help of dpctl:
 
-- Pass input data as `dpctl.tensor.usm_ndarray <https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#dpctl.tensor.usm_ndarray>`_ to the algorithm.
+- Pass input data as `dpctl.tensor.usm_ndarray <https://intelpython.github.io/dpctl/latest/docfiles/dpctl/usm_ndarray.html#dpctl.tensor.usm_ndarray>`_ to the algorithm.
 
   The computation will run on the device where the input data is
   located, and the result will be returned as :code:`usm_ndarray` to the same


### PR DESCRIPTION
# Description
The PR includes a fix for broken link found in the docs.

Changes proposed in this pull request:
- The original link, which is non-functional, can be accessed [here](https://intelpython.github.io/dpctl/latest/docfiles/dpctl.tensor_api.html#dpctl.tensor.usm_ndarray). 
- The correct working link can be found [here](https://intelpython.github.io/dpctl/latest/docfiles/dpctl/usm_ndarray.html#dpctl.tensor.usm_ndarray).

 
