### PR TITLE
moving example skip workaround further

### DIFF
--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -135,8 +135,7 @@ execution_timeout = 120
 
 req_version = defaultdict(lambda: (2019, "P", 0))
 req_version["decision_forest_classification_hist.py"] = (2023, "P", 100)
-req_version["decision_forest_classification_default_dense.py"] = (
-    2023, "P", 100)
+req_version["decision_forest_classification_default_dense.py"] = (2023, "P", 100)
 req_version["decision_forest_classification_traverse.py"] = (2023, "P", 100)
 req_version["basic_statistics_spmd.py"] = (2023, "P", 100)
 # Temporary disabling due to sporadict timeout on PVC

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -134,15 +134,16 @@ def check_library(rule):
 execution_timeout = 120
 
 req_version = defaultdict(lambda: (2019, "P", 0))
-req_version["decision_forest_classification_hist.py"] = (2023, "P", 1)
-req_version["decision_forest_classification_default_dense.py"] = (2023, "P", 1)
-req_version["decision_forest_classification_traverse.py"] = (2023, "P", 1)
-req_version["basic_statistics_spmd.py"] = (2023, "P", 1)
+req_version["decision_forest_classification_hist.py"] = (2023, "P", 100)
+req_version["decision_forest_classification_default_dense.py"] = (
+    2023, "P", 100)
+req_version["decision_forest_classification_traverse.py"] = (2023, "P", 100)
+req_version["basic_statistics_spmd.py"] = (2023, "P", 100)
 # Temporary disabling due to sporadict timeout on PVC
-req_version["kmeans_spmd.py"] = (2024, "P", 2)
-req_version["knn_bf_classification_spmd.py"] = (2023, "P", 1)
-req_version["knn_bf_regression_spmd.py"] = (2023, "P", 1)
-req_version["linear_regression_spmd.py"] = (2023, "P", 1)
+req_version["kmeans_spmd.py"] = (2024, "P", 100)
+req_version["knn_bf_classification_spmd.py"] = (2023, "P", 100)
+req_version["knn_bf_regression_spmd.py"] = (2023, "P", 100)
+req_version["linear_regression_spmd.py"] = (2023, "P", 100)
 
 req_device = defaultdict(lambda: [])
 req_device["basic_statistics_spmd.py"] = ["gpu"]

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -139,7 +139,7 @@ req_version["decision_forest_classification_default_dense.py"] = (2023, "P", 1)
 req_version["decision_forest_classification_traverse.py"] = (2023, "P", 1)
 req_version["basic_statistics_spmd.py"] = (2023, "P", 1)
 # Temporary disabling due to sporadict timeout on PVC
-req_version["kmeans_spmd.py"] = (2024, "P", 1)
+req_version["kmeans_spmd.py"] = (2024, "P", 2)
 req_version["knn_bf_classification_spmd.py"] = (2023, "P", 1)
 req_version["knn_bf_regression_spmd.py"] = (2023, "P", 1)
 req_version["linear_regression_spmd.py"] = (2023, "P", 1)


### PR DESCRIPTION
# Description
currently oneDAL defined as 2024.0.1 but python detects it's not quite correctly 
DAAL version: (2024, 'P', 1)
