### PR TITLE
Release jobs update

### DIFF
--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -68,7 +68,7 @@ jobs:
     condition: eq( variables['Agent.OS'], 'Darwin')
     displayName: Add sudo access
   - script: |
-      conda update -y -q conda
+      conda update -y -q -c defaults conda
       conda create -y -q -n CB -c $(conda.channel) python=$(python.version) scikit-learn-intelex pandas pytest pyyaml
     displayName: 'Install scikit-learn-intelex'
   - script: |

--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: 'Sklearn testing'
 - job: GeneratorConda
   steps:
-  - bash: python .ci/scripts/gen_release_jobs.py --channels main conda-forge
+  - bash: python .ci/scripts/gen_release_jobs.py --channels main intel conda-forge
     name: MatrixGen
 - job: ReleaseConda
   dependsOn: GeneratorConda

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -23,7 +23,7 @@ parser.add_argument('--channels', nargs="+", default=['pypi'])
 args = parser.parse_args()
 
 CHANNELS = args.channels
-PYTHON_VERSIONS = ['3.7', '3.8', '3.9', '3.10', '3.11']
+PYTHON_VERSIONS = ['3.8', '3.9', '3.10', '3.11']
 SYSTEMS = ['ubuntu-latest', 'macos-latest', 'windows-latest']
 ACTIVATE = {
     'ubuntu-latest': 'conda activate',


### PR DESCRIPTION
Changes proposed in this pull request:
- Force conda to update base env from defaults channel (update from conda-forge channel fails on Windows)
- Remove Python 3.7 from release jobs
- Add intel conda channel to release jobs

 
