### PR TITLE
DEP: deprecate to use sklearn estimators in onedal4py LogReg

### DIFF
--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -18,7 +18,6 @@ from abc import ABCMeta, abstractmethod
 from numbers import Number
 
 import numpy as np
-from sklearn.base import BaseEstimator
 
 from daal4py.sklearn._utils import get_dtype, make2d
 from onedal import _backend
@@ -36,7 +35,7 @@ from ..utils import (
 )
 
 
-class BaseLogisticRegression(BaseEstimator, metaclass=ABCMeta):
+class BaseLogisticRegression(metaclass=ABCMeta):
     @abstractmethod
     def __init__(self, tol, C, fit_intercept, solver, max_iter, algorithm):
         self.tol = tol


### PR DESCRIPTION
# Description
Trying to remove sklearn's BaseEstimator from LogRegOneDAL4py.
OneDAL4py estimators should be sklearn compatible but sklearn like iface.

After dispatching to onedal4py backend, no any base/non-base sklearn estimators should be used.


 
