### PR TITLE
DEP: deprecate `dpctx` using in examples

### DIFF
--- a/examples/daal4py/sycl/covariance_streaming.py
+++ b/examples/daal4py/sycl/covariance_streaming.py
@@ -27,16 +27,11 @@ sys.path.insert(0, '..')
 from stream import read_next
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # At this moment with sycl we are working only with numpy arrays
@@ -70,26 +65,9 @@ def main(readcsv=None, method='defaultDense'):
     # finalize computation
     result_classic = algo.finalize()
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             # configure a covariance object
             algo = d4p.covariance(streaming=True, fptype='float')
             # get the generator (defined in stream.py)...
@@ -105,7 +83,7 @@ def main(readcsv=None, method='defaultDense'):
         assert np.allclose(result_classic.correlation, result_gpu.correlation)
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         # configure a covariance object
         algo = d4p.covariance(streaming=True, fptype='float')
         # get the generator (defined in stream.py)...

--- a/examples/daal4py/sycl/dbscan_batch.py
+++ b/examples/daal4py/sycl/dbscan_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # At this moment with sycl we are working only with numpy arrays
@@ -89,26 +84,9 @@ def main(readcsv=read_csv, method='defaultDense'):
 
     data = to_numpy(data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data, minObservations, epsilon)
             assert np.allclose(result_classic.nClusters, result_gpu.nClusters)
@@ -117,7 +95,7 @@ def main(readcsv=read_csv, method='defaultDense'):
             assert np.allclose(result_classic.coreObservations,
                                result_gpu.coreObservations)
 
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_data = sycl_buffer(data)
         result_cpu = compute(sycl_data, minObservations, epsilon)
         assert np.allclose(result_classic.nClusters, result_cpu.nClusters)

--- a/examples/daal4py/sycl/decision_forest_classification_batch.py
+++ b/examples/daal4py/sycl/decision_forest_classification_batch.py
@@ -33,16 +33,11 @@ except Exception:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2, dtype=t)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except Exception:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except Exception:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -117,20 +112,9 @@ def main(readcsv=read_csv, method='defaultDense'):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/decision_forest_classification_hist_batch.py
+++ b/examples/daal4py/sycl/decision_forest_classification_hist_batch.py
@@ -33,16 +33,11 @@ except Exception:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2, dtype=t)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except Exception:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except Exception:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -119,20 +114,9 @@ def main(readcsv=read_csv):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/decision_forest_regression_batch.py
+++ b/examples/daal4py/sycl/decision_forest_regression_batch.py
@@ -33,16 +33,11 @@ except Exception:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2, dtype=t)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except Exception:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except Exception:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -109,20 +104,9 @@ def main(readcsv=read_csv, method='defaultDense'):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/decision_forest_regression_hist_batch.py
+++ b/examples/daal4py/sycl/decision_forest_regression_hist_batch.py
@@ -33,16 +33,11 @@ except Exception:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2, dtype=t)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except Exception:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except Exception:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -111,20 +106,9 @@ def main(readcsv=read_csv):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/gradient_boosted_regression_batch.py
+++ b/examples/daal4py/sycl/gradient_boosted_regression_batch.py
@@ -39,6 +39,7 @@ try:
 except:
     gpu_available = False
 
+
 # Commone code for both CPU and GPU computations
 def compute(train_indep_data, train_dep_data, test_indep_data, maxIterations):
     # Configure a training object

--- a/examples/daal4py/sycl/kmeans_batch.py
+++ b/examples/daal4py/sycl/kmeans_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -93,26 +88,9 @@ def main(readcsv=read_csv, method='randomDense'):
 
     data = to_numpy(data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data, nClusters, maxIter, method)
         assert np.allclose(result_classic.centroids, result_gpu.centroids)
@@ -121,7 +99,7 @@ def main(readcsv=read_csv, method='randomDense'):
                           result_gpu.objectiveFunction)
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_data = sycl_buffer(data)
         result_cpu = compute(sycl_data, nClusters, maxIter, method)
 

--- a/examples/daal4py/sycl/linear_regression_batch.py
+++ b/examples/daal4py/sycl/linear_regression_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -94,26 +89,9 @@ def main(readcsv=read_csv, method='defaultDense'):
     train_dep_data = to_numpy(train_dep_data)
     test_indep_data = to_numpy(test_indep_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_indep_data = sycl_buffer(train_indep_data)
             sycl_train_dep_data = sycl_buffer(train_dep_data)
             sycl_test_indep_data = sycl_buffer(test_indep_data)
@@ -122,7 +100,7 @@ def main(readcsv=read_csv, method='defaultDense'):
         assert np.allclose(result_classic.prediction, result_gpu.prediction, atol=1e-1)
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_train_indep_data = sycl_buffer(train_indep_data)
         sycl_train_dep_data = sycl_buffer(train_dep_data)
         sycl_test_indep_data = sycl_buffer(test_indep_data)

--- a/examples/daal4py/sycl/log_reg_binary_dense_batch.py
+++ b/examples/daal4py/sycl/log_reg_binary_dense_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -96,26 +91,9 @@ def main(readcsv=read_csv, method='defaultDense'):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)
@@ -126,7 +104,7 @@ def main(readcsv=read_csv, method='defaultDense'):
         assert np.mean(result_classic.prediction != result_gpu.prediction) < 0.2
 
     # It is possible to specify to make the computations on GPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_train_data = sycl_buffer(train_data)
         sycl_train_labels = sycl_buffer(train_labels)
         sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/log_reg_dense_batch.py
