### PR TITLE
[testing, bug] include sklearn fallback for normal non-invertible matrices in preview linearRegression

### DIFF
--- a/.ci/scripts/select_sklearn_tests.py
+++ b/.ci/scripts/select_sklearn_tests.py
@@ -38,9 +38,7 @@ def parse_tests_tree(entry, prefix=""):
 tests_map = {
     "cluster/tests": ["test_dbscan.py", "test_k_means.py"],
     "decomposition/tests": "test_pca.py",
-    "inspection/tests": ["test_partial_dependence.py", "test_permutation_importance.py"],
     "ensemble/tests": "test_forest.py",
-    "tests/": "test_common.py",
     "linear_model/tests": ["test_base.py", "test_coordinate_descent.py", "test_ridge.py"],
     "manifold/tests": "test_t_sne.py",
     "model_selection/tests": ["test_split.py", "test_validation.py"],

--- a/.ci/scripts/select_sklearn_tests.py
+++ b/.ci/scripts/select_sklearn_tests.py
@@ -38,7 +38,9 @@ def parse_tests_tree(entry, prefix=""):
 tests_map = {
     "cluster/tests": ["test_dbscan.py", "test_k_means.py"],
     "decomposition/tests": "test_pca.py",
+    "inspection/tests": ["test_partial_dependence.py", "test_permutation_importance.py"],
     "ensemble/tests": "test_forest.py",
+    "tests/": "test_common.py",
     "linear_model/tests": ["test_base.py", "test_coordinate_descent.py", "test_ridge.py"],
     "manifold/tests": "test_t_sne.py",
     "model_selection/tests": ["test_split.py", "test_validation.py"],

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -81,6 +81,8 @@ def get_patch_message(s, queue=None):
             message += "CPU"
     elif s == "sklearn":
         message = "fallback to original Scikit-learn"
+    elif s == "sklearn_after_onedal":
+        message = "failed to run accelerated version, fallback to original Scikit-learn"
     else:
         raise ValueError(
             f"Invalid input - expected one of 'onedal','sklearn',"

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -305,7 +305,7 @@ if daal_check_version((2023, "P", 100)):
                 self._save_attributes()
 
             except RuntimeError:
-                logging.warning(get_patch_message('sklearn_after_daal'))
+                logging.warning(get_patch_message("sklearn_after_daal"))
 
                 del self._onedal_estimator
                 super().fit(X, y)

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -305,7 +305,7 @@ if daal_check_version((2023, "P", 100)):
                 self._save_attributes()
 
             except RuntimeError:
-                logging.getlogger("sklearnex").info(
+                logging.getLogger("sklearnex").info(
                     f"{self.__class__.__name__}.fit "
                     + get_patch_message("sklearn_after_onedal")
                 )

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -305,7 +305,10 @@ if daal_check_version((2023, "P", 100)):
                 self._save_attributes()
 
             except RuntimeError:
-                logging.warning(get_patch_message("sklearn_after_daal"))
+                logging.getlogger("sklearnex").info(
+                    f"{self.__class__.__name__}.fit "
+                    + get_patch_message("sklearn_after_onedal")
+                )
 
                 del self._onedal_estimator
                 super().fit(X, y)

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -25,7 +25,7 @@ if daal_check_version((2023, "P", 100)):
     from daal4py.sklearn._utils import get_dtype, make2d, sklearn_check_version
 
     from ..._device_offload import dispatch, wrap_output_data
-    from ..._utils import PatchingConditionsChain
+    from ..._utils import get_patch_message, PatchingConditionsChain
     from ...utils.validation import _assert_all_finite
     from ._common import BaseLinearRegression
 
@@ -302,9 +302,11 @@ if daal_check_version((2023, "P", 100)):
             self._initialize_onedal_estimator()
             try:
                 self._onedal_estimator.fit(X, y, queue=queue)
-
                 self._save_attributes()
+
             except RuntimeError:
+                logging.warning(get_patch_message('sklearn_after_daal'))
+
                 del self._onedal_estimator
                 super().fit(X, y)
 

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -25,7 +25,7 @@ if daal_check_version((2023, "P", 100)):
     from daal4py.sklearn._utils import get_dtype, make2d, sklearn_check_version
 
     from ..._device_offload import dispatch, wrap_output_data
-    from ..._utils import get_patch_message, PatchingConditionsChain
+    from ..._utils import PatchingConditionsChain, get_patch_message
     from ...utils.validation import _assert_all_finite
     from ._common import BaseLinearRegression
 

--- a/sklearnex/preview/linear_model/linear.py
+++ b/sklearnex/preview/linear_model/linear.py
@@ -300,9 +300,13 @@ if daal_check_version((2023, "P", 100)):
                 )
 
             self._initialize_onedal_estimator()
-            self._onedal_estimator.fit(X, y, queue=queue)
+            try:
+                self._onedal_estimator.fit(X, y, queue=queue)
 
-            self._save_attributes()
+                self._save_attributes()
+            except RuntimeError:
+                del self._onedal_estimator
+                super().fit(X, y)
 
         def _onedal_predict(self, X, queue=None):
             X = self._validate_data(X, accept_sparse=False, reset=False)


### PR DESCRIPTION
# Description
Daal contains several [methods for linear regression](https://github.com/oneapi-src/oneDAL/blob/master/cpp/daal/include/algorithms/linear_regression/linear_regression_training_types.h#L58). oneDAL uses daal for CPU, but only has the [norm_eq method available](https://github.com/oneapi-src/oneDAL/blob/master/cpp/oneapi/dal/algo/linear_regression/parameters/cpu/train_parameters.cpp#L42). Daal4py linear regression [includes a fallback](https://github.com/intel/scikit-learn-intelex/blob/master/daal4py/sklearn/linear_model/_linear.py#L61) for non-invertible normal matrices:  using the other method before falling back to sklearn. sklearnex.preview.linearRegression does not have either of these fallbacks, meaning it cannot handle norm_eq non-invertible matrices. Ideally additional work should be done on the oneDAL side to include the QRdense method, and then expose it to sklearnex. This PR can be considered a stopgap bugfix as it falls directly back to sklearn.

This causes unit test failures for sklearn preview in public Nightly:
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[1-est0]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[1-est1]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[1-est2]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[1-est3]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est0]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est1]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est2]
inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est3]
Changes proposed in this pull request:
- Include a try catch for a Runtime error, fallback to sklearn due to non-invertibility.
- Fixed issue with sklearnex get_patch_message which wasn't implemented but necessary for bugfix




 
