### PR TITLE
Testing: python 3.8 test sklearnex deselections

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -1107,6 +1107,74 @@ gpu:
   - tests/test_common.py::test_estimators[SequentialFeatureSelector(estimator=LogisticRegression(C=1))-
   # Sporadic failures on Max series with 2024.0 toolchain update that require deeper investigation
   - tests/test_multiclass.py::test_ovo_consistent_binary_classification
+  # Python 3.8 failures on Max series with 2024.0 toolchain update
+  - neighbors/tests/test_neighbors.py::test_query_equidistant_kth_nn
+  - neighbors/tests/test_neighbors.py::test_radius_neighbors_sort_results
+  - neighbors/tests/test_neighbors.py::test_neighbors_digits
+  - neighbors/tests/test_neighbors.py::test_nearest_neighbors_validate_params
+  - neighbors/tests/test_neighbors.py::test_kneighbors_brute_backend
+  - neighbors/tests/test_neighbors.py::test_metric_params_interface
+  - neighbors/tests/test_neighbors.py::test_non_euclidean_kneighbors
+  - neighbors/tests/test_neighbors.py::test_k_and_radius_neighbors_X_None
+  - neighbors/tests/test_neighbors.py::test_k_and_radius_neighbors_duplicates
+  - neighbors/tests/test_neighbors.py::test_same_knn_parallel
+  - neighbors/tests/test_neighbors.py::test_knn_forcing_backend
+  - neighbors/tests/test_neighbors.py::test_auto_algorithm
+  - neighbors/tests/test_neighbors.py::test_radius_neighbors_brute_backend
+  - svm/tests/test_svm.py::test_consistent_proba
+  - svm/tests/test_svm.py::test_libsvm_parameters
+  - svm/tests/test_svm.py::test_negative_weight_equal_coeffs
+  - svm/tests/test_svm.py::test_unicode_kernel
+  - svm/tests/test_svm.py::test_consistent_proba
+  - svm/tests/test_svm.py::test_gamma_scale
+  - svm/tests/test_svm.py::test_svc_raises_error_internal_representation
+  - svm/tests/test_svm.py::test_n_iter_libsvm[dataset0-SVC-ndarray]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_dtypes]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit_score_takes_y]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_pandas_series]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_not_an_array]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_list]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_shape]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_not_overwritten]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_invariance(kind=ones)]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_sample_weights_invariance(kind=zeros)]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_fit_returns_self]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_complex_data]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_dtype_object]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_empty_data_messages]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_pipeline_consistency]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_nan_inf]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_overwrite_params]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_clustering]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_clustering(readonly_memmap=True)]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_methods_sample_order_invariance]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_methods_subset_invariance]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit2d_1sample]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit2d_1feature]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_dict_unchanged]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_dont_overwrite_parameters]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit_idempotent]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit_check_is_fitted]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_n_features_in]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit1d]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_fit2d_predict1d]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_dtypes]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit_score_takes_y]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_fit_returns_self]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_dtype_object]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_pipeline_consistency]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_nan_inf]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_overwrite_params]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_methods_subset_invariance]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit2d_1sample]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit2d_1feature]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_dict_unchanged]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_dont_overwrite_parameters]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit2d_predict1d]
+  - tests/test_common.py::test_check_n_features_in_after_fitting[DBSCAN()]
+  - tests/test_common.py::test_check_n_features_in_after_fitting[SVC()]   
 
 preview:
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -1121,11 +1121,10 @@ gpu:
   - neighbors/tests/test_neighbors.py::test_knn_forcing_backend
   - neighbors/tests/test_neighbors.py::test_auto_algorithm
   - neighbors/tests/test_neighbors.py::test_radius_neighbors_brute_backend
-  - svm/tests/test_svm.py::test_consistent_proba
+  - svm/tests/test_sparse.py::test_consistent_proba
   - svm/tests/test_svm.py::test_libsvm_parameters
   - svm/tests/test_svm.py::test_negative_weight_equal_coeffs
   - svm/tests/test_svm.py::test_unicode_kernel
-  - svm/tests/test_svm.py::test_consistent_proba
   - svm/tests/test_svm.py::test_gamma_scale
   - svm/tests/test_svm.py::test_svc_raises_error_internal_representation
   - svm/tests/test_svm.py::test_n_iter_libsvm[dataset0-SVC-ndarray]
@@ -1146,6 +1145,7 @@ gpu:
   - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_nan_inf]
   - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_overwrite_params]
   - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[DBSCAN()-check_estimators_fit_returns_self(readonly_memmap=True)]
   - tests/test_common.py::test_estimators[DBSCAN()-check_clustering]
   - tests/test_common.py::test_estimators[DBSCAN()-check_clustering(readonly_memmap=True)]
   - tests/test_common.py::test_estimators[DBSCAN()-check_methods_sample_order_invariance]
@@ -1162,11 +1162,13 @@ gpu:
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_dtypes]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit_score_takes_y]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_fit_returns_self]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_fit_returns_self(readonly_memmap=True)]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_dtype_object]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_pipeline_consistency]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_nan_inf]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_overwrite_params]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_methods_sample_order_invariance]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_methods_subset_invariance]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit2d_1sample]
   - tests/test_common.py::test_estimators[LocalOutlierFactor()-check_fit2d_1feature]


### PR DESCRIPTION
# Description
These tests are currently failing on python 3.8 with 2024.0 setup.

 
