### PR TITLE
fix: update CI scripts to fail on intermediate failures

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -15,58 +15,58 @@
 #===============================================================================
 steps:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: 'apt-get'
+    displayName: "apt-get"
   - script: |
       bash .ci/scripts/install_dpcpp.sh
-    displayName: 'dpcpp installation'
+    displayName: "dpcpp installation"
   - script: |
       bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
+    displayName: "System info"
   - script: |
-      conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl>=0.14 "; else export DPCPP_PACKAGE=""; fi
+      conda update -y -q conda && \
+      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl>=0.14 "; else export DPCPP_PACKAGE=""; fi && \
       conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE dpcpp-cpp-rt>=2023.2.0
-    displayName: 'Conda create'
+    displayName: "Conda create"
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      pip install -r dependencies-dev
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
+      pip install -r dependencies-dev && \
       pip list
-    displayName: 'Install develop requirements'
+    displayName: "Install develop requirements"
   - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      export DALROOT=$CONDA_PREFIX
-      ./conda-recipe/build.sh
+      export DPCPPROOT=/opt/intel/oneapi/compiler/latest && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
+      export DALROOT=$CONDA_PREFIX && \
+      ./conda-recipe/build.sh && \
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
+    displayName: "Build daal4py/sklearnex"
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then conda install -q -y -c intel dpnp; fi
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && \
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && \
+      pip install $(python .ci/scripts/get_compatible_scipy_version.py) && \
+      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then conda install -q -y -c intel dpnp; fi && \
       pip list
-    displayName: 'Install testing requirements'
+    displayName: "Install testing requirements"
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      cd ..
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
+      cd .. && \
       ./s/conda-recipe/run_test.sh
-    displayName: 'Sklearnex testing'
+    displayName: "Sklearnex testing"
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
       bash .ci/scripts/run_sklearn_tests.sh cpu
-    displayName: 'Sklearn testing'
+    displayName: "Sklearn testing"
     condition: succeededOrFailed()
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
+      . /usr/share/miniconda/etc/profile.d/conda.sh && \
+      conda activate CB && \
       bash .ci/scripts/run_sklearn_tests.sh cpu
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: 'Sklearn testing [preview]'
+    displayName: "Sklearn testing [preview]"
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -15,47 +15,47 @@
 #===============================================================================
 steps:
   - script: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-      conda config --set always_yes yes --set changeps1 no
-      conda update -q conda
+      echo "##vso[task.prependpath]$CONDA/bin" && \
+      sudo chown -R $USER $CONDA && \
+      conda config --set always_yes yes --set changeps1 no && \
+      conda update -q conda && \
       conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich clang-format pyyaml
     displayName: Create Anaconda environment
   - script: |
-      source activate CB
-      pip install -q cpufeature
+      source activate CB && \
+      pip install -q cpufeature && \
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
-      source activate CB
-      pip install -r dependencies-dev
+      source activate CB && \
+      pip install -r dependencies-dev && \
       pip list
     displayName: 'Install develop requirements'
   - script: |
-      source activate CB
-      export DALROOT=$CONDA_PREFIX
-      ./conda-recipe/build.sh
+      source activate CB && \
+      export DALROOT=$CONDA_PREFIX && \
+      ./conda-recipe/build.sh && \
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: Conda build
   - script: |
-      source activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
+      source activate CB && \
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && \
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && \
+      pip install $(python .ci/scripts/get_compatible_scipy_version.py) && \
       pip list
     displayName: 'Install testing requirements'
   - script: |
-      source activate CB
-      cd ..
+      source activate CB && \
+      cd .. && \
       ./s/conda-recipe/run_test.sh
     displayName: 'Sklearnex testing'
   - script: |
-      source activate CB
+      source activate CB && \
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     condition: succeededOrFailed()
   - script: |
-      source activate CB
+      source activate CB && \
       bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -31,11 +31,11 @@ steps:
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
+      call activate CB
       set PREFIX=%CONDA_PREFIX%
       set DALROOT=%CONDA_PREFIX%
       set PYTHON=python
       call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 && ^
-      call activate CB && ^
       call conda-recipe\bld.bat && ^
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: "Build daal4py/sklearnex"

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -17,52 +17,52 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel impi-devel clang-format pyyaml
-    displayName: 'Create Anaconda environment'
+    displayName: "Create Anaconda environment"
   - script: |
-      call activate CB
-      pip install --upgrade setuptools
-      pip install cpufeature
-      pip install -r dependencies-dev
+      call activate CB && ^
+      pip install --upgrade setuptools && ^
+      pip install cpufeature && ^
+      pip install -r dependencies-dev && ^
       pip list
-    displayName: 'Install develop requirements'
+    displayName: "Install develop requirements"
   - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB
+      set PATH=C:\msys64\usr\bin;%PATH% && ^
+      call activate CB && ^
       bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
+    displayName: "System info"
   - script: |
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-      call activate CB
-      set PREFIX=%CONDA_PREFIX%
-      set PYTHON=python
-      call conda-recipe\bld.bat
-      set DALROOT=%CONDA_PREFIX%
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 && ^
+      call activate CB && ^
+      set PREFIX=%CONDA_PREFIX% && ^
+      set PYTHON=python && ^
+      call conda-recipe\bld.bat && ^
+      set DALROOT=%CONDA_PREFIX% && ^
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
+    displayName: "Build daal4py/sklearnex"
   - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
