### PR TITLE
[bugfix] Preview Ensemble algos - allow for onedal fit to be called multiple times

### DIFF
--- a/sklearnex/preview/ensemble/extra_trees.py
+++ b/sklearnex/preview/ensemble/extra_trees.py
@@ -623,8 +623,6 @@ class ExtraTreesClassifier(sklearn_ExtraTreesClassifier, BaseTree):
                 ]
             )
 
-            dal_ready = dal_ready and not hasattr(self, "estimators_")
-
             if dal_ready and (self.random_state is not None):
                 warnings.warn(
                     "Setting 'random_state' value is not supported. "
@@ -684,8 +682,6 @@ class ExtraTreesClassifier(sklearn_ExtraTreesClassifier, BaseTree):
                     (sample_weight is not None, "sample_weight is not supported."),
                 ]
             )
-
-            dal_ready &= not hasattr(self, "estimators_")
 
             if dal_ready and (self.random_state is not None):
                 warnings.warn(
@@ -1154,8 +1150,6 @@ class ExtraTreesRegressor(sklearn_ExtraTreesRegressor, BaseTree):
                 ]
             )
 
-            dal_ready &= not hasattr(self, "estimators_")
-
             if dal_ready and (self.random_state is not None):
                 warnings.warn(
                     "Setting 'random_state' value is not supported. "
@@ -1215,8 +1209,6 @@ class ExtraTreesRegressor(sklearn_ExtraTreesRegressor, BaseTree):
                     (sample_weight is not None, "sample_weight is not supported."),
                 ]
             )
-
-            dal_ready &= not hasattr(self, "estimators_")
 
             if dal_ready and (self.random_state is not None):
                 warnings.warn(

--- a/sklearnex/preview/ensemble/forest.py
+++ b/sklearnex/preview/ensemble/forest.py
@@ -593,8 +593,6 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
                 return False
             elif not self.n_outputs_ == 1:
                 return False
-            elif hasattr(self, "estimators_"):
-                return False
             else:
                 return True
         if method_name in ["predict", "predict_proba"]:
@@ -642,8 +640,6 @@ class RandomForestClassifier(sklearn_RandomForestClassifier, BaseRandomForest):
             elif self.oob_score:
                 return False
             elif not self.n_outputs_ == 1:
-                return False
-            elif hasattr(self, "estimators_"):
                 return False
             else:
                 return True
@@ -1004,8 +1000,6 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
                 return False
             elif not self.n_outputs_ == 1:
                 return False
-            elif hasattr(self, "estimators_"):
-                return False
             else:
                 return True
         if method_name == "predict":
@@ -1056,8 +1050,6 @@ class RandomForestRegressor(sklearn_RandomForestRegressor, BaseRandomForest):
             elif self.warm_start:
                 return False
             elif self.oob_score:
-                return False
-            elif hasattr(self, "estimators_"):
                 return False
             else:
                 return True


### PR DESCRIPTION
# Description
oneDAL Random Forest and Extra Trees algorithms create an .estimators_ attribute to match scikit-learn. This attribute contains all the tree node information in a scikit-learn format.  However, currently the code checks to see if this attribute exists for oneDAL patching, and if it exists it assumes that it has fallen back to the Scikit-learn implementation. The logic bug assumes that oneDAL versions do not create this attribute, and thus is a bad check. The 'fit' function can only oneDAL code once before always falling back to Scikit-learn. This removes that check.

The check for the .estimators_ attribute does not exist in the daal4py Random Forest implementations.

Changes proposed in this pull request:
- Remove hasattr check for estimators in onedal checks for ExtraTreesClassifier, ExtraTreesRegressor, RandomForestRegressor and RandomForestClassifier in preview namespace
