### PR TITLE
Add model_selection to sklearnex module content

### DIFF
--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "linear_model",
     "manifold",
     "metrics",
+    "model_selection",
     "neighbors",
     "patch_sklearn",
     "set_config",


### PR DESCRIPTION
# Description
`model_selection` was missing in sklearnex module content list (while available for import anyway). It resulted in invisibility of `sklearnex.model_selection.train_test_split` from `inspect` tool travelling through `sklearnex` module content.
 
