### PR TITLE
[testing, bug] allow for n_jobs support on methods without arguments

### DIFF
--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -84,7 +84,10 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
         if method_name == "fit":
             continue
         method = getattr(estimator_instance, method_name)
-        check_method(X, method=method, caplog=caplog)
+        if len(inspect.signature(method).parameters) == 0:
+            check_method(method=method, caplog=caplog)
+        else:
+            check_method(X, method=method, caplog=caplog)
     # check if correct methods were decorated
     check_methods_decoration(estimator_class)
     check_methods_decoration(estimator_instance)


### PR DESCRIPTION
# Description
Testing n_jobs support currently requires that the wrapped function take inputs. There are circumstances ([in Incremental Algorithms](https://github.com/intel/scikit-learn-intelex/blob/main/sklearnex/covariance/incremental_covariance.py#L58)) where onedal code may be called without an input to finalize a computation. Decorating these methods for n_jobs will lead to erroneous test failures.

Changes proposed in this pull request:
- Add an inspect check on the method input, and branch test for methods which take args, and those that don't

 
