### PR TITLE
FIX: Update xgboost model builder to fit changes in xgboost 2.0

### DIFF
--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -176,8 +176,11 @@ def get_gbt_model_from_xgboost(booster: Any, xgb_config=None) -> Any:
     else:
         is_regression = True
 
-    n_iterations = booster.best_iteration + 1
-    trees_arr = trees_arr[: n_iterations * (n_classes if n_classes > 2 else 1)]
+    if hasattr(booster, "best_iteration"):
+        n_iterations = booster.best_iteration + 1
+        trees_arr = trees_arr[: n_iterations * (n_classes if n_classes > 2 else 1)]
+    else:
+        n_iterations = int(len(trees_arr) / (n_classes if n_classes > 2 else 1))
 
     # Create + base iteration
     if is_regression:


### PR DESCRIPTION
# Description
Since v2.0 XGBoost.Booster object has "best_iteration" attribute only in case of early stopping. Add check to handle this case.

https://github.com/intel/scikit-learn-intelex/pull/1471
 
