### PR TITLE
[performance] remove _assert_all_finite() call from onedal/utils/_check_array

### DIFF
--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -125,11 +125,6 @@ def _check_array(
     ensure_2d=True,
     accept_large_sparse=True,
 ):
-    if force_all_finite:
-        if sp.issparse(array):
-            if hasattr(array, "data"):
-                _assert_all_finite(array.data)
-                force_all_finite = False
 
     array = check_array(
         array=array,

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -130,9 +130,7 @@ def _check_array(
             if hasattr(array, "data"):
                 _assert_all_finite(array.data)
                 force_all_finite = False
-        else:
-            _assert_all_finite(array)
-            force_all_finite = False
+
     array = check_array(
         array=array,
         dtype=dtype,

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -125,7 +125,6 @@ def _check_array(
     ensure_2d=True,
     accept_large_sparse=True,
 ):
-
     array = check_array(
         array=array,
         dtype=dtype,

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -89,7 +89,7 @@ def get_patch_map():
         from .svm import NuSVR as NuSVR_sklearnex
 
         # Patch for mapping
-        if True:
+        if _is_preview_enabled():
             # Ensemble
             mapping["extra_trees_classifier"] = [
                 [

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -89,7 +89,7 @@ def get_patch_map():
         from .svm import NuSVR as NuSVR_sklearnex
 
         # Patch for mapping
-        if _is_preview_enabled():
+        if True:
             # Ensemble
             mapping["extra_trees_classifier"] = [
                 [


### PR DESCRIPTION
# Description
sklearn's check_array() contains force_all_finite=True as default. It also [handles pandas dataframes](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/validation.py#L835) before doing finite checks which could be the cause of a performance degradation on random forest preview predict.

Changes proposed in this pull request:
- Remove if statement entirely

 
