### PR TITLE
chore: deprecate azure PEP8 in favor of black/isort GHA

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -42,20 +42,6 @@ variables:
   ARGS: '1'
 
 jobs:
-- job: PEP8
-  pool:
-    vmImage: 'ubuntu-22.04'
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.9'
-      addToPath: true
-  - script: |
-      python -m pip install --upgrade pip setuptools
-      pip install flake8
-      flake8 --ignore=E265,E722,E402,F401,F403,W503 --max-line-length=90 --count
-    displayName: 'PEP 8 check'
-
 - job: Linux
   timeoutInMinutes: 120
   strategy:


### PR DESCRIPTION
There are a few edge cases in which black output will not strictly follow PEP8, see e.g. https://github.com/psf/black/issues/1582
In this case the two CI actions will fight, and we should deprecate the standalone PEP8 check in favor of the new black/isort GH action. It's reasonable to align CI requirements with the output of formatting tools.