### PR TITLE
Adding dpctl import workaround to setup_sklearnex

### DIFF
--- a/setup_sklearnex.py
+++ b/setup_sklearnex.py
@@ -59,7 +59,15 @@ try:
 
     dpctl_available = dpctl.__version__ >= "0.14"
 except ImportError:
-    dpctl_available = False
+    import importlib.util
+
+    try:
+        dpctl_include = os.path.join(
+            importlib.util.find_spec("dpctl").submodule_search_locations[0], "include"
+        )
+        dpctl_available = dpctl_include is not None
+    except AttributeError:
+        dpctl_available = False
 
 build_distribute = dpcpp and dpctl_available and not no_dist and IS_LIN
 


### PR DESCRIPTION
# Description
Follow-up to https://github.com/intel/scikit-learn-intelex/pull/1490. Some examples are getting skipped due to not being built.
 
