### PR TITLE
Add constraints and rename patched sklearn functions

### DIFF
--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -101,7 +101,7 @@ def _get_n_samples_bootstrap(n_samples, max_samples):
             if max_samples > n_samples:
                 msg = "`max_samples` must be <= n_samples={} but got value {}"
                 raise ValueError(msg.format(n_samples, max_samples))
-        return float(max_samples / n_samples)
+        return max(float(max_samples / n_samples), 1 / n_samples)
 
     if isinstance(max_samples, numbers.Real):
         if sklearn_check_version("1.2"):
@@ -114,7 +114,7 @@ def _get_n_samples_bootstrap(n_samples, max_samples):
             if not (0 < float(max_samples) < 1):
                 msg = "`max_samples` must be in range (0, 1) but got value {}"
                 raise ValueError(msg.format(max_samples))
-        return float(max_samples)
+        return max(float(max_samples), 1 / n_samples)
 
     msg = "`max_samples` should be int or float, but got type '{}'"
     raise TypeError(msg.format(type(max_samples)))

--- a/daal4py/sklearn/metrics/__init__.py
+++ b/daal4py/sklearn/metrics/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-from ._ranking import _daal_roc_auc_score
-from ._pairwise import daal_pairwise_distances
+from ._ranking import roc_auc_score
+from ._pairwise import pairwise_distances
 
-__all__ = ['_daal_roc_auc_score', 'daal_pairwise_distances']
+__all__ = ['roc_auc_score', 'pairwise_distances']

--- a/daal4py/sklearn/metrics/_pairwise.py
+++ b/daal4py/sklearn/metrics/_pairwise.py
@@ -55,7 +55,7 @@ def _daal4py_correlation_distance_dense(X):
 
 @support_usm_ndarray(freefunc=True)
 def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
-                            force_all_finite=True, **kwds):
+                       force_all_finite=True, **kwds):
     """ Compute the distance matrix from a vector array X and optional Y.
 
     This method takes either a vector array or a distance matrix, and returns

--- a/daal4py/sklearn/metrics/_pairwise.py
+++ b/daal4py/sklearn/metrics/_pairwise.py
@@ -54,7 +54,7 @@ def _daal4py_correlation_distance_dense(X):
 
 
 @support_usm_ndarray(freefunc=True)
-def daal_pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
+def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
                             force_all_finite=True, **kwds):
     """ Compute the distance matrix from a vector array X and optional Y.
 

--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -181,6 +181,7 @@ def roc_auc_score(
         sample_weight=sample_weight,
     )
 
