### PR TITLE
Fix inference for xgboost fitted with early-stopping

### DIFF
--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -152,7 +152,8 @@ def get_gbt_model_from_xgboost(booster: Any) -> Any:
     else:
         is_regression = True
 
-    n_iterations = int(len(trees_arr) / (n_classes if n_classes > 2 else 1))
+    n_iterations = booster.best_ntree_limit
+    trees_arr = trees_arr[: n_iterations * (n_classes if n_classes > 2 else 1)]
 
     # Create + base iteration
     if is_regression:

--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -152,7 +152,7 @@ def get_gbt_model_from_xgboost(booster: Any) -> Any:
     else:
         is_regression = True
 
-    n_iterations = booster.best_ntree_limit
+    n_iterations = booster.best_iteration + 1
     trees_arr = trees_arr[: n_iterations * (n_classes if n_classes > 2 else 1)]
 
     # Create + base iteration


### PR DESCRIPTION
# Description
Earlier there was a difference in results between xgboost predictions and predictions of our modelbuilder if xgboost was fitted using early-stopping parameter. This pull request is to fix this issue

 
