### PR TITLE
[testing, bug] fix table conversion issue with preview kmeans.fit when X is not contiguous

### DIFF
--- a/.ci/scripts/select_sklearn_tests.py
+++ b/.ci/scripts/select_sklearn_tests.py
@@ -38,6 +38,7 @@ def parse_tests_tree(entry, prefix=""):
 tests_map = {
     "cluster/tests": ["test_dbscan.py", "test_k_means.py"],
     "decomposition/tests": "test_pca.py",
+    "preprocessing/tests": "test_discretization.py",
     "ensemble/tests": "test_forest.py",
     "linear_model/tests": ["test_base.py", "test_coordinate_descent.py", "test_ridge.py"],
     "manifold/tests": "test_t_sne.py",

--- a/.ci/scripts/select_sklearn_tests.py
+++ b/.ci/scripts/select_sklearn_tests.py
@@ -38,7 +38,6 @@ def parse_tests_tree(entry, prefix=""):
 tests_map = {
     "cluster/tests": ["test_dbscan.py", "test_k_means.py"],
     "decomposition/tests": "test_pca.py",
-    "preprocessing/tests": "test_discretization.py",
     "ensemble/tests": "test_forest.py",
     "linear_model/tests": ["test_base.py", "test_coordinate_descent.py", "test_ridge.py"],
     "manifold/tests": "test_t_sne.py",

--- a/onedal/cluster/kmeans.py
+++ b/onedal/cluster/kmeans.py
@@ -38,7 +38,7 @@ from sklearn.utils.validation import check_is_fitted
 from onedal.basic_statistics import BasicStatistics
 
 from ..common._policy import _get_policy
-from ..utils import _is_arraylike_not_scalar
+from ..utils import _check_array, _is_arraylike_not_scalar
 
 
 class _BaseKMeans(TransformerMixin, ClusterMixin, BaseEstimator, ABC):
@@ -151,10 +151,7 @@ class _BaseKMeans(TransformerMixin, ClusterMixin, BaseEstimator, ABC):
         }
 
     def _get_params_and_input(self, X, policy):
-        X_loc = np.asarray(X)
-        types = [np.float32, np.float64]
-        if get_dtype(X_loc) not in types:
-            X_loc = X_loc.astype(np.float64)
+        X_loc = _check_array(X, dtype=[np.float64, np.float32], force_all_finite=False)
 
         X_loc = _convert_to_supported(policy, X_loc)
 


### PR DESCRIPTION
# Description
Inputs into preview kmeans fail when X is not a contiguous array, this causes unit test issues and is not properly checked. This change fixes the following unit test failures:
preprocessing/tests/test_discretization.py::test_fit_transform[kmeans-expected1-None]
preprocessing/tests/test_discretization.py::test_fit_transform_n_bins_array[kmeans-expected1-None]
preprocessing/tests/test_discretization.py::test_inverse_transform[ordinal-kmeans-expected_inv1]
preprocessing/tests/test_discretization.py::test_inverse_transform[onehot-kmeans-expected_inv1]
preprocessing/tests/test_discretization.py::test_inverse_transform[onehot-dense-kmeans-expected_inv1]

Changes proposed in this pull request:
- place _check_array in onedal kmeans fit for setting contiguous array for table conversion.

 