+
 if sklearn_check_version('1.3'):
     roc_auc_score = validate_params(
         {

--- a/daal4py/sklearn/metrics/_ranking.py
+++ b/daal4py/sklearn/metrics/_ranking.py
@@ -24,7 +24,7 @@ from sklearn.utils import check_array
 from sklearn.utils.multiclass import is_multilabel
 from sklearn.preprocessing import label_binarize
 
-from ..utils.validation import _daal_assert_all_finite
+from ..utils.validation import _assert_all_finite
 from .._utils import get_patch_message, sklearn_check_version, PatchingConditionsChain
 from .._device_offload import support_usm_ndarray
 import logging
@@ -36,6 +36,10 @@ if sklearn_check_version('0.22'):
     from sklearn.metrics._base import _average_binary_score
 else:
     from sklearn.metrics.ranking import roc_auc_score as multiclass_roc_auc_score
+
+if sklearn_check_version('1.3'):
+    from sklearn.utils._param_validation import (
+        validate_params, Interval, Real, StrOptions)
 
 try:
     import pandas as pd
@@ -96,7 +100,7 @@ def _daal_type_of_target(y):
     # check float and contains non-integer float values
     if y.dtype.kind == 'f' and np.any(y != y.astype(int)):
         # [.1, .2, 3] or [[.1, .2, 3]] or [[1., .2]] and not [1., 2., 3.]
-        _daal_assert_all_finite(y)
+        _assert_all_finite(y)
         return 'continuous' + suffix
 
     unique = np.sort(
@@ -112,7 +116,7 @@ def _daal_type_of_target(y):
 
 
 @support_usm_ndarray(freefunc=True)
-def _daal_roc_auc_score(
+def roc_auc_score(
     y_true,
     y_score,
     *,
@@ -176,3 +180,16 @@ def _daal_roc_auc_score(
         average,
         sample_weight=sample_weight,
     )
+
+if sklearn_check_version('1.3'):
+    roc_auc_score = validate_params(
+        {
+            "y_true": ["array-like"],
+            "y_score": ["array-like"],
+            "average": [StrOptions({"micro", "macro", "samples", "weighted"}), None],
+            "sample_weight": ["array-like", None],
+            "max_fpr": [Interval(Real, 0.0, 1, closed="right"), None],
+            "multi_class": [StrOptions({"raise", "ovr", "ovo"})],
+            "labels": ["array-like", None],
+        }
+    )(roc_auc_score)

--- a/daal4py/sklearn/model_selection/__init__.py
+++ b/daal4py/sklearn/model_selection/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #===============================================================================
 
-from ._split import _daal_train_test_split
+from ._split import train_test_split
 
-__all__ = ['_daal_train_test_split']
+__all__ = ['train_test_split']

--- a/daal4py/sklearn/model_selection/tests/test_split.py
+++ b/daal4py/sklearn/model_selection/tests/test_split.py
@@ -17,7 +17,7 @@
 import numpy as np
 import pytest
 from sklearn.model_selection import train_test_split as skl_train_test_split
-from daal4py.sklearn.model_selection import _daal_train_test_split as d4p_train_test_split
+from daal4py.sklearn.model_selection import train_test_split as d4p_train_test_split
 from daal4py.sklearn._utils import daal_check_version
 from sklearn.datasets import make_classification
 

--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -18,13 +18,13 @@ from daal4py.sklearn._utils import set_idp_sklearn_verbose
 from ..neighbors import KNeighborsRegressor as KNeighborsRegressor_daal4py
 from ..neighbors import NearestNeighbors as NearestNeighbors_daal4py
 from ..neighbors import KNeighborsClassifier as KNeighborsClassifier_daal4py
-from ..model_selection import _daal_train_test_split
-from ..utils.validation import _daal_assert_all_finite
+from ..model_selection import train_test_split
+from ..utils.validation import _assert_all_finite
 from ..svm.svm import SVC as SVC_daal4py
 from ..ensemble._forest import RandomForestClassifier as RandomForestClassifier_daal4py
 from ..ensemble._forest import RandomForestRegressor as RandomForestRegressor_daal4py
-from ..metrics import _daal_roc_auc_score
-from ..metrics import daal_pairwise_distances
+from ..metrics import roc_auc_score
+from ..metrics import pairwise_distances
 from ..cluster.k_means import KMeans as KMeans_daal4py
 from ..cluster.dbscan import DBSCAN as DBSCAN_daal4py
 from ..linear_model.coordinate_descent import Lasso as Lasso_daal4py
@@ -60,7 +60,7 @@ def _get_map_of_algorithms():
         'pca': [[(decomposition_module, 'PCA', PCA_daal4py), None]],
         'kmeans': [[(cluster_module, 'KMeans', KMeans_daal4py), None]],
         'dbscan': [[(cluster_module, 'DBSCAN', DBSCAN_daal4py), None]],
-        'distances': [[(metrics, 'pairwise_distances', daal_pairwise_distances), None]],
+        'distances': [[(metrics, 'pairwise_distances', pairwise_distances), None]],
         'linear': [[(linear_model_module, 'LinearRegression',
                      LinearRegression_daal4py), None]],
         'ridge': [[(linear_model_module, 'Ridge', Ridge_daal4py), None]],
@@ -82,11 +82,11 @@ def _get_map_of_algorithms():
         'random_forest_regressor': [[(ensemble_module, 'RandomForestRegressor',
                                       RandomForestRegressor_daal4py), None]],
         'train_test_split': [[(model_selection, 'train_test_split',
-                               _daal_train_test_split), None]],
+                               train_test_split), None]],
         'fin_check': [[(validation, '_assert_all_finite',
-                        _daal_assert_all_finite), None]],
+                        _assert_all_finite), None]],
         'roc_auc_score': [[(metrics, 'roc_auc_score',
-                           _daal_roc_auc_score), None]],
+                           roc_auc_score), None]],
         'tsne': [[(manifold_module, 'TSNE', TSNE_daal4py), None]],
     }
     mapping['svc'] = mapping['svm']

--- a/daal4py/sklearn/utils/__init__.py
+++ b/daal4py/sklearn/utils/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-from .validation import _daal_assert_all_finite
+from .validation import _assert_all_finite
 
