### PR TITLE
DEV: removing dpctl from CI build scripts

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -24,8 +24,7 @@ steps:
     displayName: "System info"
   - script: |
       conda update -y -q conda
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then export DPCPP_PACKAGE="dpctl=0.15.0"; else export DPCPP_PACKAGE=""; fi
-      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) intel::dal-devel mpich pyyaml $DPCPP_PACKAGE "dpcpp-cpp-rt=2024.0.2"
+      conda create -q -y -n CB -c conda-forge -c intel python=$(PYTHON_VERSION) intel::dal-devel mpich pyyaml "dpcpp-cpp-rt=2024.0.2"
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -47,7 +46,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpnp=0.13.0; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.15.0 dpnp=0.13.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |


### PR DESCRIPTION
# Description
removing `dpctl` from CI build scripts.


**NOTE:** merge after #1685 

 
