### PR TITLE
Hide `predict_proba` in modelbuilder regressor

### DIFF
--- a/daal4py/mb/model_builders.py
+++ b/daal4py/mb/model_builders.py
@@ -290,10 +290,7 @@ class GBTDAALModel(GBTDAALBaseModel):
     @available_if(_check_proba)
     def predict_proba(self, X):
         fptype = getFPType(X)
-        if self._is_regression:
-            raise NotImplementedError("Can't predict probabilities for regression task")
-        else:
-            return self._predict_classification(X, fptype, "computeClassProbabilities")
+        return self._predict_classification(X, fptype, "computeClassProbabilities")
 
 
 def convert_model(model):

--- a/daal4py/mb/model_builders.py
+++ b/daal4py/mb/model_builders.py
@@ -30,6 +30,8 @@ try:
 except (ImportError, ModuleNotFoundError):
     pandas_is_imported = False
 
+from sklearn.utils.metaestimators import available_if
+
 
 def parse_dtype(dt):
     if dt == np.double:
@@ -282,6 +284,10 @@ class GBTDAALModel(GBTDAALBaseModel):
                 )
             return self._predict_classification(X, fptype, "computeClassLabels")
 
+    def _check_proba(self):
+        return not self._is_regression
+
+    @available_if(_check_proba)
     def predict_proba(self, X):
         fptype = getFPType(X)
         if self._is_regression:


### PR DESCRIPTION
Exposure of `predict_proba` method for regression model can be confusing in some cases: for example, in automated testing of sklearn-like estimator where methods are checked by `hasattr` function.
Fix is implemented in similar way to `SVC` where probabilities available only when `probabilities=True` in constructor.