### PR TITLE
Fix for floating point types support in train_test_split

### DIFF
--- a/daal4py/sklearn/model_selection/_split.py
+++ b/daal4py/sklearn/model_selection/_split.py
@@ -189,7 +189,7 @@ def train_test_split(*arrays, **options):
         if dtypes is not None:
             incorrect_dtype = None
             for i, dtype in enumerate(dtypes):
-                if "float" not in str(dtype) and "int" not in str(dtype):
+                if str(dtype) not in ["float32", "float64"] and "int" not in str(dtype):
                     incorrect_dtype = str(dtype)
                     break
             _dal_ready = _patching_status.and_conditions(
@@ -197,7 +197,7 @@ def train_test_split(*arrays, **options):
                     (
                         incorrect_dtype is None,
                         f"Input has incorrect data type '{incorrect_dtype}'. "
-                        "Only integer and floating point types are supported.",
+                        "Only integer and 32/64-bits floating point types are supported.",
                     )
                 ]
             )


### PR DESCRIPTION
# Description
`sklearnex.model_selection.train_test_split` raises error if float16 is passed in input array:
```python
--> 223 d4p.daal_train_test_split(
    224     arr_copy, train_arr, test_arr, [train], [test])
    225 train_arr = {col: train_arr[i]
    226              for i, col in enumerate(arr.columns)}
    227 test_arr = {col: test_arr[i]
    228             for i, col in enumerate(arr.columns)}

File build/daal4py_cy.pyx:184, in daal4py._daal4py.daal_train_test_split()

RuntimeError: Cannot operate on column: 0  because it is non-contiguous.
Please make it contiguous before passing it to daal4py
```

Changes proposed in this pull request:
- Explicitly check float32/64 type in train_test_split patching conditions check

