### PR TITLE
Remove deprecated `is_sparse` function

### DIFF
--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -276,7 +276,10 @@ def _daal_check_array(
 
     # a branch for heterogeneous pandas.DataFrame
     if is_DataFrame(array) and get_number_of_types(array) > 1:
-        from pandas.api.types import is_sparse
+        from pandas import SparseDtype
+
+        def is_sparse(dtype):
+            return isinstance(dtype, SparseDtype)
 
         if hasattr(array, "sparse") or not array.dtypes.apply(is_sparse).any():
             return _pandas_check_array(
@@ -305,7 +308,10 @@ def _daal_check_array(
         # throw warning if columns are sparse. If all columns are sparse, then
         # array.sparse exists and sparsity will be perserved (later).
         with suppress(ImportError):
-            from pandas.api.types import is_sparse
+            from pandas import SparseDtype
+
+            def is_sparse(dtype):
+                return isinstance(dtype, SparseDtype)
 
             if not hasattr(array, "sparse") and array.dtypes.apply(is_sparse).any():
                 warnings.warn(


### PR DESCRIPTION
# Description
`pandas.api.types.is_sparse` was deprecated and produces FutureWarning. This PR replaces it with `pandas.SparseDtype` instance check like it's done in [sklearn](https://github.com/scikit-learn/scikit-learn/blob/2490ff1715ff107eddc4a147f9fcbef2d4b43401/sklearn/utils/validation.py#L785).

 
