### PR TITLE
[bug,testing] correct n_jobs testing for aliased class methods

### DIFF
--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -65,7 +65,7 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
 
         for i in funcs:
             assert hasattr(funcs[i], "__onedal_n_jobs_decorated__") == (
-                i in estimator._n_jobs_suppored_onedal_methods
+                i in estimator._n_jobs_supported_onedal_methods
             ), f"{estimator}.{i} n_jobs decoration does not match {estimator} n_job supported methods"
 
     caplog.set_level(logging.DEBUG, logger="sklearnex")

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -64,10 +64,9 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
         }
 
         for i in funcs:
-            if func in estimator._n_jobs_supported_onedal_methods:
-                assert hasattr(funcs[i], "__onedal_n_jobs_decorated__")
-            else:
-                assert not hasattr(funcs[i], "__onedal_n_jobs_decorated__")
+            assert hasattr(funcs[i], "__onedal_n_jobs_decorated__") == (
+                i in estimator._n_jobs_suppored_onedal_methods
+            ), f"{estimator}.{i} n_jobs decoration does not match {estimator} n_job supported methods"
 
     caplog.set_level(logging.DEBUG, logger="sklearnex")
     estimator_kwargs = {"n_jobs": n_jobs}

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -16,7 +16,6 @@
 
 import inspect
 import logging
-from io import StringIO
 from multiprocessing import cpu_count
 
 import pytest
@@ -58,19 +57,17 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
         assert check_n_jobs_entry_in_logs(caplog, method.__name__, n_jobs)
 
     def check_methods_decoration(estimator):
-        attrs = []
-        for attr_name in dir(estimator):
-            try:
-                attrs.append(getattr(estimator, attr_name))
-            except AttributeError:
-                # some attribute are available depending on specific estimator parameters
-                pass
-        funcs = filter(lambda attr: inspect.isfunction(attr), attrs)
-        for func in funcs:
-            if func.__name__ in estimator._n_jobs_supported_onedal_methods:
-                assert hasattr(func, "__onedal_n_jobs_decorated__")
+        funcs = {
+            i: getattr(estimator, i)
+            for i in dir(estimator)
+            if hasattr(estimator, i) and callable(getattr(estimator, i))
+        }
+
+        for i in funcs:
+            if func in estimator._n_jobs_supported_onedal_methods:
+                assert hasattr(funcs[i], "__onedal_n_jobs_decorated__")
             else:
-                assert not hasattr(func, "__onedal_n_jobs_decorated__")
+                assert not hasattr(funcs[i], "__onedal_n_jobs_decorated__")
 
     caplog.set_level(logging.DEBUG, logger="sklearnex")
     estimator_kwargs = {"n_jobs": n_jobs}

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -63,10 +63,10 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
             if hasattr(estimator, i) and callable(getattr(estimator, i))
         }
 
-        for i in funcs:
-            assert hasattr(funcs[i], "__onedal_n_jobs_decorated__") == (
-                i in estimator._n_jobs_supported_onedal_methods
-            ), f"{estimator}.{i} n_jobs decoration does not match {estimator} n_job supported methods"
+        for func_name, func in funcs.items():
+            assert hasattr(func, "__onedal_n_jobs_decorated__") == (
+                func_name in estimator._n_jobs_supported_onedal_methods
+            ), f"{estimator}.{func_name} n_jobs decoration does not match {estimator} n_jobs supported methods"
 
     caplog.set_level(logging.DEBUG, logger="sklearnex")
     estimator_kwargs = {"n_jobs": n_jobs}


### PR DESCRIPTION
# Description
The current logic will check the name of the method via the ```__name__``` parameter of the attribute. For aliased methods, this will give the incorrect name for the attribute (it will provide the original rather than new name). If a new attribute is created from one with n_jobs_support with an additional wrap, this will cause an erroneous failure in the test. The following would fail.

```python
@control_n_jobs(decorated_methods=["hello"])
class example():
    def hello():
        pass
    hello2 = wrap_output_data(hello)
    
print(getattr(example, "hello").__name__)
print(getattr(example,"hello2").__name__) # will print hello instead of hello2
```
Such a class above will test the ```hello2``` and ```hello``` methods as the name ```hello```. This issue was observed in the LocalOutlierFactor refactor (#1640), where certain methods need to be accessed without wrap_output_data, and overall needs to have n_jobs support (see _kneighbors and kneighbors methods).
 
Changes proposed in this pull request:
- fix the error by using a dict to store names, use those for testing
- use hasattr to handle available_if rather than try catch (fixes issues for lof, NuSVC, etc)

 
