### PR TITLE
FIX: LinReg gpu tol issue

### DIFF
--- a/onedal/linear_model/tests/test_linear_regression.py
+++ b/onedal/linear_model/tests/test_linear_regression.py
@@ -87,7 +87,10 @@ if daal_check_version((2023, "P", 100)):
 
         res = model.predict(Xt, queue=queue)
 
-        tol = 2e-4 if res.dtype == np.float32 else 1e-7
+        if queue.sycl_device.is_gpu:
+            tol = 2.5e-4 if res.dtype == np.float32 else 1e-7
+        else:
+            tol = 2e-4 if res.dtype == np.float32 else 1e-7
         assert_allclose(gtr, res, rtol=tol)
 
     @pytest.mark.parametrize("queue", get_queues())

--- a/onedal/linear_model/tests/test_linear_regression.py
+++ b/onedal/linear_model/tests/test_linear_regression.py
@@ -76,7 +76,10 @@ if daal_check_version((2023, "P", 100)):
         model = LinearRegression(fit_intercept=True)
         model.fit(X, y, queue=queue)
 
-        tol = 2e-3 if model.coef_.dtype == np.float32 else 1e-5
+        if queue.sycl_device.is_gpu:
+            tol = 2.5e-3 if model.coef_.dtype == np.float32 else 1e-5
+        else:
+            tol = 2e-3 if model.coef_.dtype == np.float32 else 1e-5
         assert_allclose(coef, model.coef_.T, rtol=tol)
 
         tol = 2e-3 if model.intercept_.dtype == np.float32 else 1e-5
@@ -87,10 +90,7 @@ if daal_check_version((2023, "P", 100)):
 
         res = model.predict(Xt, queue=queue)
 
-        if queue.sycl_device.is_gpu:
-            tol = 2.5e-4 if res.dtype == np.float32 else 1e-7
-        else:
-            tol = 2e-4 if res.dtype == np.float32 else 1e-7
+        tol = 2e-4 if res.dtype == np.float32 else 1e-7
         assert_allclose(gtr, res, rtol=tol)
 
     @pytest.mark.parametrize("queue", get_queues())


### PR DESCRIPTION
# Description
LinReg gpu tol issue
fixes sporadically fail of:
```
linear_model/tests/test_linear_regression.py::test_full_results[float32-SyclQueue_GPU]
```

 
