### PR TITLE
deps: sklearn dependency on python

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,7 @@ pytest==7.4.2
 numpy>=1.19.5 ; python_version <= '3.9'
 numpy>=1.21.6 ; python_version == '3.10'
 numpy>=1.23.5 ; python_version >= '3.11'
-scikit-learn==1.3.0
+scikit-learn==1.2.2 ; python_version == '3.8'
+scikit-learn==1.3.0 ; python_version >= '3.9'
 pandas==2.0.1 ; python_version == '3.8'
 pandas==2.1.0 ; python_version >= '3.9'


### PR DESCRIPTION
Workaround for python3.8 GPU recipe test failure. Further investigation in progress.
 