-      cd ..
-      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
-      pip install %SCIPY_VERSION%
+      set PATH=C:\msys64\usr\bin;%PATH% && ^
+      call activate CB && ^
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && ^
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && ^
+      cd .. && ^
+      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c && ^
+      pip install %SCIPY_VERSION% && ^
       pip list
-    displayName: 'Install testing requirements'
+    displayName: "Install testing requirements"
   - script: |
-      call activate CB
-      cd ..
+      call activate CB && ^
+      cd .. && ^
       call s\conda-recipe\run_test.bat s
-    displayName: 'Sklearnex testing'
+    displayName: "Sklearnex testing"
   - script: |
-      call activate CB
+      call activate CB && ^
       bash .ci/scripts/run_sklearn_tests.sh
-    displayName: 'Sklearn testing'
+    displayName: "Sklearn testing"
     condition: succeededOrFailed()
   - script: |
-      call activate CB
+      call activate CB && ^
       bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: 'Sklearn testing [preview]'
+    displayName: "Sklearn testing [preview]"
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -41,26 +41,26 @@ steps:
     displayName: "Build daal4py/sklearnex"
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB && ^
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && ^
+      call activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && ^
       cd .. && ^
-      for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c && ^
       pip install %SCIPY_VERSION% && ^
       pip list
     displayName: "Install testing requirements"
   - script: |
-      call activate CB && ^
-      cd .. && ^
+      call activate CB
+      cd ..
       call s\conda-recipe\run_test.bat s
     displayName: "Sklearnex testing"
   - script: |
-      call activate CB && ^
+      call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: "Sklearn testing"
     condition: succeededOrFailed()
   - script: |
-      call activate CB && ^
+      call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -26,21 +26,21 @@ steps:
       pip list
     displayName: "Install develop requirements"
   - script: |
-      set PATH=C:\msys64\usr\bin;%PATH% && ^
+      set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB && ^
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
+      set PREFIX=%CONDA_PREFIX%
+      set DALROOT=%CONDA_PREFIX%
+      set PYTHON=python
       call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 && ^
       call activate CB && ^
-      set PREFIX=%CONDA_PREFIX% && ^
-      set PYTHON=python && ^
       call conda-recipe\bld.bat && ^
-      set DALROOT=%CONDA_PREFIX% && ^
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: "Build daal4py/sklearnex"
   - script: |
-      set PATH=C:\msys64\usr\bin;%PATH% && ^
+      set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB && ^
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && ^
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && ^

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -17,52 +17,52 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel impi-devel clang-format pyyaml
-    displayName: "Create Anaconda environment"
+    displayName: 'Create Anaconda environment'
   - script: |
-      call activate CB && ^
-      pip install --upgrade setuptools && ^
-      pip install cpufeature && ^
-      pip install -r dependencies-dev && ^
+      call activate CB
+      pip install --upgrade setuptools
+      pip install cpufeature
+      pip install -r dependencies-dev
       pip list
-    displayName: "Install develop requirements"
+    displayName: 'Install develop requirements'
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
-      call activate CB && ^
+      call activate CB
       bash .ci/scripts/describe_system.sh
-    displayName: "System info"
+    displayName: 'System info'
   - script: |
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
       call activate CB
       set PREFIX=%CONDA_PREFIX%
-      set DALROOT=%CONDA_PREFIX%
       set PYTHON=python
-      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 && ^
-      call conda-recipe\bld.bat && ^
+      call conda-recipe\bld.bat
+      set DALROOT=%CONDA_PREFIX%
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: "Build daal4py/sklearnex"
+    displayName: 'Build daal4py/sklearnex'
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
       cd ..
-      bash s\.ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && ^
-      pip install %SCIPY_VERSION% && ^
+      pip install %SCIPY_VERSION%
       pip list
-    displayName: "Install testing requirements"
+    displayName: 'Install testing requirements'
   - script: |
       call activate CB
       cd ..
       call s\conda-recipe\run_test.bat s
-    displayName: "Sklearnex testing"
+    displayName: 'Sklearnex testing'
   - script: |
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
-    displayName: "Sklearn testing"
+    displayName: 'Sklearn testing'
     condition: succeededOrFailed()
   - script: |
       call activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: "Sklearn testing [preview]"
+    displayName: 'Sklearn testing [preview]'
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -42,10 +42,10 @@ steps:
   - script: |
       set PATH=C:\msys64\usr\bin;%PATH%
       call activate CB
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      cd ..
+      bash s\.ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       for /f "delims=" %%c in ('python s\.ci\scripts\get_compatible_scipy_version.py') do set SCIPY_VERSION=%%c
       pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && ^
-      cd .. && ^
       pip install %SCIPY_VERSION% && ^
       pip list
     displayName: "Install testing requirements"


### PR DESCRIPTION
The CI scripts would only trigger a failed step if the last command in each `script` returned a non-zero exit code. By logically `and`ing all commands, intermediate commands can fail the entire step.