### PR TITLE
[perf] Remove preview ensemble assert_all_finite duplication

### DIFF
--- a/sklearnex/preview/ensemble/_forest.py
+++ b/sklearnex/preview/ensemble/_forest.py
@@ -85,6 +85,7 @@ class BaseForest(ABC):
                 multi_output=False,
                 accept_sparse=False,
                 dtype=[np.float64, np.float32],
+                force_all_finite=False,
             )
         else:
             X, y = check_X_y(
@@ -93,6 +94,7 @@ class BaseForest(ABC):
                 accept_sparse=False,
                 dtype=[np.float64, np.float32],
                 multi_output=False,
+                force_all_finite=False,
             )
 
         if sample_weight is not None:
@@ -287,6 +289,7 @@ class BaseForest(ABC):
                 ensure_2d=False,
                 dtype=dtype,
                 order="C",
+                force_all_finite=False,
             )
             if sample_weight.ndim != 1:
                 raise ValueError("Sample weights must be 1D array or scalar")
@@ -406,6 +409,7 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
     # significantly at some point then this may need to be versioned.
 
     _err = "out_of_bag_error_accuracy|out_of_bag_error_decision_function"
+    _get_tree_state = staticmethod(get_tree_state_cls)    
 
     def __init__(
         self,
@@ -457,9 +461,6 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
         classes_ = self.classes_[0]
         for est in self._cached_estimators_:
             est.classes_ = classes_
-
-    def _get_tree_state(self, model, iTree, n_classes):
-        return get_tree_state_cls(model, iTree, n_classes)
 
     def fit(self, X, y, sample_weight=None):
         dispatch(
@@ -550,8 +551,8 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
                     force_all_finite=False,
                 )
             else:
-                X = check_array(X, dtype=[np.float64, np.float32])
-                y = check_array(y, ensure_2d=False, dtype=X.dtype)
+                X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
+                y = check_array(y, ensure_2d=False, dtype=X.dtype,force_all_finite=False)
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -775,7 +776,8 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
 
     def _onedal_predict(self, X, queue=None):
         X = check_array(
-            X, dtype=[np.float64, np.float32]
+            X, dtype=[np.float64, np.float32],
+            force_all_finite=False,
         )  # Warning, order of dtype matters
         check_is_fitted(self, "_onedal_estimator")
 
@@ -786,7 +788,7 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
         return np.take(self.classes_, res.ravel().astype(np.int64, casting="unsafe"))
 
     def _onedal_predict_proba(self, X, queue=None):
-        X = check_array(X, dtype=[np.float64, np.float32])
+        X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
         check_is_fitted(self, "_onedal_estimator")
 
         if sklearn_check_version("0.23"):
@@ -798,6 +800,7 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
 
 class ForestRegressor(sklearn_ForestRegressor, BaseForest):
     _err = "out_of_bag_error_r2|out_of_bag_error_prediction"
+    _get_tree_state = staticmethod(get_tree_state_reg)
 
     def __init__(
         self,
@@ -841,9 +844,6 @@ class ForestRegressor(sklearn_ForestRegressor, BaseForest):
 
         if self._onedal_factory is None:
             raise TypeError(f" oneDAL estimator has not been set.")
-
-    def _get_tree_state(self, model, iTree, n_classes):
-        return get_tree_state_reg(model, iTree, n_classes)
 
     def _onedal_fit_ready(self, patching_status, X, y, sample_weight):
         if sp.issparse(y):
@@ -915,11 +915,11 @@ class ForestRegressor(sklearn_ForestRegressor, BaseForest):
                     multi_output=True,
                     accept_sparse=True,
                     dtype=[np.float64, np.float32],
-                    force_all_finite=not sklearn_check_version("1.4"),
+                    force_all_finite=False,
                 )
             else:
-                X = check_array(X, dtype=[np.float64, np.float32])
-                y = check_array(y, ensure_2d=False, dtype=X.dtype)
+                X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
+                y = check_array(y, ensure_2d=False, dtype=X.dtype,force_all_finite=False)
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -1082,7 +1082,8 @@ class ForestRegressor(sklearn_ForestRegressor, BaseForest):
 
     def _onedal_predict(self, X, queue=None):
         X = check_array(
-            X, dtype=[np.float64, np.float32]
+            X, dtype=[np.float64, np.float32],
+            force_all_finite=False
         )  # Warning, order of dtype matters
         check_is_fitted(self, "_onedal_estimator")
 

--- a/sklearnex/preview/ensemble/_forest.py
+++ b/sklearnex/preview/ensemble/_forest.py
@@ -409,7 +409,7 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
     # significantly at some point then this may need to be versioned.
 
     _err = "out_of_bag_error_accuracy|out_of_bag_error_decision_function"
-    _get_tree_state = staticmethod(get_tree_state_cls)    
+    _get_tree_state = staticmethod(get_tree_state_cls)
 
     def __init__(
         self,
@@ -551,8 +551,8 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
                     force_all_finite=False,
                 )
             else:
-                X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
-                y = check_array(y, ensure_2d=False, dtype=X.dtype,force_all_finite=False)
+                X = check_array(X, dtype=[np.float64, np.float32], force_all_finite=False)
+                y = check_array(y, ensure_2d=False, dtype=X.dtype, force_all_finite=False)
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -776,7 +776,8 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
 
     def _onedal_predict(self, X, queue=None):
         X = check_array(
-            X, dtype=[np.float64, np.float32],
+            X,
+            dtype=[np.float64, np.float32],
             force_all_finite=False,
         )  # Warning, order of dtype matters
         check_is_fitted(self, "_onedal_estimator")
@@ -788,7 +789,7 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
         return np.take(self.classes_, res.ravel().astype(np.int64, casting="unsafe"))
 
     def _onedal_predict_proba(self, X, queue=None):
-        X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
+        X = check_array(X, dtype=[np.float64, np.float32], force_all_finite=False)
         check_is_fitted(self, "_onedal_estimator")
 
         if sklearn_check_version("0.23"):
@@ -918,8 +919,8 @@ class ForestRegressor(sklearn_ForestRegressor, BaseForest):
                     force_all_finite=False,
                 )
             else:
