### PR TITLE
[enhancement] add check for sklearn estimator or Mixin inheritance

### DIFF
--- a/sklearnex/tests/test_patching.py
+++ b/sklearnex/tests/test_patching.py
@@ -42,6 +42,14 @@ from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
     get_dataframes_and_queues,
 )
+from sklearn.base import (
+    BaseEstimator,
+    ClassifierMixin,
+    ClusterMixin,
+    OutlierMixin,
+    RegressorMixin,
+    TransformerMixin,
+)
 from sklearnex import is_patched_instance
 from sklearnex.dispatcher import _is_preview_enabled
 from sklearnex.metrics import pairwise_distances, roc_auc_score
@@ -292,6 +300,29 @@ def test_is_patched_instance(estimator):
     unpatched = UNPATCHED_MODELS[estimator]
     assert is_patched_instance(patched), f"{patched} is a patched instance"
     assert not is_patched_instance(unpatched), f"{unpatched} is an unpatched instance"
+
+
+@pytest.mark.parametrize("estimator", PATCHED_MODELS.keys())
+def test_if_estimator_inherits_sklearn(estimator):
+    est = PATCHED_MODELS[estimator]
+    if estimator in UNPATCHED_MODELS:
+        assert issubclass(
+            est, UNPATCHED_MODELS[estimator]
+        ), f"{estimator} does not inherit from the patched sklearn estimator"
+    else:
+        assert issubclass(est, BaseEstimator)
+        assert any(
+            [
+                issubclass(est, i)
+                for i in [
+                    ClassifierMixin,
+                    ClusterMixin,
+                    OutlierMixin,
+                    RegressorMixin,
+                    TransformerMixin,
+                ]
+            ]
+        ), f"{estimator} does not inherit a sklearn Mixin"
 
 
 @pytest.mark.parametrize("estimator", UNPATCHED_MODELS.keys())

--- a/sklearnex/tests/test_patching.py
+++ b/sklearnex/tests/test_patching.py
@@ -36,12 +36,6 @@ from _utils import (
     gen_dataset,
     gen_models_info,
 )
-
-from daal4py.sklearn._utils import sklearn_check_version
-from onedal.tests.utils._dataframes_support import (
-    _convert_to_dataframe,
-    get_dataframes_and_queues,
-)
 from sklearn.base import (
     BaseEstimator,
     ClassifierMixin,
@@ -49,6 +43,12 @@ from sklearn.base import (
     OutlierMixin,
     RegressorMixin,
     TransformerMixin,
+)
+
+from daal4py.sklearn._utils import sklearn_check_version
+from onedal.tests.utils._dataframes_support import (
+    _convert_to_dataframe,
+    get_dataframes_and_queues,
 )
 from sklearnex import is_patched_instance
 from sklearnex.dispatcher import _is_preview_enabled


### PR DESCRIPTION
# Description
Simple but obvious test, does the sklearnex estimator inherit from the sklearn estimator it patches out. If not, does it contain BaseEstimator and at least one sklearn mixin? This will be useful for testing sklearnex-only estimators for methods like "score" and "fit_transform" which are missed by other tests (they rely on Mixin inheritance to dictate what to test).

Changes proposed in this pull request:
- Add test_if_estimator_inherits_sklearn

 
