### PR TITLE
Correct DPCPP detection in setup

### DIFF
--- a/daal4py/oneapi/__init__.py
+++ b/daal4py/oneapi/__init__.py
@@ -18,6 +18,7 @@ import platform
 
 if "Windows" in platform.system():
     import os
+    import shutil
     import sys
     import sysconfig
 
@@ -26,15 +27,14 @@ if "Windows" in platform.system():
     sitepackages_path = sysconfig.get_paths()["purelib"]
     installed_package_path = os.path.join(sitepackages_path, "daal4py", "oneapi")
     if sys.version_info.minor >= 8:
-        if "DPCPPROOT" in os.environ:
-            dpcpp_rt_root_bin = os.path.join(os.environ["DPCPPROOT"], "windows", "bin")
-            dpcpp_rt_root_redist = os.path.join(
-                os.environ["DPCPPROOT"], "windows", "redist", "intel64_win", "compiler"
-            )
-            if os.path.exists(dpcpp_rt_root_bin):
-                os.add_dll_directory(dpcpp_rt_root_bin)
-            if os.path.exists(dpcpp_rt_root_redist):
-                os.add_dll_directory(dpcpp_rt_root_redist)
+        dpc_path = shutil.which("icpx")
+        if dpc_path is not None:
+            dpc_bin_dir = os.path.dirname(dpc_path)
+            dpc_compiler_dir = os.path.join(dpc_bin_dir, "compiler")
+            if os.path.exists(dpc_bin_dir):
+                os.add_dll_directory(dpc_bin_dir)
+            if os.path.exists(dpc_compiler_dir):
+                os.add_dll_directory(dpc_compiler_dir)
         os.add_dll_directory(current_path)
         if os.path.exists(installed_package_path):
             os.add_dll_directory(installed_package_path)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -108,8 +108,9 @@ if(IFACE STREQUAL "host")
 elseif(IFACE STREQUAL "dpc")
     set(TARGET "_onedal_py_dpc")
 
+    # FIXME: icx>=2024.1 and pybind11 don't work correctly with IPO
     if(WIN32)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=link")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
     endif()
 
     if(CMAKE_CXX_COMPILER MATCHES ".*icpx" OR CMAKE_CXX_COMPILER MATCHES ".*icx")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -108,6 +108,10 @@ if(IFACE STREQUAL "host")
 elseif(IFACE STREQUAL "dpc")
     set(TARGET "_onedal_py_dpc")
 
+    if(WIN32)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=link")
+    endif()
+
     if(CMAKE_CXX_COMPILER MATCHES ".*icpx" OR CMAKE_CXX_COMPILER MATCHES ".*icx")
         set(CMAKE_CXX_FLAGS "-fsycl ${CMAKE_CXX_FLAGS}")
     endif()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ import glob
 # System imports
 import os
 import pathlib
+import shutil
 import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -84,8 +85,7 @@ trues = ["true", "True", "TRUE", "1", "t", "T", "y", "Y", "Yes", "yes", "YES"]
 no_dist = True if "NO_DIST" in os.environ and os.environ["NO_DIST"] in trues else False
 no_stream = "NO_STREAM" in os.environ and os.environ["NO_STREAM"] in trues
 mpi_root = None if no_dist else os.environ["MPIROOT"]
-dpcpp = True if "DPCPPROOT" in os.environ else False
-dpcpp_root = None if not dpcpp else os.environ["DPCPPROOT"]
+dpcpp = shutil.which("icpx") is not None
 
 use_parameters_lib = (not IS_WIN) and (ONEDAL_VERSION >= 20240000)
 

--- a/setup_sklearnex.py
+++ b/setup_sklearnex.py
@@ -17,6 +17,7 @@
 
 # System imports
 import os
+import shutil
 import sys
 import time
 
@@ -51,8 +52,7 @@ if dal_root is None:
 
 trues = ["true", "True", "TRUE", "1", "t", "T", "y", "Y", "Yes", "yes", "YES"]
 no_dist = True if "NO_DIST" in os.environ and os.environ["NO_DIST"] in trues else False
-dpcpp = True if "DPCPPROOT" in os.environ else False
-dpcpp_root = None if not dpcpp else os.environ["DPCPPROOT"]
+dpcpp = shutil.which("icpx") is not None
 
 try:
     import dpctl


### PR DESCRIPTION
Update dpcpp compiler detection to last changes on Windows platform:
- Watch for `icpx` executable instead of `DPCPPROOT` variable (it's not set in last versions)
- Disable interprocedural optimization on Windows due to icx and pybind11 linker flags incompatibility