### PR TITLE
OCL setting fix for Release jobs

### DIFF
--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -26,5 +26,11 @@ cd $ci_dir
 export SELECTED_TESTS=${SELECTED_TESTS:-$(python scripts/select_sklearn_tests.py)}
 export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_tests.yaml)
 
+# manual setting of OCL_ICD_FILENAMES is required in
+# specific MSYS environment with conda packages downloaded from intel channel
+if [[ "${os}" =~ "MSYS" ]] && [ -z "${OCL_ICD_FILENAMES}" ] && [ -n "${CONDA_PREFIX}" ]; then
+    export OCL_ICD_FILENAMES=$(find $CONDA_PREFIX -name intelocl64.dll | sed 's/\\/\//g')
+fi
+
 python scripts/run_sklearn_tests.py -d ${1:-none}
 exit $?

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -28,7 +28,7 @@ export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_te
 
 # manual setting of OCL_ICD_FILENAMES is required in
 # specific MSYS environment with conda packages downloaded from intel channel
-if [[ "${os}" =~ "MSYS" ]] && [ -z "${OCL_ICD_FILENAMES}" ] && [ -n "${CONDA_PREFIX}" ]; then
+if [[ "$(uname)" =~ "MSYS" ]] && [ -z "${OCL_ICD_FILENAMES}" ] && [ -n "${CONDA_PREFIX}" ]; then
     export OCL_ICD_FILENAMES=$(find $CONDA_PREFIX -name intelocl64.dll | sed 's/\\/\//g')
     echo "OCL_ICD_FILENAMES is set to ${OCL_ICD_FILENAMES}"
 fi

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -30,6 +30,7 @@ export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_te
 # specific MSYS environment with conda packages downloaded from intel channel
 if [[ "${os}" =~ "MSYS" ]] && [ -z "${OCL_ICD_FILENAMES}" ] && [ -n "${CONDA_PREFIX}" ]; then
     export OCL_ICD_FILENAMES=$(find $CONDA_PREFIX -name intelocl64.dll | sed 's/\\/\//g')
+    echo "OCL_ICD_FILENAMES is set to ${OCL_ICD_FILENAMES}"
 fi
 
 python scripts/run_sklearn_tests.py -d ${1:-none}

--- a/.ci/scripts/run_sklearn_tests.sh
+++ b/.ci/scripts/run_sklearn_tests.sh
@@ -30,6 +30,8 @@ export DESELECTED_TESTS=$(python ../.circleci/deselect_tests.py ../deselected_te
 # specific MSYS environment with conda packages downloaded from intel channel
 if [[ "$(uname)" =~ "MSYS" ]] && [ -z "${OCL_ICD_FILENAMES}" ] && [ -n "${CONDA_PREFIX}" ]; then
     export OCL_ICD_FILENAMES=$(find $CONDA_PREFIX -name intelocl64.dll | sed 's/\\/\//g')
+fi
+if [ -n "${OCL_ICD_FILENAMES}" ]; then
     echo "OCL_ICD_FILENAMES is set to ${OCL_ICD_FILENAMES}"
 fi
 


### PR DESCRIPTION
Changes:
- Manual setting of `OCL_ICD_FILENAMES` on Windows to fix unavailability of cpu context.

Fixes:
- [ReleaseConda intel - python3.* - windows-latest](https://dev.azure.com/daal/daal4py/_build/results?buildId=26448&view=logs&jobId=4158e84d-bc9b-56b7-5928-54644d05b357&j=9faf4711-b2a9-5004-cc98-2f9b4983b7e8&t=ec94ac12-3c76-5cc3-7176-e8d70e67ff17):
```
..\sklearnex\svm\nusvr.py:79: in fit
    dispatch(self, 'fit', {
..\sklearnex\_device_offload.py:161: in dispatch
    return branches[backend](obj, *hostargs, **hostkwargs, queue=q)
..\sklearnex\svm\nusvr.py:125: in _onedal_fit
    self._onedal_estimator.fit(X, y, sample_weight, queue=queue)
..\onedal\svm\svm.py:448: in fit
    return super()._fit(X, y, sample_weight, _backend.svm.nu_regression, queue)
..\onedal\svm\svm.py:231: in _fit
    policy = _get_policy(queue, X, y, sample_weight)
..\onedal\common\_policy.py:30: in _get_policy
    return _HostInteropPolicy()
..\onedal\common\_policy.py:61: in __init__
    self._d4p_interop = _Daal4PyContextReset()
..\onedal\common\_policy.py:50: in __init__
    self._host_context = sycl_execution_context('cpu')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   RuntimeError: No device of requested type available.
Please check https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-system-requirements.html
-1 (PI_ERROR_DEVICE_NOT_FOUND)
```