### PR TITLE
[bug] csr_array input causes onedal/utils/validation.py _check_array fail

### DIFF
--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -144,7 +144,7 @@ def _check_array(
         accept_large_sparse=accept_large_sparse,
     )
 
-    if sp.isspmatrix(array):
+    if sp.issparse(array):
         return array
 
     # TODO: Convert this kind of arrays to a table like in daal4py


### PR DESCRIPTION
# Description
Switch check for sparsity from isspmatrix to issparse which is more general and covers csr_array.

Changes proposed in this pull request:
- isspmatrix -> issparse

 
