### PR TITLE
ENH: add ids for the onedal4py test cases sycl_queue param

### DIFF
--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -26,9 +26,9 @@ def get_queues(filter_="cpu,gpu"):
         import dpctl
 
         if dpctl.has_cpu_devices and "cpu" in filter_:
-            queues.append(dpctl.SyclQueue("cpu"))
+            queues.append(pytest.param(dpctl.SyclQueue("cpu"), id="SyclQueue_CPU"))
         if dpctl.has_gpu_devices and "gpu" in filter_:
-            queues.append(dpctl.SyclQueue("gpu"))
+            queues.append(pytest.param(dpctl.SyclQueue("gpu"), id="SyclQueue_GPU"))
     finally:
         return queues
 


### PR DESCRIPTION
# Description
Onedal4py tests uses get_queue helper func for getting sycl_queues on available devices. This auto created by pytest ids are not informative and absolutely are not useable in case of having deselected_tests list, that we are going to use later.
Currently we have some test cases for onedal4py that skipped by hardcoding, that will be updated via using deselected tests list.
* add ids for the onedal4py test cases sycl_queue params\

# TODO
add deselected_tests list for sklearnex and onedal4py own tests
