### PR TITLE
MAINT: refactor DBSCAN onedal support funcs

### DIFF
--- a/sklearnex/cluster/dbscan.py
+++ b/sklearnex/cluster/dbscan.py
@@ -98,7 +98,7 @@ class DBSCAN(sklearn_DBSCAN, BaseDBSCAN):
         self._onedal_estimator.fit(X, y=y, sample_weight=sample_weight, queue=queue)
         self._save_attributes()
 
-    def _onedal_cpu_supported(self, method_name, *data):
+    def _onedal_supported(self, method_name, *data):
         if method_name == "fit":
             X, y, sample_weight = data
             if self.algorithm not in ["auto", "brute"]:
@@ -113,20 +113,11 @@ class DBSCAN(sklearn_DBSCAN, BaseDBSCAN):
                 return True
         raise RuntimeError(f"Unknown method {method_name} in {self.__class__.__name__}")
 
+    def _onedal_cpu_supported(self, method_name, *data):
+        return self._onedal_supported(method_name, *data)
+
     def _onedal_gpu_supported(self, method_name, *data):
-        if method_name == "fit":
-            X, y, sample_weight = data
-            if self.algorithm not in ["auto", "brute"]:
-                return False
-            elif not (
-                self.metric == "euclidean" or (self.metric == "minkowski" and self.p == 2)
-            ):
-                return False
-            elif sp.issparse(X):
-                return False
-            else:
-                return True
-        raise RuntimeError(f"Unknown method {method_name} in {self.__class__.__name__}")
+        return self._onedal_supported(method_name, *data)
 
     def fit(self, X, y=None, sample_weight=None):
         if sklearn_check_version("1.2"):


### PR DESCRIPTION
# Description
refactor DBSCAN onedal support funcs:
* added common `_onedal_supported` function to avoid code duplication 
* Addressed  https://github.com/intel/scikit-learn-intelex/pull/1400#discussion_r1307959551
* added patching status



 
