### PR TITLE
FIX: changing RF regressor default train method

### DIFF
--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -53,7 +53,6 @@ from ..utils import (
 from onedal import _backend
 
 from sklearn.ensemble import BaseEnsemble
-from sklearn.tree import DecisionTreeClassifier
 
 
 class BaseForest(BaseEnsemble, metaclass=ABCMeta):
@@ -536,7 +535,7 @@ class RandomForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
                  voting_mode='weighted',
                  error_metric_mode='none',
                  variable_importance_mode='none',
-                 algorithm='dense',
+                 algorithm='hist',
                  **kwargs):
         super().__init__(
             n_estimators=n_estimators,


### PR DESCRIPTION
# Description
* removed not used import
* changing RF regressor default train method

[WIP]
# TODO
* disable test cases:
  * FAILED scikit-learn-intelex/onedal/ensemble/tests/test_random_forest.py::test_rf_regression[SyclQueue1] - AssertionError:                                                                                                                                                                                                            
  * FAILED scikit-learn-intelex/onedal/ensemble/tests/test_random_forest.py::test_rf_regression_random_splitter[SyclQueue] - AssertionError:    

 
