### PR TITLE
Update CI and Nightly matrix for sklearn testing

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -37,12 +37,9 @@ pr:
     - .ci/pipeline/docs.yml
 
 variables:
-  - name: MACOSX_DEPLOYMENT_TARGET
-    value: '10.15'
-  - name: 'PYTHON'
-    value: python
-  - name: 'ARGS'
-    value: '1'
+  MACOSX_DEPLOYMENT_TARGET: '10.15'
+  PYTHON: 'python'
+  ARGS: '1'
 
 jobs:
 - job: PEP8
@@ -63,20 +60,17 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
+      Python3.7_Sklearn0.24:
         PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
-      Python3.8_Sklearn0.24:
-        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
+      Python3.8_Sklearn1.0:
+        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
+      Python3.9_Sklearn1.1:
+        PYTHON_VERSION: '3.9'
         SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
+      Python3.10_Sklearn1.2:
+        PYTHON_VERSION: '3.10'
         SKLEARN_VERSION: '1.2'
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
@@ -89,20 +83,17 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
+      Python3.7_Sklearn0.24:
         PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
-      Python3.8_Sklearn0.24:
-        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
+      Python3.8_Sklearn1.0:
+        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
+      Python3.9_Sklearn1.1:
+        PYTHON_VERSION: '3.9'
         SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
+      Python3.10_Sklearn1.2:
+        PYTHON_VERSION: '3.10'
         SKLEARN_VERSION: '1.2'
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
@@ -115,20 +106,17 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.7_Sklearn1.0:
+      Python3.7_Sklearn0.24:
         PYTHON_VERSION: '3.7'
-        SKLEARN_VERSION: '1.0'
-      Python3.8_Sklearn0.24:
-        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '0.24'
-      Python3.9_Sklearn1.0:
-        PYTHON_VERSION: '3.9'
+      Python3.8_Sklearn1.0:
+        PYTHON_VERSION: '3.8'
         SKLEARN_VERSION: '1.0'
-      Python3.10_Sklearn1.1:
-        PYTHON_VERSION: '3.10'
+      Python3.9_Sklearn1.1:
+        PYTHON_VERSION: '3.9'
         SKLEARN_VERSION: '1.1'
-      Python3.11_Sklearn1.2:
-        PYTHON_VERSION: '3.11'
+      Python3.10_Sklearn1.2:
+        PYTHON_VERSION: '3.10'
         SKLEARN_VERSION: '1.2'
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -40,7 +40,6 @@ variables:
   MACOSX_DEPLOYMENT_TARGET: '10.15'
   PYTHON: 'python'
   ARGS: '1'
-  SELECTED_TESTS: 'all'
 
 jobs:
 - job: PEP8

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -40,6 +40,7 @@ variables:
   MACOSX_DEPLOYMENT_TARGET: '10.15'
   PYTHON: 'python'
   ARGS: '1'
+  SELECTED_TESTS: 'all'
 
 jobs:
 - job: PEP8

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -85,8 +85,8 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.10_SklearnMain:
-        PYTHON_VERSION: '3.10'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'ubuntu-22.04'
@@ -96,8 +96,8 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.10_SklearnMain:
-        PYTHON_VERSION: '3.10'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'macos-12'
@@ -109,8 +109,8 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.10_SklearnMain:
-        PYTHON_VERSION: '3.10'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'windows-latest'


### PR DESCRIPTION
Change Python and sklearn versions in CI matrix:

| Python version | Sklearn version |
| - | - |
| 3.7 | 0.24 |
| 3.8 | 1.0 |
| 3.9 | 1.1 |
| 3.10 | 1.2 |
| 3.11 | 1.3 |

Update Python version to 3.11 in Nightly job