### PR TITLE
Fix: Do not import onedal when OFF_ONEDAL_IFACE=1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ ONEDAL_VERSION = get_onedal_version(dal_root)
 ONEDAL_2021_3 = 2021 * 10000 + 3 * 100
 ONEDAL_2023_0_1 = 2023 * 10000 + 0 * 100 + 1
 is_onedal_iface = (
-    os.environ.get("OFF_ONEDAL_IFACE") is None and ONEDAL_VERSION >= ONEDAL_2021_3
+    os.environ.get("OFF_ONEDAL_IFACE", "0") == "0" and ONEDAL_VERSION >= ONEDAL_2021_3
 )
 
 d4p_version = (

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 # ==============================================================================
 # Copyright 2014 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -1,6 +1,6 @@
 # ==============================================================================
 # Copyright 2021 Intel Corporation
-# Copyright contributors to the oneDAL project
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
     "unpatch_sklearn",
     "utils",
 ]
-onedal_iface_flag = os.getenv("OFF_ONEDAL_IFACE", "0")
+onedal_iface_flag = os.environ.get("OFF_ONEDAL_IFACE", "0")
 if onedal_iface_flag == "0":
     from onedal import _is_spmd_backend
     from onedal.common.hyperparameters import get_hyperparameters

--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from onedal.common.hyperparameters import get_hyperparameters
+import os
 
 from . import utils
 from ._config import config_context, get_config, set_config
@@ -50,12 +50,13 @@ __all__ = [
     "unpatch_sklearn",
     "utils",
 ]
+onedal_iface_flag = os.getenv("OFF_ONEDAL_IFACE", "0")
+if onedal_iface_flag == "0":
+    from onedal import _is_spmd_backend
+    from onedal.common.hyperparameters import get_hyperparameters
 
-
-from onedal import _is_spmd_backend
-
-if _is_spmd_backend:
-    __all__.append("spmd")
+    if _is_spmd_backend:
+        __all__.append("spmd")
 
 
 from ._utils import set_sklearn_ex_verbose

--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -1,5 +1,6 @@
 # ==============================================================================
 # Copyright 2021 Intel Corporation
+# Copyright contributors to the oneDAL project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -22,7 +22,7 @@ from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 
 
 def _is_new_patching_available():
-    return os.environ.get("OFF_ONEDAL_IFACE") is None and daal_check_version(
+    return os.environ.get("OFF_ONEDAL_IFACE", "0") == "0" and daal_check_version(
         (2021, "P", 300)
     )
 

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -1,5 +1,6 @@
 # ==============================================================================
 # Copyright 2021 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
- sklearnex can be built/installed without **onedal** interface by setting `OFF_ONEDAL_IFACE=1` during installation.
    - Due to which onedal interface is not built/installed and when we try to `import sklearnex` we get import error because `sklearnex/__init__.py` has `import onedal` statement without checking `OFF_ONEDAL_IFACE` flag.
  
## Changes proposed in this pull request:
- This PR fixes import error by adding conditional check of `OFF_ONEDAL_IFACE` flag when importing **onedal**

Reference - [Github issue](https://github.com/intel/scikit-learn-intelex/issues/1329)


 
