### PR TITLE
[Experimental]: avoid using dpctl include for python3.8

### DIFF
--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import sys
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -145,6 +146,7 @@ def test_input_format_f_contiguous_pandas(queue, dtype):
 
 
 @pytest.mark.skipif(not dpctl_available, reason="requires dpctl>=0.14")
+@pytest.mark.skipif(not (sys.version_info.minor > 8), reason="requires python 3.9")
 @pytest.mark.parametrize("queue", get_queues("cpu,gpu"))
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_input_format_c_contiguous_dpctl(queue, dtype):
@@ -172,6 +174,7 @@ def test_input_format_c_contiguous_dpctl(queue, dtype):
 
 
 @pytest.mark.skipif(not dpctl_available, reason="requires dpctl>=0.14")
+@pytest.mark.skipif(not (sys.version_info.minor > 8), reason="requires python 3.9")
 @pytest.mark.parametrize("queue", get_queues("cpu,gpu"))
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_input_format_f_contiguous_dpctl(queue, dtype):

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -207,13 +207,13 @@ def custom_build_cmake_clib(
         "-DoneDAL_USE_PARAMETERS_LIB=" + use_parameters_arg,
     ]
 
-    if dpctl_available:
+    if dpctl_available and sys.version_info.minor > 8:
         cmake_args += [
             "-DDPCTL_INCLUDE_DIR=" + dpctl_include,
             "-DONEDAL_DPCTL_INTEGRATION:BOOL=ON",
         ]
 
-    if build_distribute:
+    if build_distribute and sys.version_info.minor > 8:
         cmake_args += [
             "-DMPI_INCLUDE_DIRS=" + MPI_INCDIRS,
             "-DMPI_LIBRARY_DIR=" + MPI_LIBDIRS,

--- a/setup.py
+++ b/setup.py
@@ -550,7 +550,7 @@ if ONEDAL_VERSION >= 20230100:
 if ONEDAL_VERSION >= 20230200:
     packages_with_tests += ["onedal.cluster"]
 
-if build_distribute:
+if build_distribute and sys.version_info.minor > 8:
     packages_with_tests += [
         "onedal.spmd",
         "onedal.spmd.decomposition",

--- a/setup_sklearnex.py
+++ b/setup_sklearnex.py
@@ -102,7 +102,7 @@ packages_with_tests = [
     "sklearnex.utils",
 ]
 
-if build_distribute:
+if build_distribute and sys.version_info.minor > 8:
     packages_with_tests += [
         "sklearnex.spmd",
         "sklearnex.spmd.decomposition",

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -181,6 +181,20 @@ req_os = defaultdict(lambda: [])
 
 skiped_files = []
 
+# Workaroud for dpctl issues on python 3.8.
+if not (sys.version_info.minor > 8):
+    skiped_files.extend([
+        "basic_statistics_spmd.py",
+        "dbscan_spmd.py",
+        "kmeans_spmd.py",
+        "knn_bf_classification_spmd.py",
+        "knn_bf_regression_spmd.py",
+        "linear_regression_spmd.py",
+        "pca_spmd.py",
+        "random_forest_classifier_spmd.py",
+        "random_forest_regressor_spmd.py",
+    ])
+
 
 def get_exe_cmd(ex, nodist, nostream):
     if os.path.dirname(ex).endswith("sycl"):
@@ -230,7 +244,7 @@ def run(exdir, logdir, nodist=False, nostream=False):
                     print("\n##### " + jp(dirpath, script))
                     print(
                         strftime("%H:%M:%S", gmtime())
-                        + "\tKNOWN BUG IN EXAMPLES\t"
+                        + "\tSKIPPED\t"
                         + script
                     )
                 else:


### PR DESCRIPTION
# Description
workaround for dpctl issues on python3.8 with compiler version 2024.0.0
__[DO NOT MERGE]__


 
