### PR TITLE
[ci] set black version for azure CI

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -52,10 +52,11 @@ jobs:
       addToPath: true
   - script: |
       python -m pip install --upgrade pip setuptools
-      pip install isort black[jupyter]
+      pip install isort black[jupyter]==24.1.1
       isort --check . && black --check .
     displayName: 'Linting'
 - job: Linux
+  dependsOn: Lint
   timeoutInMinutes: 120
   strategy:
     matrix:
@@ -79,6 +80,7 @@ jobs:
   steps:
   - template: build-and-test-lnx.yml
 - job: Windows
+  dependsOn: Lint
   timeoutInMinutes: 120
   strategy:
     matrix:


### PR DESCRIPTION
# Description
force specific black version for formatting such that we now maintain control when repository-wide formatting changes are to be made

Changes proposed in this pull request:
- set black to 24.1.1
- add dependency for windows and linux testing on linting to save CI resources (as we have a limited number of runners)

 
