### PR TITLE
TEST: disabling RF regressor GPU test cases

### DIFF
--- a/onedal/ensemble/tests/test_random_forest.py
+++ b/onedal/ensemble/tests/test_random_forest.py
@@ -38,7 +38,9 @@ def test_rf_classifier(queue):
     assert_allclose([1], rf.predict([[0, 0, 0, 0]], queue=queue))
 
 
-@pytest.mark.parametrize("queue", get_queues())
+# TODO:
+# fix RF regressor predict for the GPU sycl_queue.
+@pytest.mark.parametrize("queue", get_queues("cpu"))
 def test_rf_regression(queue):
     X, y = make_regression(
         n_samples=100, n_features=4, n_informative=2, random_state=0, shuffle=False
@@ -66,6 +68,9 @@ def test_rf_classifier_random_splitter(queue):
     assert_allclose([1], rf.predict([[0, 0, 0, 0]], queue=queue))
 
 
+# TODO:
+# fix RF regressor predict for the GPU sycl_queue.
+@pytest.mark.skip(reason="fix RF regressor predict for the GPU sycl_queue")
 @pytest.mark.parametrize("queue", get_queues("gpu"))
 def test_rf_regression_random_splitter(queue):
     X, y = make_regression(


### PR DESCRIPTION
# Description
* disabling RF regressor GPU test cases
* added TODOs for disabled tests

 # TODO
Let's wait https://github.com/oneapi-src/oneDAL/pull/2456 merge that could probably fix this issue.