### PR TITLE
[CI] Deselect failing 1.4.1 sklearn kmeans tests

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -353,6 +353,15 @@ deselected_tests:
   - tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=zeros)] >=1.4
   - tests/test_multioutput.py::test_classifier_chain_fit_and_predict_with_sparse_data >=1.4
 
+  # New failing sklearn1.4.1 tests for kmeans associated with incorrect n_iter_ values in daal4py
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[lloyd-dense] >=1.4
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[lloyd-sparse_matrix] >=1.4
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[lloyd-sparse_array] >=1.4
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[elkan-dense] >=1.4
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[elkan-sparse_matrix] >=1.4
+  - cluster/tests/test_k_means.py::test_relocating_with_duplicates[elkan-sparse_array] >=1.4
+
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:


### PR DESCRIPTION
# Description
Conda just upgraded sklearn from 1.4.0 to 1.4.1 and new kmeans tests fail for daal4py (not preview). A ticket has been made to investigate and correct these issues, but this is a stopgap to insure green CI for other PRs.

Changes proposed in this pull request:
- add to deselected_tests

 
