### PR TITLE
Remove flake8 from docs jobs

### DIFF
--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -41,19 +41,6 @@ variables:
     value: python
 
 jobs:
-- job: PEP8
-  pool:
-    vmImage: 'ubuntu-22.04'
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.9'
-      addToPath: true
-  - script: |
-      python -m pip install --upgrade pip setuptools
-      pip install flake8
-      flake8 --ignore=E265,E722,E402,F401,F403,W503 --max-line-length=90 --count
-    displayName: 'PEP 8 check'
 - job: Docs
   pool:
     vmImage: 'ubuntu-22.04'


### PR DESCRIPTION
Removing extra flake8 job for docs: `black` already replaced `flake8` as code formatting tool in https://github.com/intel/scikit-learn-intelex/commit/1fc8e54b370c7699e61dfbb5cb251abcd4fbfffa and https://github.com/intel/scikit-learn-intelex/commit/4b045e8367119e1ef639d4d034c724fc27a05066