### PR TITLE
Add _n_inner_iter attribute for Logistic Regression

### DIFF
--- a/onedal/linear_model/logistic_regression.cpp
+++ b/onedal/linear_model/logistic_regression.cpp
@@ -95,9 +95,12 @@ auto get_onedal_result_options(const py::dict& params) {
             else if (match.str() == "iterations_count") {
                 onedal_options = onedal_options | result_options::iterations_count;
             }
+#if ONEDAL_VERSION >= 20240400
             else if (match.str() == "inner_iterations_count") {
                 onedal_options = onedal_options | result_options::inner_iterations_count;
-            } else {
+            }
+#endif 
+            else {
                 ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(result_option);
             }
         }
@@ -210,7 +213,9 @@ void init_train_result(py::module_& m) {
                    .DEF_ONEDAL_PY_PROPERTY(intercept, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(coefficients, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(iterations_count, result_t)
+#if ONEDAL_VERSION >= 20240400
                    .DEF_ONEDAL_PY_PROPERTY(inner_iterations_count, result_t)
+#endif
                    .DEF_ONEDAL_PY_PROPERTY(packed_coefficients, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(result_options, result_t);
 }

--- a/onedal/linear_model/logistic_regression.cpp
+++ b/onedal/linear_model/logistic_regression.cpp
@@ -95,7 +95,7 @@ auto get_onedal_result_options(const py::dict& params) {
             else if (match.str() == "iterations_count") {
                 onedal_options = onedal_options | result_options::iterations_count;
             }
-#if ONEDAL_VERSION >= 20240400
+#if ONEDAL_VERSION >= 20240300
             else if (match.str() == "inner_iterations_count") {
                 onedal_options = onedal_options | result_options::inner_iterations_count;
             }
@@ -213,7 +213,7 @@ void init_train_result(py::module_& m) {
                    .DEF_ONEDAL_PY_PROPERTY(intercept, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(coefficients, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(iterations_count, result_t)
-#if ONEDAL_VERSION >= 20240400
+#if ONEDAL_VERSION >= 20240300
                    .DEF_ONEDAL_PY_PROPERTY(inner_iterations_count, result_t)
 #endif
                    .DEF_ONEDAL_PY_PROPERTY(packed_coefficients, result_t)

--- a/onedal/linear_model/logistic_regression.cpp
+++ b/onedal/linear_model/logistic_regression.cpp
@@ -95,8 +95,11 @@ auto get_onedal_result_options(const py::dict& params) {
             else if (match.str() == "iterations_count") {
                 onedal_options = onedal_options | result_options::iterations_count;
             }
-            else
+            else if (match.str() == "inner_iterations_count") {
+                onedal_options = onedal_options | result_options::inner_iterations_count;
+            } else {
                 ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(result_option);
+            }
         }
     }
     catch (std::regex_error&) {
@@ -207,6 +210,7 @@ void init_train_result(py::module_& m) {
                    .DEF_ONEDAL_PY_PROPERTY(intercept, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(coefficients, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(iterations_count, result_t)
+                   .DEF_ONEDAL_PY_PROPERTY(inner_iterations_count, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(packed_coefficients, result_t)
                    .DEF_ONEDAL_PY_PROPERTY(result_options, result_t);
 }

--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -54,7 +54,11 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
             "max_iter": self.max_iter,
             "C": self.C,
             "optimizer": self.solver,
-            "result_option": (intercept + "coefficients|iterations_count"),
+            "result_option": (
+                intercept + "coefficients|iterations_count" + "|inner_iterations_count"
+                if self.solver == "newton-cg"
+                else ""
+            ),
         }
 
     def _fit(self, X, y, module, queue):
@@ -84,6 +88,8 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
 
         self._onedal_model = result.model
         self.n_iter_ = np.array([result.iterations_count])
+        if self.solver == "newton-cg":
+            self.n_inner_iter_ = result.inner_iterations_count
 
         coeff = from_table(result.model.packed_coefficients)
         self.coef_, self.intercept_ = coeff[:, 1:], coeff[:, 0]

--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -88,7 +88,7 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
 
         self._onedal_model = result.model
         self.n_iter_ = np.array([result.iterations_count])
-        if daal_check_version((2024, "P", 400)) and self.solver == "newton-cg":
+        if daal_check_version((2024, "P", 300)) and self.solver == "newton-cg":
             self._n_inner_iter = result.inner_iterations_count
 
         coeff = from_table(result.model.packed_coefficients)

--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -19,7 +19,7 @@ from numbers import Number
 
 import numpy as np
 
-from daal4py.sklearn._utils import get_dtype, make2d
+from daal4py.sklearn._utils import daal_check_version, get_dtype, make2d
 
 from ..common._base import BaseEstimator as onedal_BaseEstimator
 from ..common._estimator_checks import _check_is_fitted
@@ -88,8 +88,8 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
 
         self._onedal_model = result.model
         self.n_iter_ = np.array([result.iterations_count])
-        if self.solver == "newton-cg":
-            self.n_inner_iter_ = result.inner_iterations_count
+        if daal_check_version((2024, "P", 400)) and self.solver == "newton-cg":
+            self._n_inner_iter = result.inner_iterations_count
 
         coeff = from_table(result.model.packed_coefficients)
         self.coef_, self.intercept_ = coeff[:, 1:], coeff[:, 0]

--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -55,9 +55,9 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
             "C": self.C,
             "optimizer": self.solver,
             "result_option": (
-                intercept + "coefficients|iterations_count" + "|inner_iterations_count"
-                if self.solver == "newton-cg"
-                else ""
+                intercept
+                + "coefficients|iterations_count"
+                + ("|inner_iterations_count" if self.solver == "newton-cg" else "")
             ),
         }
 
@@ -88,6 +88,8 @@ class BaseLogisticRegression(onedal_BaseEstimator, metaclass=ABCMeta):
 
         self._onedal_model = result.model
         self.n_iter_ = np.array([result.iterations_count])
+
+        # _n_inner_iter is the total number of cg-solver iterations
         if daal_check_version((2024, "P", 300)) and self.solver == "newton-cg":
             self._n_inner_iter = result.inner_iterations_count
 

--- a/onedal/linear_model/tests/test_logistic_regression.py
+++ b/onedal/linear_model/tests/test_logistic_regression.py
@@ -40,6 +40,12 @@ if daal_check_version((2024, "P", 1)):
         y_pred = model.predict(X_test, queue=queue)
         assert accuracy_score(y_test, y_pred) > 0.95
 
+        assert hasattr(model, "n_iter_")
+        assert hasattr(model, "coef_")
+        assert hasattr(model, "intercept_")
+        if daal_check_version((2024, "P", 300)):
+            assert hasattr(model, "_n_inner_iter")
+
     @pytest.mark.parametrize("queue", get_queues("gpu"))
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     def test_pickle(queue, dtype):

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -32,8 +32,8 @@ class BaseLogisticRegression(ABC):
         self.intercept_ = self._onedal_estimator.intercept_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.n_iter_ = self._onedal_estimator.n_iter_
-        if self.solver:
-            self.n_inner_iter_ = self._onedal_estimator.n_inner_iter_
+        if hasattr(self._onedal_estimator, "_n_inner_iter"):
+            self._n_inner_iter = self._onedal_estimator._n_inner_iter
 
 
 if daal_check_version((2024, "P", 1)):

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -32,6 +32,8 @@ class BaseLogisticRegression(ABC):
         self.intercept_ = self._onedal_estimator.intercept_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.n_iter_ = self._onedal_estimator.n_iter_
+        if self.solver:
+            self.n_inner_iter_ = self._onedal_estimator.n_inner_iter_
 
 
 if daal_check_version((2024, "P", 1)):

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -32,8 +32,6 @@ class BaseLogisticRegression(ABC):
         self.intercept_ = self._onedal_estimator.intercept_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.n_iter_ = self._onedal_estimator.n_iter_
-        if hasattr(self._onedal_estimator, "_n_inner_iter"):
-            self._n_inner_iter = self._onedal_estimator._n_inner_iter
 
 
 if daal_check_version((2024, "P", 1)):


### PR DESCRIPTION
# Description
If the solver was set to newton-cg and training was done on GPU, it is possible to get the total number of CG-solver iterations done via _onedal_estimator._n_inner_iter attribute. This attribute can be used to estimate the time per iteration. Note that this attribute will be available if build with oneDAL of version 2024.4.0 or higher

 
