### PR TITLE
[bug,enh] add exception handling to daal4py LogisticRegression.fit monkeypatch

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -1034,9 +1034,10 @@ if sklearn_check_version("0.24"):
             setattr(which, what, replacer)
             try:
                 clf = LogisticRegression_original.fit(self, X, y, sample_weight)
-            except Exception as e:
+            except Exception as error:
+                # guarantee monkeypatch is returned to previous state
                 setattr(which, what, descriptor)
-                raise e
+                raise error
 
             setattr(which, what, descriptor)
             return clf

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -1034,12 +1034,8 @@ if sklearn_check_version("0.24"):
             setattr(which, what, replacer)
             try:
                 clf = LogisticRegression_original.fit(self, X, y, sample_weight)
-            except Exception as error:
-                # guarantee monkeypatch is returned to previous state
+            finally:
                 setattr(which, what, descriptor)
-                raise error
-
-            setattr(which, what, descriptor)
             return clf
 
         @support_usm_ndarray()

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -1032,7 +1032,12 @@ if sklearn_check_version("0.24"):
             replacer = logistic_regression_path
             descriptor = getattr(which, what, None)
             setattr(which, what, replacer)
-            clf = super().fit(X, y, sample_weight)
+            try:
+                clf = LogisticRegression_original.fit(self, X, y, sample_weight)
+            except Exception as e:
+                setattr(which, what, descriptor)
+                raise e
+
             setattr(which, what, descriptor)
             return clf
 


### PR DESCRIPTION
Initial fix for daal4py's LogisticRegression fit, which uses a monkeypatch design pattern to calculate the fit. This currently doesn't have a reversion capability in the case of an error. This means any exception will not properly return sklearn to the original state. Secondly, this method will be used by the new LogisticRegression (#1649) but without inheritance, requiring moving from a super statement to something more explicit such that it can be used without inheritance.

Changes proposed in this pull request:
- Add a try finally statement to guarantee that monkeypatch is reverted before returning
- switch from super().fit() to LogisticRegression_original.fit(self...) for use by non-inherited classes

Tasks
- [x] implement
- [x] test
- [x] benchmark

 
