### PR TITLE
MAINT: aligning gpu interfaces y param with sklearn

### DIFF
--- a/onedal/cluster/kmeans.py
+++ b/onedal/cluster/kmeans.py
@@ -387,7 +387,7 @@ class KMeans(_BaseKMeans):
         self.algorithm = algorithm
         assert self.algorithm == "lloyd"
 
-    def fit(self, X, queue=None):
+    def fit(self, X, y=None, queue=None):
         return super()._fit(X, self._get_backend("kmeans", "clustering", None), queue)
 
     def predict(self, X, queue=None):
@@ -409,7 +409,7 @@ class KMeans(_BaseKMeans):
         """
         return super()._predict(X, self._get_backend("kmeans", "clustering", None), queue)
 
-    def fit_predict(self, X, queue=None):
+    def fit_predict(self, X, y=None, queue=None):
         """Compute cluster centers and predict cluster index for each sample.
 
         Convenience method; equivalent to calling fit(X) followed by
@@ -420,14 +420,17 @@ class KMeans(_BaseKMeans):
         X : array-like of shape (n_samples, n_features)
             New data to transform.
 
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
         Returns
         -------
         labels : ndarray of shape (n_samples,)
             Index of the cluster each sample belongs to.
         """
-        return self.fit(X, queue).labels_
+        return self.fit(X, queue=queue).labels_
 
-    def fit_transform(self, X, queue=None):
+    def fit_transform(self, X, y=None, queue=None):
         """Compute clustering and transform X to cluster-distance space.
 
         Equivalent to fit(X).transform(X), but more efficiently implemented.
@@ -436,6 +439,9 @@ class KMeans(_BaseKMeans):
         ----------
         X : array-like of shape (n_samples, n_features)
             New data to transform.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
 
         Returns
         -------
@@ -491,7 +497,7 @@ def k_means(
         random_state=random_state,
         copy_x=copy_x,
         algorithm=algorithm,
-    ).fit(X, queue)
+    ).fit(X, queue=queue)
     if return_n_iter:
         return est.cluster_centers_, est.labels_, est.inertia_, est.n_iter_
     else:

--- a/onedal/covariance/covariance.py
+++ b/onedal/covariance/covariance.py
@@ -64,7 +64,7 @@ class EmpiricalCovariance(BaseEmpiricalCovariance):
         Estimated covariance matrix
     """
 
-    def fit(self, X, queue=None):
+    def fit(self, X, y=None, queue=None):
         """Fit the sample covariance matrix of X.
 
         Parameters
@@ -72,6 +72,9 @@ class EmpiricalCovariance(BaseEmpiricalCovariance):
         X : array-like of shape (n_samples, n_features)
             Training data, where `n_samples` is the number of samples, and
             `n_features` is the number of features.
+
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         queue : dpctl.SyclQueue
             If not None, use this queue for computations.

--- a/onedal/covariance/incremental_covariance.py
+++ b/onedal/covariance/incremental_covariance.py
@@ -52,7 +52,7 @@ class IncrementalEmpiricalCovariance(BaseEmpiricalCovariance):
             "covariance", None, "partial_compute_result"
         )
 