+++ b/examples/daal4py/sycl/log_reg_dense_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -100,26 +95,9 @@ def main(readcsv=read_csv, method='defaultDense'):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)
@@ -132,7 +110,7 @@ def main(readcsv=read_csv, method='defaultDense'):
                            result_gpu.logProbabilities, atol=1e-2)
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_train_data = sycl_buffer(train_data)
         sycl_train_labels = sycl_buffer(train_labels)
         sycl_predict_data = sycl_buffer(predict_data)

--- a/examples/daal4py/sycl/low_order_moms_dense_batch.py
+++ b/examples/daal4py/sycl/low_order_moms_dense_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -78,26 +73,9 @@ def main(readcsv=read_csv, method="defaultDense"):
 
     data = to_numpy(data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data, "defaultDense")
         for name in ['minimum', 'maximum', 'sum', 'sumSquares', 'sumSquaresCentered',
@@ -106,7 +84,7 @@ def main(readcsv=read_csv, method="defaultDense"):
             assert np.allclose(getattr(result_classic, name), getattr(result_gpu, name))
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_data = sycl_buffer(data)
         result_cpu = compute(sycl_data, "defaultDense")
 

--- a/examples/daal4py/sycl/pca_transform_batch.py
+++ b/examples/daal4py/sycl/pca_transform_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Commone code for both CPU and GPU computations
@@ -84,32 +79,16 @@ def main(readcsv=read_csv, method='svdDense'):
     result_classic = compute(data, nComponents)
 
     data = to_numpy(data)
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
 
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_data = sycl_buffer(data)
             result_gpu = compute(sycl_data, nComponents)
         assert np.allclose(result_classic.transformedData, result_gpu.transformedData)
 
     # It is possible to specify to make the computations on CPU
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_data = sycl_buffer(data)
         result_cpu = compute(sycl_data, nComponents)
 

--- a/examples/daal4py/sycl/svm_batch.py
+++ b/examples/daal4py/sycl/svm_batch.py
@@ -33,16 +33,11 @@ except ImportError:
         return np.loadtxt(f, usecols=c, delimiter=',', ndmin=2)
 
 try:
-    from dpctx import device_context, device_type
-    with device_context(device_type.gpu, 0):
+    from daal4py.oneapi import sycl_context
+    with sycl_context('gpu'):
         gpu_available = True
 except:
-    try:
-        from daal4py.oneapi import sycl_context
-        with sycl_context('gpu'):
-            gpu_available = True
-    except:
-        gpu_available = False
+    gpu_available = False
 
 
 # Common code for both CPU and GPU computations
@@ -106,26 +101,9 @@ def main(readcsv=read_csv):
     train_labels = to_numpy(train_labels)
     predict_data = to_numpy(predict_data)
 
-    try:
-        from dpctx import device_context, device_type
-
-        def gpu_context():
-            return device_context(device_type.gpu, 0)
-
-        def cpu_context():
-            return device_context(device_type.cpu, 0)
-    except:
-        from daal4py.oneapi import sycl_context
-
-        def gpu_context():
-            return sycl_context('gpu')
-
-        def cpu_context():
-            return sycl_context('cpu')
-
     # It is possible to specify to make the computations on GPU
     if gpu_available:
-        with gpu_context():
+        with sycl_context('gpu'):
             sycl_train_data = sycl_buffer(train_data)
             sycl_train_labels = sycl_buffer(train_labels)
             sycl_predict_data = sycl_buffer(predict_data)
@@ -134,7 +112,7 @@ def main(readcsv=read_csv):
                 compute(sycl_train_data, sycl_train_labels, sycl_predict_data, 'thunder')
             # assert np.allclose(predict_result_gpu, predict_result_classic)
 
-    with cpu_context():
+    with sycl_context('cpu'):
         sycl_train_data = sycl_buffer(train_data)
         sycl_predict_data = sycl_buffer(predict_data)
 


### PR DESCRIPTION
# Description
Deprecated using `dpctx` `device_context` in daal4py sycl examples.

Updates on `sycl_contex` and `config_context` will be considered on other PRs.
 
