### PR TITLE
[bug] fix test_patching routines for intelex-only sklearnex estimators

### DIFF
--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -52,7 +52,7 @@ def _load_all_models(with_sklearnex=True, estimator=True):
 
         models = {}
         for patch_infos in get_patch_map().values():
-            candidate = getattr(patch_infos[0][0][0], patch_infos[0][0][1])
+            candidate = getattr(patch_infos[0][0][0], patch_infos[0][0][1], None)
             if candidate is not None and isclass(candidate) == estimator:
                 if not estimator or issubclass(candidate, BaseEstimator):
                     models[patch_infos[0][0][1]] = candidate
@@ -105,7 +105,7 @@ def gen_models_info(algorithms):
         # split handles SPECIAL_INSTANCES or custom inputs
         # custom sklearn inputs must be a dict of estimators
         # with keys set by the __str__ method
-        est = UNPATCHED_MODELS[i.split("(")[0]]
+        est = PATCHED_MODELS[i.split("(")[0]]
 
         methods = set()
         candidates = set(

--- a/sklearnex/tests/test_patching.py
+++ b/sklearnex/tests/test_patching.py
@@ -263,21 +263,20 @@ def test_patch_map_match():
 
     module_map = {i: i for i in sklearnex__all__.intersection(sklearn__all__)}
 
-    # _assert_all_finite and _logistic_regression_path patch internal
-    # sklearn functions which aren't exposed. These are not available in
-    # __all__ and require more careful anaylsis.
+    # _assert_all_finite patches an internal sklearn function which isn't
+    # exposed via __all__ in sklearn. It is a special case where this rule
+    # is not applied (e.g. it is grandfathered in).
+    del patched["_assert_all_finite"]
 
+    # remove all scikit-learn-intelex-only estimators
     for i in patched.copy():
-        if i.startswith("_"):
+        if i not in UNPATCHED_MODELS and i not in UNPATCHED_FUNCTIONS:
             del patched[i]
+
     for module in module_map:
         sklearn_module__all__ = list_all_attr("sklearn." + module_map[module])
         sklearnex_module__all__ = list_all_attr("sklearnex." + module)
         intersect = sklearnex_module__all__.intersection(sklearn_module__all__)
-
-        assert (
-            intersect == sklearnex_module__all__
-        ), f"{sklearnex_module__all__ - intersect} should not be in sklearnex.{module}.__all__"
 
         for i in intersect:
             if i:


### PR DESCRIPTION
# Description
New sklearnex-native estimators are now allowed in the patch map, a recent refactor of test_patching will block this new rule (as shown by #1656). This PR modifies the necessary files to allow test_patching to handle sklearnex-native estimators and functions.

Changes proposed in this pull request:
- modify sklearnex/tests/_utils.py
- modify sklearnex/tests/test_patching.py

 