-    def partial_fit(self, X, queue=None):
+    def partial_fit(self, X, y=None, queue=None):
         """
         Computes partial data for the covariance matrix
         from data batch X and saves it to `_partial_result`.
@@ -62,6 +62,9 @@ class IncrementalEmpiricalCovariance(BaseEmpiricalCovariance):
         X : array-like of shape (n_samples, n_features)
             Training data batch, where `n_samples` is the number of samples
             in the batch, and `n_features` is the number of features.
+
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         queue : dpctl.SyclQueue
             If not None, use this queue for computations.

--- a/onedal/decomposition/pca.py
+++ b/onedal/decomposition/pca.py
@@ -39,7 +39,7 @@ class PCA(BaseEstimator):
             "is_deterministic": self.is_deterministic,
         }
 
-    def fit(self, X, queue):
+    def fit(self, X, y=None, queue=None):
         n_samples, n_features = X.shape
         n_sf_min = min(n_samples, n_features)
 
@@ -111,7 +111,7 @@ class PCA(BaseEstimator):
         self._onedal_model = m
         return m
 
-    def predict(self, X, queue):
+    def predict(self, X, queue=None):
         policy = self._get_policy(queue, X)
         model = self._create_model()
 

--- a/onedal/spmd/basic_statistics/basic_statistics.py
+++ b/onedal/spmd/basic_statistics/basic_statistics.py
@@ -23,4 +23,4 @@ from .._common import BaseEstimatorSPMD
 class BasicStatistics(BaseEstimatorSPMD, BasicStatistics_Batch):
     @support_usm_ndarray()
     def compute(self, data, weights=None, queue=None):
-        return super().compute(data, weights, queue)
+        return super().compute(data, weights=weights, queue=queue)

--- a/onedal/spmd/cluster/kmeans.py
+++ b/onedal/spmd/cluster/kmeans.py
@@ -38,7 +38,7 @@ class KMeans(BaseEstimatorSPMD, KMeans_Batch):
         return KMeansInit(cluster_count=cluster_count, seed=seed, algorithm=algorithm)
 
     @support_usm_ndarray()
-    def fit(self, X, queue=None):
+    def fit(self, X, y=None, queue=None):
         return super().fit(X, queue)
 
     @support_usm_ndarray()
@@ -46,7 +46,7 @@ class KMeans(BaseEstimatorSPMD, KMeans_Batch):
         return super().predict(X, queue)
 
     @support_usm_ndarray()
-    def fit_predict(self, X, queue=None):
+    def fit_predict(self, X, y=None, queue=None):
         return super().fit_predict(X, queue)
 
     def transform(self, X):

--- a/onedal/spmd/cluster/kmeans.py
+++ b/onedal/spmd/cluster/kmeans.py
@@ -39,18 +39,18 @@ class KMeans(BaseEstimatorSPMD, KMeans_Batch):
 
     @support_usm_ndarray()
     def fit(self, X, y=None, queue=None):
-        return super().fit(X, queue)
+        return super().fit(X, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue=None):
-        return super().predict(X, queue)
+        return super().predict(X, queue=queue)
 
     @support_usm_ndarray()
     def fit_predict(self, X, y=None, queue=None):
-        return super().fit_predict(X, queue)
+        return super().fit_predict(X, queue=queue)
 
     def transform(self, X):
         return super().transform(X)
 
     def fit_transform(self, X, queue=None):
-        return super().fit_transform(X, queue)
+        return super().fit_transform(X, queue=queue)

--- a/onedal/spmd/covariance/covariance.py
+++ b/onedal/spmd/covariance/covariance.py
@@ -22,5 +22,5 @@ from .._common import BaseEstimatorSPMD
 
 class EmpiricalCovariance(BaseEstimatorSPMD, EmpiricalCovariance_Batch):
     @support_usm_ndarray()
-    def fit(self, X, queue=None):
-        return super().fit(X, queue)
+    def fit(self, X, y=None, queue=None):
+        return super().fit(X, queue=queue)

--- a/onedal/spmd/decomposition/pca.py
+++ b/onedal/spmd/decomposition/pca.py
@@ -26,5 +26,5 @@ class PCA(BaseEstimatorSPMD, PCABatch):
         return super().fit(X, queue=queue)
 
     @support_usm_ndarray()
-    def predict(self, X, queue):
+    def predict(self, X, queue=None):
         return super().predict(X, queue=queue)

--- a/onedal/spmd/decomposition/pca.py
+++ b/onedal/spmd/decomposition/pca.py
@@ -22,9 +22,9 @@ from .._common import BaseEstimatorSPMD
 
 class PCA(BaseEstimatorSPMD, PCABatch):
     @support_usm_ndarray()
-    def fit(self, X, queue):
-        return super().fit(X, queue)
+    def fit(self, X, y=None, queue=None):
+        return super().fit(X, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue):
-        return super().predict(X, queue)
+        return super().predict(X, queue=queue)

--- a/onedal/spmd/linear_model/linear_model.py
+++ b/onedal/spmd/linear_model/linear_model.py
@@ -23,8 +23,8 @@ from .._common import BaseEstimatorSPMD
 class LinearRegression(BaseEstimatorSPMD, LinearRegression_Batch):
     @support_usm_ndarray()
     def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue)
+        return super().fit(X, y, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue=None):
-        return super().predict(X, queue)
+        return super().predict(X, queue=queue)

--- a/onedal/spmd/linear_model/logistic_regression.py
+++ b/onedal/spmd/linear_model/logistic_regression.py
@@ -23,16 +23,16 @@ from .._common import BaseEstimatorSPMD
 class LogisticRegression(BaseEstimatorSPMD, LogisticRegression_Batch):
     @support_usm_ndarray()
     def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue)
+        return super().fit(X, y, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue=None):
-        return super().predict(X, queue)
+        return super().predict(X, queue=queue)
 
     @support_usm_ndarray()
     def predict_proba(self, X, queue=None):
-        return super().predict_proba(X, queue)
+        return super().predict_proba(X, queue=queue)
 
     @support_usm_ndarray()
     def predict_log_proba(self, X, queue=None):
-        return super().predict_log_proba(X, queue)
+        return super().predict_log_proba(X, queue=queue)

--- a/onedal/spmd/neighbors/neighbors.py
+++ b/onedal/spmd/neighbors/neighbors.py
@@ -24,11 +24,11 @@ from .._common import BaseEstimatorSPMD
 class KNeighborsClassifier(BaseEstimatorSPMD, KNeighborsClassifier_Batch):
     @support_usm_ndarray()
     def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue)
+        return super().fit(X, y, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue=None):
-        return super().predict(X, queue)
+        return super().predict(X, queue=queue)
 
     @support_usm_ndarray()
     def predict_proba(self, X, queue=None):
@@ -36,7 +36,7 @@ class KNeighborsClassifier(BaseEstimatorSPMD, KNeighborsClassifier_Batch):
 
     @support_usm_ndarray()
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
-        return super().kneighbors(X, n_neighbors, return_distance, queue)
+        return super().kneighbors(X, n_neighbors, return_distance, queue=queue)
 
 
 class KNeighborsRegressor(BaseEstimatorSPMD, KNeighborsRegressor_Batch):
@@ -52,7 +52,7 @@ class KNeighborsRegressor(BaseEstimatorSPMD, KNeighborsRegressor_Batch):
 
     @support_usm_ndarray()
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
-        return super().kneighbors(X, n_neighbors, return_distance, queue)
+        return super().kneighbors(X, n_neighbors, return_distance, queue=queue)
 
     @support_usm_ndarray()
     def predict(self, X, queue=None):
@@ -68,8 +68,8 @@ class KNeighborsRegressor(BaseEstimatorSPMD, KNeighborsRegressor_Batch):
 class NearestNeighbors(BaseEstimatorSPMD):
     @support_usm_ndarray()
     def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue)
+        return super().fit(X, y, queue=queue)
 
     @support_usm_ndarray()
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
-        return super().kneighbors(X, n_neighbors, return_distance, queue)
+        return super().kneighbors(X, n_neighbors, return_distance, queue=queue)


### PR DESCRIPTION
# Description
scikit-learn provides dummy y variable in cluster/compute ([example](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/decomposition/_incremental_pca.py#L201)) interfaces for general alignment - we mostly have this implemented in our daal4py/sklearnex cpu interfaces already. It's not used in sklearn or in sklearnex but provides uniform interfaces and will be useful in resolving common sklbench errors.

also adds queue as kwarg when passing in cases where its not already done.
 
