### PR TITLE
FIX: no dpc if windows debug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,9 @@ d4p_version = (
 trues = ["true", "True", "TRUE", "1", "t", "T", "y", "Y", "Yes", "yes", "YES"]
 no_dist = True if "NO_DIST" in os.environ and os.environ["NO_DIST"] in trues else False
 no_stream = "NO_STREAM" in os.environ and os.environ["NO_STREAM"] in trues
+debug_build = os.getenv("DEBUG_BUILD") == "1"
 mpi_root = None if no_dist else os.environ["MPIROOT"]
-dpcpp = shutil.which("icpx") is not None
+dpcpp = shutil.which("icpx") is not None and not (IS_WIN and debug_build)
 
 use_parameters_lib = (not IS_WIN) and (ONEDAL_VERSION >= 20240000)
 


### PR DESCRIPTION
# Description
Do not build sklearnex dpc/spmd libs if in using windows debug - onedal dpc libs not built. Should resolve fail in build step of sklearnex windows in debug jobs.
 
