### PR TITLE
[bug] fix for test_common.py preview KMeans()-check_estimators_dtypes

### DIFF
--- a/sklearnex/preview/cluster/k_means.py
+++ b/sklearnex/preview/cluster/k_means.py
@@ -290,7 +290,9 @@ if daal_check_version((2023, "P", 200)):
             )
 
         def _onedal_predict(self, X, queue=None):
-            X = self._validate_data(X, accept_sparse=False, reset=False)
+            X = self._validate_data(
+                X, accept_sparse=False, reset=False, dtype=[np.float64, np.float32]
+            )
             if not hasattr(self, "_onedal_estimator"):
                 self._initialize_onedal_estimator()
                 self._onedal_estimator.cluster_centers_ = self.cluster_centers_


### PR DESCRIPTION
# Description
Preview k-means has a CI failure for tests/test_common due to a lack of a dtype check for predict. This is similar to an issue just discovered on the ensemble algorithms. This doesn't show up on normal CI runs, but on extended CI sklearn evaluations which include the test_common suite.

Changes proposed in this pull request:
- Add dtype check to preview kmeans predict
 
