### PR TITLE
[bug] sklearnex-only estimators will not work with sklearnex/tests/_utils.py::get_dataset

### DIFF
--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -123,7 +123,7 @@ def gen_models_info(algorithms):
 def gen_dataset(estimator, queue=None, target_df=None, dtype=np.float64):
     dataset = None
     name = estimator.__class__.__name__
-    est = UNPATCHED_MODELS[name]
+    est = PATCHED_MODELS[name]
     for mixin, _, data in mixin_map:
         if issubclass(est, mixin) and data is not None:
             dataset = data


### PR DESCRIPTION
This function assumed that the keys in UNPATCHED_MODELS and PATCHED_MODELS were the same. This is now not the case due to sklearnex-only estimators being introduced into the patch_map. I forgot to correct this in the last PR on this subject. This will not change the behavior of the function, as sklearnex estimators inherit from sklearn. (Not yet a rule, but a follow-up PR will make it so in test_patching.py)

This change can be seen in #1656 for verification of functionality.

Changes proposed in this pull request:
- UNPATCHED_MODELS -> PATCHED_MODELS

 
