### PR TITLE
deps: Update scipy script from major release

### DIFF
--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -19,9 +19,11 @@ from sys import version_info as python_version
 
 from daal4py.sklearn._utils import sklearn_check_version
 
-if sklearn_check_version("1.3") or python_version[1] > 11:
+if sklearn_check_version("1.4"):
     print("Scipy version is not specified for this sklearn/python version.", file=stderr)
     print("scipy")
+elif sklearn_check_version("1.3") or python_version[1] > 11:
+    print("scipy==1.11.*")
 elif sklearn_check_version("1.2") or python_version[1] > 10:
     print("scipy==1.9.*")
 elif sklearn_check_version("1.1"):


### PR DESCRIPTION
# Description
Scipy just had major release (0.12) which is now being installed with our sklearn1.3 validation - need to downgrade for compatibility. Should resolve sporadic `scipy flapack liwork dsyevr` errors in conformance steps.