-__all__ = ['_daal_assert_all_finite', '_daal_check_array', '_daal_check_X_y',
+__all__ = ['_assert_all_finite', '_daal_check_array', '_daal_check_X_y',
            '_daal_validate_data']

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -32,7 +32,7 @@ from .._utils import (is_DataFrame, get_dtype, get_number_of_types,
 
 
 def _assert_all_finite(X, allow_nan=False, msg_dtype=None,
-                            estimator_name=None, input_name=""):
+                       estimator_name=None, input_name=""):
     if _get_config()['assume_finite']:
         return
 

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -24,13 +24,14 @@ import scipy.sparse as sp
 from numpy.core.numeric import ComplexWarning
 from sklearn.utils.validation import (_num_samples, _ensure_no_complex_data,
                                       _ensure_sparse_format, column_or_1d,
-                                      check_consistent_length, _assert_all_finite)
+                                      check_consistent_length)
+from sklearn.utils.validation import _assert_all_finite as _sklearn_assert_all_finite
 from sklearn.utils.extmath import _safe_accumulator_op
 from .._utils import (is_DataFrame, get_dtype, get_number_of_types,
                       sklearn_check_version, PatchingConditionsChain)
 
 
-def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
+def _assert_all_finite(X, allow_nan=False, msg_dtype=None,
                             estimator_name=None, input_name=""):
     if _get_config()['assume_finite']:
         return
@@ -40,10 +41,11 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
     if hasattr(X, 'size'):
         if X.size < 32768:
             if sklearn_check_version("1.1"):
-                _assert_all_finite(X, allow_nan=allow_nan, msg_dtype=msg_dtype,
-                                   estimator_name=estimator_name, input_name=input_name)
+                _sklearn_assert_all_finite(X, allow_nan=allow_nan, msg_dtype=msg_dtype,
+                                           estimator_name=estimator_name,
+                                           input_name=input_name)
             else:
-                _assert_all_finite(X, allow_nan=allow_nan, msg_dtype=msg_dtype)
+                _sklearn_assert_all_finite(X, allow_nan=allow_nan, msg_dtype=msg_dtype)
             return
 
     is_df = is_DataFrame(X)
