### PR TITLE
[enhancement] add cpu guard to sklearnex testing

### DIFF
--- a/sklearnex/conftest.py
+++ b/sklearnex/conftest.py
@@ -27,8 +27,10 @@ def pytest_configure(config):
         "markers", "allow_sklearn_fallback: mark test to not check for sklearnex usage"
     )
     config.addinivalue_line(
-        "markers", "allow_fallback_to_cpu: mark test to allow for sklearnex to fallback to cpu"
+        "markers",
+        "allow_fallback_to_cpu: mark test to allow for sklearnex to fallback to cpu",
     )
+
 
 def sklearn_guard(item):
     if not item.get_closest_marker("allow_sklearn_fallback"):
@@ -64,14 +66,12 @@ def cpu_guard(item):
             yield sklearn_guard(item)
     else:
         yield sklearn_guard(item)
-        
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    # setup logger to check for fallbacks. cpu_guard will yield
-    # sklearn_guard
+    # setup logger to check for sklearn fallback
     yield cpu_guard(item)
-
 
 
 @pytest.fixture

--- a/sklearnex/conftest.py
+++ b/sklearnex/conftest.py
@@ -19,42 +19,59 @@ import logging
 
 import pytest
 
-from sklearnex import patch_sklearn, unpatch_sklearn
+from sklearnex import get_config, patch_sklearn, set_config, unpatch_sklearn
 
 
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "allow_sklearn_fallback: mark test to not check for sklearnex usage"
     )
+    config.addinivalue_line(
+        "markers", "allow_fallback_to_cpu: mark test to allow for sklearnex to fallback to cpu"
+    )
 
+def sklearn_guard(item):
+    if not item.get_closest_marker("allow_sklearn_fallback"):
+        try:
+            log_stream = io.StringIO()
+            log_handler = logging.StreamHandler(log_stream)
+            sklearnex_logger = logging.getLogger("sklearnex")
+            level = sklearnex_logger.level
+            sklearnex_stderr_handler = sklearnex_logger.handlers
+            sklearnex_logger.handlers = []
+            sklearnex_logger.addHandler(log_handler)
+            sklearnex_logger.setLevel(logging.INFO)
+            log_handler.setLevel(logging.INFO)
+
+            yield
+
+        finally:
+            sklearnex_logger.handlers = sklearnex_stderr_handler
+            sklearnex_logger.setLevel(level)
+            sklearnex_logger.removeHandler(log_handler)
+            text = log_stream.getvalue()
+            if "fallback to original Scikit-learn" in text:
+                raise TypeError(
+                    f"test did not properly evaluate sklearnex functionality and fell back to sklearn:\n{text}"
+                )
+    else:
+        yield
+
+
+def cpu_guard(item):
+    if not item.get_closest_marker("allow_fallback_to_cpu"):
+        with config_context(allow_fallback_to_host=False):
+            yield sklearn_guard(item)
+    else:
+        yield sklearn_guard(item)
+        
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
-    # setup logger to check for sklearn fallback
-    if not item.get_closest_marker("allow_sklearn_fallback"):
+    # setup logger to check for fallbacks. cpu_guard will yield
+    # sklearn_guard
+    yield cpu_guard(item)
 
-        log_stream = io.StringIO()
-        log_handler = logging.StreamHandler(log_stream)
-        sklearnex_logger = logging.getLogger("sklearnex")
-        level = sklearnex_logger.level
-        sklearnex_stderr_handler = sklearnex_logger.handlers
-        sklearnex_logger.handlers = []
-        sklearnex_logger.addHandler(log_handler)
-        sklearnex_logger.setLevel(logging.INFO)
-        log_handler.setLevel(logging.INFO)
-
-        yield
-
-        sklearnex_logger.handlers = sklearnex_stderr_handler
-        sklearnex_logger.setLevel(level)
-        sklearnex_logger.removeHandler(log_handler)
-        text = log_stream.getvalue()
-        if "fallback to original Scikit-learn" in text:
-            raise TypeError(
-                f"test did not properly evaluate sklearnex functionality and fell back to sklearn:\n{text}"
-            )
-    else:
-        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description
Tests which use dpnp, dpctl avoid config_context allow_fallback_to_host limitations in testing. This means that dpnp dpctl may be using the cpu code when we want to test the viability of the SYCL code. This adds another generator which will force all tests to run with a config_context(allow_fallback_to_host=False).

Changes proposed in this pull request:
- Refactor logger into separate generator called sklearn_guard
- add cpu_guard
- add mark to allow for toggling cpu_guard

 
