### PR TITLE
Reducing MacOS validation scope in public CI

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -80,12 +80,6 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.8_Sklearn1.0:
-        PYTHON_VERSION: '3.8'
-        SKLEARN_VERSION: '1.0'
-      Python3.9_Sklearn1.1:
-        PYTHON_VERSION: '3.9'
-        SKLEARN_VERSION: '1.1'
       Python3.10_Sklearn1.2:
         PYTHON_VERSION: '3.10'
         SKLEARN_VERSION: '1.2'

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -92,19 +92,6 @@ jobs:
     vmImage: 'ubuntu-22.04'
   steps:
   - template: build-and-test-lnx.yml
-- job: MacOSNightly
-  timeoutInMinutes: 120
-  strategy:
-    matrix:
-      Python3.11_SklearnMain:
-        PYTHON_VERSION: '3.11'
-        SKLEARN_VERSION: 'main'
-  pool:
-    vmImage: 'macos-12'
-  variables:
-    SKLEARN_SKIP_OPENMP_TEST: 'true'
-  steps:
-  - template: build-and-test-mac.yml
 - job: WindowsNightly
   timeoutInMinutes: 120
   strategy:

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -24,10 +24,9 @@ args = parser.parse_args()
 
 CHANNELS = args.channels
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-SYSTEMS = ["ubuntu-latest", "macos-latest", "windows-latest"]
+SYSTEMS = ["ubuntu-latest", "windows-latest"]
 ACTIVATE = {
     "ubuntu-latest": "conda activate",
-    "macos-latest": "source activate",
     "windows-latest": "call activate",
 }
 


### PR DESCRIPTION
# Description
Reducing scope of MacOS validation

1. Disable nightly against sklern master
2. Disable releases validation
3. Reduce CI for 2 last python/scikit versions
 
