### PR TITLE
CI: Add SHELLOPTS for immediate exit from pipeline script

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -30,6 +30,7 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      python -c "import sys; sys.exit(-1)"
       pip install -r dependencies-dev
       pip list
     displayName: 'Install develop requirements'

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -15,25 +15,25 @@
 #===============================================================================
 steps:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: 'apt-get'
+    displayName: "apt-get"
   - script: |
       bash .ci/scripts/install_dpcpp.sh
-    displayName: 'dpcpp installation'
+    displayName: "dpcpp installation"
   - script: |
       bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
+    displayName: "System info"
   - script: |
       conda update -y -q conda
       if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl>=0.14 "; else export DPCPP_PACKAGE=""; fi
       conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE dpcpp-cpp-rt>=2023.2.0
-    displayName: 'Conda create'
+    displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       python -c "import sys; sys.exit(-1)"
       pip install -r dependencies-dev
       pip list
-    displayName: 'Install develop requirements'
+    displayName: "Install develop requirements"
   - script: |
       export DPCPPROOT=/opt/intel/oneapi/compiler/latest
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -41,7 +41,7 @@ steps:
       export DALROOT=$CONDA_PREFIX
       ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: 'Build daal4py/sklearnex'
+    displayName: "Build daal4py/sklearnex"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -50,18 +50,18 @@ steps:
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then conda install -q -y -c intel dpnp; fi
       pip list
-    displayName: 'Install testing requirements'
+    displayName: "Install testing requirements"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       cd ..
       ./s/conda-recipe/run_test.sh
-    displayName: 'Sklearnex testing'
+    displayName: "Sklearnex testing"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
-    displayName: 'Sklearn testing'
+    displayName: "Sklearn testing"
     condition: succeededOrFailed()
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -69,5 +69,5 @@ steps:
       bash .ci/scripts/run_sklearn_tests.sh cpu
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: 'Sklearn testing [preview]'
+    displayName: "Sklearn testing [preview]"
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -30,7 +30,6 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
-      python -c "import sys; sys.exit(-1)"
       pip install -r dependencies-dev
       pip list
     displayName: "Install develop requirements"

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -15,58 +15,58 @@
 #===============================================================================
 steps:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
-    displayName: "apt-get"
+    displayName: 'apt-get'
   - script: |
       bash .ci/scripts/install_dpcpp.sh
-    displayName: "dpcpp installation"
+    displayName: 'dpcpp installation'
   - script: |
       bash .ci/scripts/describe_system.sh
-    displayName: "System info"
+    displayName: 'System info'
   - script: |
-      conda update -y -q conda && \
-      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl>=0.14 "; else export DPCPP_PACKAGE=""; fi && \
+      conda update -y -q conda
+      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl>=0.14 "; else export DPCPP_PACKAGE=""; fi
       conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) dal-devel mpich pyyaml $DPCPP_PACKAGE dpcpp-cpp-rt>=2023.2.0
-    displayName: "Conda create"
+    displayName: 'Conda create'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
-      pip install -r dependencies-dev && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      pip install -r dependencies-dev
       pip list
-    displayName: "Install develop requirements"
+    displayName: 'Install develop requirements'
   - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest && \
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
-      export DALROOT=$CONDA_PREFIX && \
-      ./conda-recipe/build.sh && \
+      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      export DALROOT=$CONDA_PREFIX
+      ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
-    displayName: "Build daal4py/sklearnex"
+    displayName: 'Build daal4py/sklearnex'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && \
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && \
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py) && \
-      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then conda install -q -y -c intel dpnp; fi && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
+      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
+      if [ $(echo $(PYTHON_VERSION) | grep '3.8\|3.9\|3.10') ]; then conda install -q -y -c intel dpnp; fi
       pip list
-    displayName: "Install testing requirements"
+    displayName: 'Install testing requirements'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
-      cd .. && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      cd ..
       ./s/conda-recipe/run_test.sh
-    displayName: "Sklearnex testing"
+    displayName: 'Sklearnex testing'
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
-    displayName: "Sklearn testing"
+    displayName: 'Sklearn testing'
     condition: succeededOrFailed()
   - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh && \
-      conda activate CB && \
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
       bash .ci/scripts/run_sklearn_tests.sh cpu
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: "Sklearn testing [preview]"
+    displayName: 'Sklearn testing [preview]'
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -15,47 +15,47 @@
 #===============================================================================
 steps:
   - script: |
-      echo "##vso[task.prependpath]$CONDA/bin" && \
-      sudo chown -R $USER $CONDA && \
-      conda config --set always_yes yes --set changeps1 no && \
-      conda update -q conda && \
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
       conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich clang-format pyyaml
     displayName: Create Anaconda environment
   - script: |
-      source activate CB && \
-      pip install -q cpufeature && \
+      source activate CB
+      pip install -q cpufeature
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
-      source activate CB && \
-      pip install -r dependencies-dev && \
+      source activate CB
+      pip install -r dependencies-dev
       pip list
     displayName: 'Install develop requirements'
   - script: |
-      source activate CB && \
-      export DALROOT=$CONDA_PREFIX && \
-      ./conda-recipe/build.sh && \
+      source activate CB
+      export DALROOT=$CONDA_PREFIX
+      ./conda-recipe/build.sh
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: Conda build
   - script: |
-      source activate CB && \
-      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION) && \
-      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt && \
-      pip install $(python .ci/scripts/get_compatible_scipy_version.py) && \
+      source activate CB
+      bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
+      pip install --upgrade -r requirements-test.txt -r requirements-test-optional.txt
+      pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       pip list
     displayName: 'Install testing requirements'
   - script: |
-      source activate CB && \
-      cd .. && \
+      source activate CB
+      cd ..
       ./s/conda-recipe/run_test.sh
     displayName: 'Sklearnex testing'
   - script: |
-      source activate CB && \
+      source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
     condition: succeededOrFailed()
   - script: |
-      source activate CB && \
+      source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -28,7 +28,6 @@ steps:
     displayName: "System info"
   - script: |
       source activate CB
-      python -c "import sys; sys.exit(-1)"
       pip install -r dependencies-dev
       pip list
     displayName: 'Install develop requirements'

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -28,6 +28,7 @@ steps:
     displayName: "System info"
   - script: |
       source activate CB
+      python -c "import sys; sys.exit(-1)"
       pip install -r dependencies-dev
       pip list
     displayName: 'Install develop requirements'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -40,6 +40,7 @@ variables:
   MACOSX_DEPLOYMENT_TARGET: '10.15'
   PYTHON: 'python'
   ARGS: '1'
+  SHELLOPTS: 'errexit:pipefail'
 
 jobs:
 - job: Lint

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -21,6 +21,7 @@ variables:
   PYTHON: 'python'
   ARGS: '1'
   SELECTED_TESTS: 'all'
+  SHELLOPTS: 'errexit:pipefail'
 
 jobs:
 - job: Coverity


### PR DESCRIPTION
Add `SHELLOPTS='errexit:pipefail'` on Unix systems for immediate exit from pipeline step script if last command has non-zero exit code.
For example of work, see jobs in https://github.com/intel/scikit-learn-intelex/pull/1554/commits/08210a559dd99b6fe4f89fb54e8f916bd14dba32 commit.