### PR TITLE
tests: push back kmeans spmd example again

### DIFF
--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -140,7 +140,7 @@ req_version["decision_forest_classification_default_dense.py"] = (2023, "P", 100
 req_version["decision_forest_classification_traverse.py"] = (2023, "P", 100)
 req_version["basic_statistics_spmd.py"] = (2023, "P", 100)
 # Temporary disabling due to sporadict timeout on PVC
-req_version["kmeans_spmd.py"] = (2024, "P", 101)
+req_version["kmeans_spmd.py"] = (2024, "P", 201)
 req_version["knn_bf_classification_spmd.py"] = (2023, "P", 100)
 req_version["knn_bf_regression_spmd.py"] = (2023, "P", 100)
 req_version["linear_regression_spmd.py"] = (2023, "P", 100)


### PR DESCRIPTION
# Description
Bump required oneDAL version to run kmeans_spmd.py example in CI. Hopefully for the last time.

 
