### PR TITLE
Create a more informative error in assert in _get_policy.py for the dpc backend

### DIFF
--- a/onedal/common/_policy.py
+++ b/onedal/common/_policy.py
@@ -32,7 +32,9 @@ def _get_policy(queue, *data):
             return _DataParallelInteropPolicy(data_queue)
         return _DataParallelInteropPolicy(queue)
     if not (data_queue is None and queue is None):
-        raise RuntimeError("Operation using the requested SYCL queue requires the DPC backend")
+        raise RuntimeError(
+            "Operation using the requested SYCL queue requires the DPC backend"
+        )
     return _HostInteropPolicy()
 
 

--- a/onedal/common/_policy.py
+++ b/onedal/common/_policy.py
@@ -31,7 +31,8 @@ def _get_policy(queue, *data):
                 return _HostInteropPolicy()
             return _DataParallelInteropPolicy(data_queue)
         return _DataParallelInteropPolicy(queue)
-    assert data_queue is None and queue is None
+    if not (data_queue is None and queue is None):
+        raise RuntimeError("Operation using the requested SYCL queue requires the DPC backend")
     return _HostInteropPolicy()
 
 


### PR DESCRIPTION
# Description
Users can run into this assert statement when the dpc backend isn't created. There is no information on what is wrong, which is that they need to have compiled scikit-learn-intelex with the proper compiler for the dpc backend.  I have run into this unfortunately and the bare assert was uninformative.  This also come across when dpctl isn't installed or the improper version is used (i.e. any case without the dpc backend).

Changes proposed in this pull request:
- Add an informative RuntimeError with a string

 
