### PR TITLE
[bug] correct decision tree threshold default values for leaf nodes in daal4py and onedal

### DIFF
--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -65,7 +65,7 @@ public:
             : left_child(ONEDAL_PY_TERMINAL_NODE),
               right_child(ONEDAL_PY_TERMINAL_NODE),
               feature(ONEDAL_PY_NO_FEATURE),
-              threshold(get_nan64()),
+              threshold(ONEDAL_PY_NO_FEATURE),
               impurity(get_nan64()),
               n_node_samples(0),
               weighted_n_node_samples(0.0),

--- a/src/tree_visitor.h
+++ b/src/tree_visitor.h
@@ -42,7 +42,7 @@ struct skl_tree_node {
         : left_child(TERMINAL_NODE),
           right_child(TERMINAL_NODE),
           feature(NO_FEATURE),
-          threshold(get_nan64()),
+          threshold(NO_FEATURE),
           impurity(get_nan64()),
           n_node_samples(0),
           weighted_n_node_samples(0.0),


### PR DESCRIPTION
# Description
Decision tree thresholds do not match sklearn's convention in daal4py or onedal. This characteristic of setting leaf node thresholds to -2 exists since at least scikit-learn 0.22, and should be changed for all circumstances. See (sklearn 0.22) https://github.com/scikit-learn/scikit-learn/blob/0.22.X/sklearn/tree/_tree.pyx#L757 and (sklearn 1.4) https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/tree/_tree.pyx#L493

Changes proposed in this pull request:
- change threshold default value to -2


 
