### PR TITLE
[bug] fix scikit-learn upper bound dependency for conda public Releases CI

### DIFF
--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -70,6 +70,7 @@ jobs:
   - script: |
       conda update -y -q -c defaults conda
       conda create -y -q -n CB -c $(conda.channel) python=$(python.version) scikit-learn-intelex pandas pytest pyyaml
+      conda install -y -q -n CB -c $(conda.channel) python=$(python.version) $(python .ci/scripts/get_compatible_sklearn_version.py $(conda.channel))
     displayName: 'Install scikit-learn-intelex'
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/scripts/get_compatible_sklearn_version.py
+++ b/.ci/scripts/get_compatible_sklearn_version.py
@@ -1,8 +1,8 @@
 import json
 import os
+import re
 import subprocess
 import sys
-import re
 
 # Find current Scikit-learn major versions in release order
 conda_call = subprocess.run(

--- a/.ci/scripts/get_compatible_sklearn_version.py
+++ b/.ci/scripts/get_compatible_sklearn_version.py
@@ -1,0 +1,55 @@
+import json
+import os
+import subprocess
+import sys
+import re
+
+# Find current Scikit-learn major versions in release order
+conda_call = subprocess.run(
+    ["conda", "search", "scikit-learn", "-c", sys.argv[1]], capture_output=True
+)
+info = conda_call.stdout.decode("utf-8").strip()
+sklearn_major_versions = list(dict.fromkeys(re.findall(r"[0-9]\.[0-9]+", info)))
+
+# Find the location of the installed packages
+conda_call = subprocess.run(["conda", "info"], capture_output=True)
+info = conda_call.stdout.decode("utf-8").strip()
+loc = list(re.findall(r"package\scache\s:\s[^\s]+", info))[0].split()[-1]
+
+# Find the info.json from the Scikit-learn-intelex install
+conda_call = subprocess.run(
+    ["conda", "list", "scikit-learn-intelex"], capture_output=True
+)
+info = conda_call.stdout.decode("utf-8").strip()
+pkg = re.sub(r"\s+", r"-", info.split("\n")[-1])
+loc += os.sep + pkg + os.sep + "info" + os.sep + "index.json"
+
+# Extract the min and possibly max supported major version of Scikit-learn
+# from the Scikit-learn-intelex index.json information
+with open(loc) as json_file:
+    json_data = json.load(json_file)
+    deps = [
+        string for string in json_data["depends"] if string.find("scikit-learn") != -1
+    ][0]
+
+depstr = re.findall(r">=[0-9]\.[0-9]+", deps)[0][2:]
+depstr2 = re.findall(r"<[0-9]\.[0-9]+", deps)
+
+
+# Each Scikit-learn-intelex version supports 4 major versions
+# Install the latest supported Scikit-learn for the installed scikit-learn-intelex
+if depstr2:
+    print(
+        "scikit-learn="
+        + sklearn_major_versions[max(0, sklearn_major_versions.index(depstr2) - 1)]
+    )
+else:
+    print(
+        "scikit-learn="
+        + sklearn_major_versions[
+            min(
+                len(sklearn_major_versions) - 1,
+                sklearn_major_versions.index(depstr) + 3,
+            )
+        ]
+    )

--- a/setup_sklearnex.py
+++ b/setup_sklearnex.py
@@ -148,7 +148,7 @@ setup(
         "Topic :: Software Development",
     ],
     python_requires=">=3.8",
-    install_requires=["daal4py>=2024.0", "scikit-learn>=1.0"],
+    install_requires=["daal4py>=2024.0", "scikit-learn>=1.0, <1.4"],
     keywords=[
         "machine learning",
         "scikit-learn",

--- a/setup_sklearnex.py
+++ b/setup_sklearnex.py
@@ -148,7 +148,7 @@ setup(
         "Topic :: Software Development",
     ],
     python_requires=">=3.8",
-    install_requires=["daal4py>=2024.0", "scikit-learn>=1.0, <1.4"],
+    install_requires=["daal4py>=2024.0", "scikit-learn>=1.0"],
     keywords=[
         "machine learning",
         "scikit-learn",


### PR DESCRIPTION
# Description
This will check the installed scikit-learn version, and will reinstall scikit-learn as necessary to the last-supported scikit-learn version for the currently available scikit-learn-intelex on the conda channel. Currently, it will test scikit-learn-intelex against a scikit-learn version that was not supported at the time of the scikit-learn-intelex release.

This will solve the Releases CI failures, which are errant faults (and may be covering true errors in recent merges).

I recommend we add an upper bound to the conda channels to avoid this problem in a more standardized way.

Changes proposed in this pull request:
- add another scikit-learn install to the releases.ci
- include a python program "get_compatible_sklearn_version.py" to check conda for the proper supported sklearn (since an upper bound is not included in most scikit-learn-intelex conda releases).

 
