### PR TITLE
kd_tree kNN metrics fix

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -75,9 +75,6 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -101,9 +98,6 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'macos-12'
   steps:
@@ -127,9 +121,6 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'windows-latest'
   steps:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -75,6 +75,9 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -98,6 +101,9 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'macos-12'
   steps:
@@ -121,6 +127,9 @@ jobs:
       Python3.11_Sklearn1.3:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: '1.3'
+      Python3.11_SklearnMain:
+        PYTHON_VERSION: '3.11'
+        SKLEARN_VERSION: 'main'
   pool:
     vmImage: 'windows-latest'
   steps:

--- a/daal4py/sklearn/neighbors/_base.py
+++ b/daal4py/sklearn/neighbors/_base.py
@@ -31,21 +31,14 @@ from sklearn.base import is_classifier, is_regressor
 import logging
 import warnings
 
-if sklearn_check_version("0.22"):
-    from sklearn.neighbors._base import KNeighborsMixin as BaseKNeighborsMixin
-    from sklearn.neighbors._base import RadiusNeighborsMixin as BaseRadiusNeighborsMixin
-    from sklearn.neighbors._base import NeighborsBase as BaseNeighborsBase
-    from sklearn.neighbors._ball_tree import BallTree
-    from sklearn.neighbors._kd_tree import KDTree
-    if not sklearn_check_version("1.2"):
-        from sklearn.neighbors._base import _check_weights
-else:
-    from sklearn.neighbors.base import KNeighborsMixin as BaseKNeighborsMixin
-    from sklearn.neighbors.base import RadiusNeighborsMixin as BaseRadiusNeighborsMixin
-    from sklearn.neighbors.base import NeighborsBase as BaseNeighborsBase
-    from sklearn.neighbors.ball_tree import BallTree
-    from sklearn.neighbors.kd_tree import KDTree
-    from sklearn.neighbors.base import _check_weights
+from sklearn.neighbors._base import KNeighborsMixin as BaseKNeighborsMixin
+from sklearn.neighbors._base import RadiusNeighborsMixin as BaseRadiusNeighborsMixin
+from sklearn.neighbors._base import NeighborsBase as BaseNeighborsBase
+from sklearn.neighbors._ball_tree import BallTree
+from sklearn.neighbors._kd_tree import KDTree
+from sklearn.neighbors import VALID_METRICS
+if not sklearn_check_version("1.2"):
+    from sklearn.neighbors._base import _check_weights
 
 
 def training_algorithm(method, fptype, params):
@@ -78,9 +71,7 @@ def parse_auto_method(estimator, method, n_samples, n_features):
         if estimator.metric == 'precomputed' or n_features > 11 or condition:
             result_method = 'brute'
         else:
-            kdtree_valid_metrics = KDTree.valid_metrics() \
-                if sklearn_check_version('1.3') else KDTree.valid_metrics
-            if estimator.effective_metric_ in kdtree_valid_metrics:
+            if estimator.effective_metric_ in VALID_METRICS['kd_tree']:
                 result_method = 'kd_tree'
             else:
                 result_method = 'brute'


### PR DESCRIPTION
Changes:
- Use `sklearn.neighbors.VALID_METRICS['kd_tree']` instead of `sklearn.neighbors.KDTree.valid_metrics` for better compatibility and fix metrics on sklearn 1.4
- Remove imports for older unsupported sklearn versions