### PR TITLE
Remove check for NAN for GBT Estimators

### DIFF
--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -69,9 +69,15 @@ def _restore_from_saved(md, saved_dict):
         setattr(md, check_f, saved_dict[check_f])
 
 
+def _check_estimator(estimator, skip_list):
+    checks = check_estimator(estimator, generate_only=True)
+    for (estimator, check) in checks:
+        if check.func.__name__ not in skip_list:
+            check(estimator)
+
 class Test(unittest.TestCase):
     def test_GBTDAALClassifier(self):
-        check_estimator(GBTDAALClassifier())
+        _check_estimator(GBTDAALClassifier(), skip_list="check_estimators_nan_inf")
 
     def test_GBTDAALRegressor(self):
         def dummy(*args, **kwargs):
@@ -81,7 +87,7 @@ class Test(unittest.TestCase):
         # got unexpected slightly different
         # prediction result between two same calls in this test
         saved = _replace_and_save(md, ['check_estimators_data_not_an_array'], dummy)
-        check_estimator(GBTDAALRegressor())
+        _check_estimator(GBTDAALRegressor(), skip_list="check_estimators_nan_inf")
         _restore_from_saved(md, saved)
 
     def test_AdaBoostClassifier(self):

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -75,6 +75,7 @@ def _check_estimator(estimator, skip_list):
         if check.func.__name__ not in skip_list:
             check(estimator)
 
+
 class Test(unittest.TestCase):
     def test_GBTDAALClassifier(self):
         _check_estimator(GBTDAALClassifier(), skip_list="check_estimators_nan_inf")


### PR DESCRIPTION
# Description
Faced with this problem, while worked on https://github.com/intel/scikit-learn-intelex/pull/1320
Checking for NAN is required for sklearn-style estimators. However GBT DAAL inference [support missing values](https://github.com/intel/scikit-learn-intelex/pull/1276) in form of NAN. Thus, I suggest removing the corresponding check from `test_estimator.py`.

See also the related issues for XGBoost estimators: [[1](https://github.com/dmlc/xgboost/issues/3580), [2](https://github.com/dmlc/xgboost/issues/5641)].

 
