### PR TITLE
Revert "chore(deps): update dependency cmake to v3.28.1 (#1615)"

### DIFF
--- a/dependencies-dev
+++ b/dependencies-dev
@@ -5,4 +5,4 @@ numpy==1.21.6 ; python_version == '3.10'
 numpy==1.23.5 ; python_version == '3.11'
 numpy==1.26.2 ; python_version >= '3.12'
 pybind11==2.11.1
-cmake==3.28.1
+cmake==3.27.9


### PR DESCRIPTION
Fixes https://github.com/intel/scikit-learn-intelex/pull/1615 which turned from green Precommit to red CI.