### PR TITLE
[enhancement] isolate underlying fit call in daal4py LogisticRegression

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -1020,7 +1020,7 @@ if sklearn_check_version("0.24"):
             -----
             The SAGA solver supports both float64 and float32 bit arrays.
             """
-            return self.daal4py_fit(self, X, y, sample_weight)
+            return self.daal4py_fit(X, y, sample_weight)
             
         def daal4py_fit(self, X, y, sample_weight=None):
             if sklearn_check_version("1.0"):

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -777,10 +777,6 @@ def __logistic_regression_path(
 
 
 def daal4py_fit(self, X, y, sample_weight=None):
-    if sklearn_check_version("1.0"):
-        self._check_feature_names(X, reset=True)
-    if sklearn_check_version("1.2"):
-        self._validate_params()
     which, what = logistic_module, "_logistic_regression_path"
     replacer = logistic_regression_path
     descriptor = getattr(which, what, None)
@@ -1036,6 +1032,10 @@ if sklearn_check_version("0.24"):
             -----
             The SAGA solver supports both float64 and float32 bit arrays.
             """
+            if sklearn_check_version("1.0"):
+                self._check_feature_names(X, reset=True)
+            if sklearn_check_version("1.2"):
+                self._validate_params()
             return daal4py_fit(self, X, y, sample_weight)
 
         @support_usm_ndarray()

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -1020,6 +1020,9 @@ if sklearn_check_version("0.24"):
             -----
             The SAGA solver supports both float64 and float32 bit arrays.
             """
+            return self.daal4py_fit(self, X, y, sample_weight)
+            
+        def daal4py_fit(self, X, y, sample_weight=None):
             if sklearn_check_version("1.0"):
                 self._check_feature_names(X, reset=True)
             if sklearn_check_version("1.2"):

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -776,6 +776,22 @@ def __logistic_regression_path(
     return np.array(coefs), np.array(Cs), n_iter
 
 
+def daal4py_fit(self, X, y, sample_weight=None):
+    if sklearn_check_version("1.0"):
+        self._check_feature_names(X, reset=True)
+    if sklearn_check_version("1.2"):
+        self._validate_params()
+    which, what = logistic_module, "_logistic_regression_path"
+    replacer = logistic_regression_path
+    descriptor = getattr(which, what, None)
+    setattr(which, what, replacer)
+    try:
+        clf = LogisticRegression_original.fit(self, X, y, sample_weight)
+    finally:
+        setattr(which, what, descriptor)
+    return clf
+
+
 def daal4py_predict(self, X, resultsToEvaluate):
     check_is_fitted(self)
     if sklearn_check_version("1.0"):
@@ -1020,22 +1036,7 @@ if sklearn_check_version("0.24"):
             -----
             The SAGA solver supports both float64 and float32 bit arrays.
             """
-            return self.daal4py_fit(X, y, sample_weight)
-            
-        def daal4py_fit(self, X, y, sample_weight=None):
-            if sklearn_check_version("1.0"):
-                self._check_feature_names(X, reset=True)
-            if sklearn_check_version("1.2"):
-                self._validate_params()
-            which, what = logistic_module, "_logistic_regression_path"
-            replacer = logistic_regression_path
-            descriptor = getattr(which, what, None)
-            setattr(which, what, replacer)
-            try:
-                clf = LogisticRegression_original.fit(self, X, y, sample_weight)
-            finally:
-                setattr(which, what, descriptor)
-            return clf
+            return daal4py_fit(self, X, y, sample_weight)
 
         @support_usm_ndarray()
         def predict(self, X):


### PR DESCRIPTION
# Description
Re-use of daal4py methods directly can cause issue with various wrappers, and currently the implementation of fit doesn't match that of predict and predict_proba. This change introduces an indirection using daal4py_fit. This will help solve issues observed in #1666 and #1649

Changes proposed in this pull request:
- daal4py_fit

 
