### PR TITLE
MAINT: removed undisposible, unnecessary onedal module helpers

### DIFF
--- a/onedal/basic_statistics/basic_statistics.py
+++ b/onedal/basic_statistics/basic_statistics.py
@@ -73,8 +73,10 @@ class BaseBasicStatistics(metaclass=ABCMeta):
     def _compute(self, data, weights, module, queue):
         policy = self._get_policy(queue, data, weights)
 
-        data = np.asarray(data)
-        weights = np.asarray(weights)
+        if data:
+            data = np.asarray(data)
+        if weights:
+            weights = np.asarray(weights)
 
         data, weights = _convert_to_supported(
             policy, data, weights)

--- a/onedal/basic_statistics/basic_statistics.py
+++ b/onedal/basic_statistics/basic_statistics.py
@@ -73,9 +73,9 @@ class BaseBasicStatistics(metaclass=ABCMeta):
     def _compute(self, data, weights, module, queue):
         policy = self._get_policy(queue, data, weights)
 
-        if data:
+        if not (data is None):
             data = np.asarray(data)
-        if weights:
+        if not (weights is None):
             weights = np.asarray(weights)
 
         data, weights = _convert_to_supported(

--- a/onedal/basic_statistics/basic_statistics.py
+++ b/onedal/basic_statistics/basic_statistics.py
@@ -74,14 +74,15 @@ class BaseBasicStatistics(metaclass=ABCMeta):
     def _compute(self, data, weights, module, queue):
         policy = self._get_policy(queue, data, weights)
 
-        data_loc, weights_loc = _convert_to_dataframe(policy, data, weights)
+        data = np.asarray(data)
+        weights = np.asarray(weights)
 
-        data_loc, weights_loc = _convert_to_supported(
-            policy, data_loc, weights_loc)
+        data, weights = _convert_to_supported(
+            policy, data, weights)
 
-        data_table, weights_table = to_table(data_loc, weights_loc)
+        data_table, weights_table = to_table(data, weights)
 
-        dtype = data_loc.dtype
+        dtype = data.dtype
         res = self._compute_raw(data_table, weights_table,
                                 module, policy, dtype)
 

--- a/onedal/basic_statistics/basic_statistics.py
+++ b/onedal/basic_statistics/basic_statistics.py
@@ -25,8 +25,7 @@ from ..common._policy import _get_policy
 from ..datatypes._data_conversion import (
     from_table,
     to_table,
-    _convert_to_supported,
-    _convert_to_dataframe)
+    _convert_to_supported)
 from onedal import _backend
 
 

--- a/onedal/datatypes/__init__.py
+++ b/onedal/datatypes/__init__.py
@@ -26,7 +26,6 @@ from .validation import (
     _check_n_features,
     _num_features,
     _num_samples,
-    _get_2d_shape,
     _is_arraylike,
     _is_arraylike_not_scalar
 )
@@ -37,5 +36,5 @@ __all__ = ['_column_or_1d', '_validate_targets', '_check_X_y',
            '_check_array', '_check_classification_targets',
            '_type_of_target', '_is_integral_float',
            '_is_multilabel', '_check_n_features', '_num_features',
-           '_num_samples', '_get_2d_shape', '_convert_to_supported',
+           '_num_samples', '_convert_to_supported',
            '_is_arraylike', '_is_arraylike_not_scalar']

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -85,19 +85,3 @@ else:
             return x
 
         return _apply_and_pass(func, *data)
-
-
-#TODO: Update with dpctl
-#For now it will fall back to numpy
-def _convert_one_to_dataframe(policy, x):
-    is_numpy = isinstance(x, np.ndarray)
-    if (x is None) or is_numpy:
-        return x
-    else:
-        return np.asarray(x)
-
-
-def _convert_to_dataframe(policy, *data):
-    def _convert_one(x):
-        return _convert_one_to_dataframe(policy, x)
-    return _apply_and_pass(_convert_one, *data)

--- a/onedal/datatypes/validation.py
+++ b/onedal/datatypes/validation.py
@@ -382,9 +382,3 @@ def _num_samples(x):
         return len(x)
     except TypeError as type_error:
         raise TypeError(message) from type_error
-
-
-def _get_2d_shape(x, fallback_1d=True):
-    n_samples = _num_samples(x)
-    n_features = _num_features(x, fallback_1d)
-    return (n_samples, n_features)

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -25,7 +25,6 @@ from ..datatypes import (
     _check_X_y,
     _num_features,
     _check_array,
-    _get_2d_shape,
     _check_n_features,
     _convert_to_supported)
 

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -36,7 +36,7 @@ if daal_check_version((2023, 'P', 100)):
     from scipy.sparse import issparse
 
     from onedal.linear_model import LinearRegression as onedal_LinearRegression
-    from onedal.datatypes import (_num_samples, _get_2d_shape)
+    from onedal.datatypes import (_num_features, _num_samples)
 
     class LinearRegression(sklearn_LinearRegression, BaseLinearRegression):
         __doc__ = sklearn_LinearRegression.__doc__
@@ -166,7 +166,9 @@ if daal_check_version((2023, 'P', 100)):
                 and self.normalize != 'deprecated'
             positive_is_set = hasattr(self, 'positive') and self.positive
 
-            n_samples, n_features = _get_2d_shape(X, fallback_1d=True)
+            n_samples = _num_samples(X)
+            n_features = _num_features(X, fallback_1d=True)
+
             # Check if equations are well defined
             is_good_for_onedal = n_samples > \
                 (n_features + int(self.fit_intercept))


### PR DESCRIPTION
# Description
Refactor `onedal` modul helpers. Removing undisposible, unnecsary onedal module helpers. This functions are not scikit-learn-like and are rarely/not used.
* removed `_get_2d_shape`
* removed `_convert_to_dataframe`

 
