### PR TITLE
[CI] fix clashing between isort and black that can occur with long imports

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -53,7 +53,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools
       pip install isort black[jupyter]==24.1.1
-      isort --check . && black --check .
+      isort --profile black --check . && black --check .
     displayName: 'Linting'
 - job: Linux
   dependsOn: Lint


### PR DESCRIPTION
# Description
isort wants to newline imports using \\, where black wants to use ( ) . isort can be made to follow black's rules with this change.

Changes proposed in this pull request:
- add --profile black to isort

 