-                X = check_array(X, dtype=[np.float64, np.float32],force_all_finite=False)
-                y = check_array(y, ensure_2d=False, dtype=X.dtype,force_all_finite=False)
+                X = check_array(X, dtype=[np.float64, np.float32], force_all_finite=False)
+                y = check_array(y, ensure_2d=False, dtype=X.dtype, force_all_finite=False)
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -1082,8 +1083,7 @@ class ForestRegressor(sklearn_ForestRegressor, BaseForest):
 
     def _onedal_predict(self, X, queue=None):
         X = check_array(
-            X, dtype=[np.float64, np.float32],
-            force_all_finite=False
+            X, dtype=[np.float64, np.float32], force_all_finite=False
         )  # Warning, order of dtype matters
         check_is_fitted(self, "_onedal_estimator")
 


### PR DESCRIPTION
# Description
force_all_finite is used in validate_data, check_array, and check_X_y sklearn calls. This is a O(n) call with _assert_all_finite behind it which should only be done once, which is handled on the onedal side (see below for documentation).  There exists still a _assert_all_finite call in fit_supported still which cannot be removed due to missing_value support checks for sklearn ensemble algorithms.

For fit:
[X](https://github.com/intel/scikit-learn-intelex/blob/master/onedal/ensemble/forest.py#L356)
[y](https://github.com/intel/scikit-learn-intelex/blob/master/onedal/ensemble/forest.py#L356)
[sample_weights](https://github.com/intel/scikit-learn-intelex/blob/master/onedal/ensemble/forest.py#L337)

for predict:
[X](https://github.com/intel/scikit-learn-intelex/blob/master/onedal/ensemble/forest.py#L417)

for predict_proba:
[X](https://github.com/intel/scikit-learn-intelex/blob/master/onedal/ensemble/forest.py#L432)

Changes proposed in this pull request:
- set all force_all_finite in the sklearnex side to false to remove unnecessary calls.
- Change _get_tree_state to a static method for ForestRegressor and ForestClassifier