@@ -106,7 +108,7 @@ def _daal_assert_all_finite(X, allow_nan=False, msg_dtype=None,
 def _pandas_check_array(array, array_orig, force_all_finite, ensure_min_samples,
                         ensure_min_features, copy, context):
     if force_all_finite:
-        _daal_assert_all_finite(array, allow_nan=force_all_finite == 'allow-nan')
+        _assert_all_finite(array, allow_nan=force_all_finite == 'allow-nan')
 
     if ensure_min_samples > 0:
         n_samples = _num_samples(array)
@@ -333,8 +335,8 @@ def _daal_check_array(array, accept_sparse=False, *, accept_large_sparse=True,
                     # then conversion float -> int would be disallowed.
                     array = np.asarray(array, order=order)
                     if array.dtype.kind == 'f':
-                        _daal_assert_all_finite(array, allow_nan=False,
-                                                msg_dtype=dtype)
+                        _assert_all_finite(array, allow_nan=False,
+                                           msg_dtype=dtype)
                     array = array.astype(dtype, casting="unsafe", copy=False)
                 else:
                     array = np.asarray(array, order=order, dtype=dtype)
@@ -383,8 +385,7 @@ def _daal_check_array(array, accept_sparse=False, *, accept_large_sparse=True,
                              % (array.ndim, estimator_name))
 
         if force_all_finite:
-            _daal_assert_all_finite(array,
-                                    allow_nan=force_all_finite == 'allow-nan')
+            _assert_all_finite(array, allow_nan=force_all_finite == 'allow-nan')
 
     if ensure_min_samples > 0:
         n_samples = _num_samples(array)
@@ -529,7 +530,7 @@ def _daal_check_X_y(X, y, accept_sparse=False, *, accept_large_sparse=True,
                               ensure_2d=False, dtype=None)
     else:
         y = column_or_1d(y, warn=True)
-        _daal_assert_all_finite(y)
+        _assert_all_finite(y)
     if y_numeric and hasattr(y, 'dtype') and y.dtype.kind == 'O':
         y = y.astype(np.float64)
 

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -22,7 +22,7 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_array
 from collections.abc import Sequence
 from numbers import Integral
-from daal4py.sklearn.utils.validation import _daal_assert_all_finite as assert_all_finite
+from daal4py.sklearn.utils.validation import _assert_all_finite
 
 
 class DataConversionWarning(UserWarning):
@@ -106,10 +106,10 @@ def _check_array(array, dtype="numeric", accept_sparse=False, order=None,
     if force_all_finite:
         if sp.issparse(array):
             if hasattr(array, 'data'):
-                assert_all_finite(array.data)
+                _assert_all_finite(array.data)
                 force_all_finite = False
         else:
-            assert_all_finite(array)
+            _assert_all_finite(array)
             force_all_finite = False
     array = check_array(
         array=array,
@@ -160,7 +160,7 @@ def _check_X_y(
         y = _column_or_1d(y, warn=True)
     if y_numeric and y.dtype.kind == 'O':
         y = y.astype(np.float64)
-    assert_all_finite(y)
+    _assert_all_finite(y)
 
     lengths = [X.shape[0], y.shape[0]]
     uniques = np.unique(lengths)
@@ -233,7 +233,7 @@ def _type_of_target(y):
     # check float and contains non-integer float values
     if y.dtype.kind == 'f' and np.any(y != y.astype(int)):
         # [.1, .2, 3] or [[.1, .2, 3]] or [[1., .2]] and not [1., 2., 3.]
-        assert_all_finite(y)
+        _assert_all_finite(y)
         return 'continuous' + suffix
 
     if (len(np.unique(y)) > 2) or (y.ndim >= 2 and len(y[0]) > 1):

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -154,7 +154,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
                 if max_samples > n_samples:
                     msg = "`max_samples` must be <= n_samples={} but got value {}"
                     raise ValueError(msg.format(n_samples, max_samples))
-            return float(max_samples / n_samples)
+            return max(float(max_samples / n_samples), 1 / n_samples)
 
         if isinstance(max_samples, numbers.Real):
             if sklearn_check_version('1.2'):
@@ -167,7 +167,7 @@ class BaseForest(BaseEnsemble, metaclass=ABCMeta):
                 if not (0 < float(max_samples) < 1):
                     msg = "`max_samples` must be in range (0, 1) but got value {}"
                     raise ValueError(msg.format(max_samples))
-            return float(max_samples)
+            return max(float(max_samples), 1 / n_samples)
 
         msg = "`max_samples` should be int or float, but got type '{}'"
         raise TypeError(msg.format(type(max_samples)))

--- a/sklearnex/metrics/pairwise.py
+++ b/sklearnex/metrics/pairwise.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 #===============================================================================
 
-from daal4py.sklearn.metrics import daal_pairwise_distances as pairwise_distances
+from daal4py.sklearn.metrics import pairwise_distances

--- a/sklearnex/metrics/ranking.py
+++ b/sklearnex/metrics/ranking.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 #===============================================================================
 
-from daal4py.sklearn.metrics import _daal_roc_auc_score as roc_auc_score
+from daal4py.sklearn.metrics import roc_auc_score

--- a/sklearnex/model_selection/split.py
+++ b/sklearnex/model_selection/split.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 #===============================================================================
 
-from daal4py.sklearn.model_selection import _daal_train_test_split as train_test_split
+from daal4py.sklearn.model_selection import train_test_split

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -23,7 +23,7 @@ if daal_check_version((2023, 'P', 100)):
     from ._common import BaseLinearRegression
     from ..._device_offload import dispatch, wrap_output_data
 
-    from ...utils.validation import assert_all_finite
+    from ...utils.validation import _assert_all_finite
     from daal4py.sklearn._utils import (
         get_dtype, make2d, sklearn_check_version, PatchingConditionsChain)
     from sklearn.linear_model import LinearRegression as sklearn_LinearRegression
@@ -148,7 +148,7 @@ if daal_check_version((2023, 'P', 100)):
                 return False
 
             try:
-                assert_all_finite(X)
+                _assert_all_finite(X)
             except BaseException:
                 return False
             return True

--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -19,7 +19,7 @@ import types
 import tracemalloc
 from sklearnex import get_patch_map
 from sklearnex.model_selection import train_test_split
-from sklearnex.utils import assert_all_finite
+from sklearnex.utils import _assert_all_finite
 from sklearnex.metrics import pairwise_distances, roc_auc_score
 from sklearnex.preview.decomposition import PCA as PreviewPCA
 from sklearnex.preview.linear_model import LinearRegression as PreviewLinearRegression
@@ -52,8 +52,8 @@ class FiniteCheckEstimator:
         pass
 
     def fit(self, x, y):
-        assert_all_finite(x)
-        assert_all_finite(y)
+        _assert_all_finite(x)
+        _assert_all_finite(y)
 
 
 class PairwiseDistancesEstimator:

--- a/sklearnex/utils/__init__.py
+++ b/sklearnex/utils/__init__.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 #===============================================================================
 
-from .validation import assert_all_finite
+from .validation import _assert_all_finite
 
-__all__ = ['assert_all_finite']
+__all__ = ['_assert_all_finite']

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 #===============================================================================
 
-from daal4py.sklearn.utils.validation import _daal_assert_all_finite as assert_all_finite
+from daal4py.sklearn.utils.validation import _assert_all_finite


### PR DESCRIPTION
Changes:
- Add parameter constraints from sklearn 1.3 for applicable patched function: `roc_auc_score` and `train_test_split`
- Rename patched functions to corresponding sklearn names (for example, `_daal_assert_all_finite -> _assert_all_finite`)
- Fix for too low max_samples in ensemble