### PR TITLE
FIX: minor fix for `sklearnex.spmd.cluster.KMeans` example

### DIFF
--- a/examples/sklearnex/kmeans_spmd.py
+++ b/examples/sklearnex/kmeans_spmd.py
@@ -22,7 +22,7 @@ from dpctl import SyclQueue
 from mpi4py import MPI
 from sklearn.datasets import load_digits
 
-from onedal.spmd.cluster import KMeans
+from sklearnex.spmd.cluster import KMeans
 
 
 def get_data_slice(chunk, count):


### PR DESCRIPTION
# Description
minor fix for `sklearnex.spmd.cluster.KMeans` example
We should import it from sklearnex module

 
