### PR TITLE
[enhancement] prevent double-wrapping of run_with_n_jobs

### DIFF
--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -225,10 +225,11 @@ def control_n_jobs(decorated_methods: list = []):
         # decorate methods to be run with applied n_jobs parameter
         for method_name in decorated_methods:
             method = getattr(original_class, method_name, None)
-            decorated_method = _run_with_n_jobs(method)
-            # sign decorated method for testing and other purposes
-            decorated_method.__onedal_n_jobs_decorated__ = True
-            setattr(original_class, method_name, decorated_method)
+            if not hasattr(method, "__onedal_n_jobs_decorated__"):
+                decorated_method = _run_with_n_jobs(method)
+                # sign decorated method for testing and other purposes
+                decorated_method.__onedal_n_jobs_decorated__ = True
+                setattr(original_class, method_name, decorated_method)
 
         return original_class
 

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -224,8 +224,9 @@ def control_n_jobs(decorated_methods: list = []):
 
         # decorate methods to be run with applied n_jobs parameter
         for method_name in decorated_methods:
-            method = getattr(original_class, method_name, None)
-            if method and not hasattr(method, "__onedal_n_jobs_decorated__"):
+            # if method doesn't exist, we want it to raise an Exception
+            method = getattr(original_class, method_name)
+            if not hasattr(method, "__onedal_n_jobs_decorated__"):
                 decorated_method = _run_with_n_jobs(method)
                 # sign decorated method for testing and other purposes
                 decorated_method.__onedal_n_jobs_decorated__ = True

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -225,7 +225,7 @@ def control_n_jobs(decorated_methods: list = []):
         # decorate methods to be run with applied n_jobs parameter
         for method_name in decorated_methods:
             method = getattr(original_class, method_name, None)
-            if not hasattr(method, "__onedal_n_jobs_decorated__"):
+            if method and not hasattr(method, "__onedal_n_jobs_decorated__"):
                 decorated_method = _run_with_n_jobs(method)
                 # sign decorated method for testing and other purposes
                 decorated_method.__onedal_n_jobs_decorated__ = True


### PR DESCRIPTION
Seen in #1649, when an object aliases a method which has been wrapped with n_jobs support, it will fail testing unless it is included in decorated_methods. When it is in decorated_methods, it will wrap the method again (which is unnecessary).  This adds a check to see if it already has an n_jobs wrap, and sets getattr to fail if the method doesn't exist (currently sets to None, but an exception is preferrable)

Changes proposed in this pull request:
- Add if statement to prevent double wrap
- Remove getattr to set to None in case method doesn't exist (exception preferrable)
 
