### PR TITLE
recovering renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,8 +15,7 @@
       "groupName": "Doc packages",
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"],
-      "excludeCommitPaths": ["(^|/)requirements-.[^oc].txt$",
-      "(^|/)dependencies-dev$"]
+      "matchFileNames": ["(^|/)requirements-doc.txt$"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,9 +12,6 @@
   },
   "packageRules": [
     {
-      "fileMatch": [
-        "(^|/)requirements-doc.txt$"
-      ],
       "groupName": "Doc packages",
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,11 +18,6 @@
       "groupName": "Doc packages",
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"]
-    },
-    {
-      "ignorePaths": ["(^|/)requirements-doc.txt$"],
-      "groupName": null,
-      "schedule": "at any time"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,10 @@
     {
       "groupName": "Doc packages",
       "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["before 2am on monday"]
+      "schedule": ["before 2am on monday"],
+      "fileMatch": [
+        "(^|/)requirements-doc.txt$"
+      ]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,9 +15,8 @@
       "groupName": "Doc packages",
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 2am on monday"],
-      "fileMatch": [
-        "(^|/)requirements-doc.txt$"
-      ]
+      "excludeCommitPaths": ["(^|/)requirements-.[^oc].txt$",
+      "(^|/)dependencies-dev$"]
     }
   ]
 }

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Validate
-        uses: rinchsan/renovate-config-validator@v0.0.12
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
         with:
-          pattern: '*.json' # Regular expression for filename to validate, default to *.json
+          config_file_path: renovate.json

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Validate
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
         with:
-          config_file_path: renovate.json
+          config_file_path: .github/renovate.json


### PR DESCRIPTION
# Description
currently renovate config is broken - so at least recovering to working state
Also changing github action for validation as previous one was always passing and this new one seems to work correctly.

Also intent of the change is to group doc related chagens together and keep rest as individual PRs
