### PR TITLE
DEP: deprecate to use sklearn estimators in onedal4py SVM

### DIFF
--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -20,7 +20,6 @@ from numbers import Number, Real
 
 import numpy as np
 from scipy import sparse as sp
-from sklearn.base import BaseEstimator
 
 from daal4py.sklearn._utils import sklearn_check_version
 from onedal import _backend
@@ -45,7 +44,7 @@ class SVMtype(Enum):
     nu_svr = 3
 
 
-class BaseSVM(BaseEstimator, metaclass=ABCMeta):
+class BaseSVM(metaclass=ABCMeta):
     @abstractmethod
     def __init__(
         self,


### PR DESCRIPTION
# Description
Trying to remove sklearn's BaseEstimator from OneDAL4py's SVM.
OneDAL4py estimators should be sklearn compatible but sklearn like iface.

After dispatching to onedal4py backend, no any base/non-base sklearn estimators should be used.

 
