### PR TITLE
addressing alias mapping gaps

### DIFF
--- a/daal4py/sklearn/monkeypatch/dispatcher.py
+++ b/daal4py/sklearn/monkeypatch/dispatcher.py
@@ -94,8 +94,13 @@ def _get_map_of_algorithms():
     mapping['kneighborsclassifier'] = mapping['knn_classifier']
     mapping['nearestneighbors'] = mapping['nearest_neighbors']
     mapping['kneighborsregressor'] = mapping['knn_regressor']
-    mapping['randomrorestclassifier'] = mapping['random_forest_classifier']
+    mapping['randomforestclassifier'] = mapping['random_forest_classifier']
     mapping['randomforestregressor'] = mapping['random_forest_regressor']
+    mapping["linearregression"] = mapping["linear"]
+    mapping["logisticregression"] = mapping["log_reg"]
+    mapping["_logistic_regression_path"] = mapping["logistic"]
+    mapping["_assert_all_finite"] = mapping["fin_check"]
+    mapping["pairwise_distances"] = mapping["distances"]
     return mapping
 
 

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -75,6 +75,8 @@ def get_patch_map():
         # Patch for mapping
         if _is_preview_enabled():
             # Ensemble
+            mapping.pop("extratreesclassifier")
+            mapping.pop("extratreesregressor")
             mapping["extra_trees_classifier"] = [[(ensemble_module,
                                                    "ExtraTreesClassifier",
                                                    ExtraTreesClassifier_sklearnex),
@@ -83,10 +85,11 @@ def get_patch_map():
                                                   "ExtraTreesRegressor",
                                                   ExtraTreesRegressor_sklearnex),
                                                  None]]
-
+            mapping["extratreesclassifier"] = mapping["extra_trees_classifier"]
+            mapping["extratreesregressor"] = mapping["extra_trees_regressor"]
             mapping.pop("random_forest_classifier")
             mapping.pop("random_forest_regressor")
-            mapping.pop("randomrorestclassifier")
+            mapping.pop("randomforestclassifier")
             mapping.pop("randomforestregressor")
             mapping["random_forest_classifier"] = [
                 [
@@ -117,6 +120,7 @@ def get_patch_map():
 
             # Linear Regression
             mapping.pop("linear")
+            mapping.pop("linearregression")
             mapping["linear"] = [
                 [
                     (
@@ -127,6 +131,7 @@ def get_patch_map():
                     None,
                 ]
             ]
+            mapping["linearregression"] = mapping["linear"]
 
             # KMeans
             mapping.pop("kmeans")

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -75,8 +75,6 @@ def get_patch_map():
         # Patch for mapping
         if _is_preview_enabled():
             # Ensemble
-            mapping.pop("extratreesclassifier")
-            mapping.pop("extratreesregressor")
             mapping["extra_trees_classifier"] = [[(ensemble_module,
                                                    "ExtraTreesClassifier",
                                                    ExtraTreesClassifier_sklearnex),


### PR DESCRIPTION
# Description
Fix for https://stackoverflow.com/questions/76430760/does-sklearnex-sklearn-intel-extension-really-support-linear-regression
Mapping of algorithm names accepted in patch function doesn't align with scikit-learn naming of those functions 
 
