### PR TITLE
[bug] Remove "sklearn_is_patchedget_patch_map" from sklearnex/__init__.py

### DIFF
--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -46,7 +46,6 @@ __all__ = [
     "patch_sklearn",
     "set_config",
     "sklearn_is_patched",
-    "sklearn_is_patchedget_patch_map",
     "svm",
     "unpatch_sklearn",
     "utils",


### PR DESCRIPTION
# Description
"sklearn_is_patchedget_patch_map" is not a function in sklearnex, and is not imported. Looks to be unnecessary

Changes proposed in this pull request:
- Remove "sklearn_is_patchedget_patch_map"  from ```sklearnex.__all__```
 
