### PR TITLE
Enable build on ARM(SVE)

### DIFF
--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -22,14 +22,9 @@ if "Windows" in platform.system():
     import site
     import sys
 
-    plt_arch = platform.machine()
-    arch_dir = None
-    if plt_arch == "x86_64":
-        arch_dir = "intel64"
-    elif plt_arch == "aarch64":
-        arch_dir = "arm"
-    else:
-        arch_dir = plt_arch
+    arch_dir = platform.machine()
+    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -23,7 +23,7 @@ if "Windows" in platform.system():
     import sys
 
     arch_dir = platform.machine()
-    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 
     current_path = os.path.dirname(__file__)

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -21,13 +21,22 @@ if "Windows" in platform.system():
     import site
     import sys
 
+    plt_arch = platform.machine()
+    arch_dir = None
+    if plt_arch=="x86_64":
+        arch_dir = "intel64"
+    elif plt_arch == "aarch64":
+        arch_dir = "arm"
+    else:
+        arch_dir = plt_arch
+    
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
     path_to_oneapi_backend = os.path.join(current_path, "oneapi")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
-            dal_root_redist = os.path.join(os.environ["DALROOT"], "redist", "intel64")
+            dal_root_redist = os.path.join(os.environ["DALROOT"], "redist", arch_dir)
             if os.path.exists(dal_root_redist):
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -23,7 +23,7 @@ if "Windows" in platform.system():
     import sys
 
     arch_dir = platform.machine()
-    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
+    plt_dict = {"x86_64": "intel64", "AMD64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 
     current_path = os.path.dirname(__file__)

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -1,5 +1,6 @@
 # ==============================================================================
 # Copyright 2014 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,13 +24,13 @@ if "Windows" in platform.system():
 
     plt_arch = platform.machine()
     arch_dir = None
-    if plt_arch=="x86_64":
+    if plt_arch == "x86_64":
         arch_dir = "intel64"
     elif plt_arch == "aarch64":
         arch_dir = "arm"
     else:
         arch_dir = plt_arch
-    
+
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -24,15 +24,9 @@ if "Windows" in platform.system():
     import site
     import sys
 
-    plt_arch = platform.machine()
-    arch_dir = None
-    if plt_arch == "x86_64":
-        arch_dir = "intel64"
-    elif plt_arch == "aarch64":
-        arch_dir = "arm"
-    else:
-        arch_dir = plt_arch
-
+    arch_dir = platform.machine()
+    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
     if sys.version_info.minor >= 8:

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -25,7 +25,7 @@ if "Windows" in platform.system():
     import sys
 
     arch_dir = platform.machine()
-    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
+    plt_dict = {"x86_64": "intel64", "AMD64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -25,7 +25,7 @@ if "Windows" in platform.system():
     import sys
 
     arch_dir = platform.machine()
-    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -17,17 +17,26 @@
 import platform
 
 from daal4py.sklearn._utils import daal_check_version
-
+    
 if "Windows" in platform.system():
     import os
     import site
     import sys
 
+    plt_arch = platform.machine()
+    arch_dir = None
+    if plt_arch=="x86_64":
+        arch_dir = "intel64"
+    elif plt_arch == "aarch64":
+        arch_dir = "arm"
+    else:
+        arch_dir = plt_arch
+ 
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
-            dal_root_redist = os.path.join(os.environ["DALROOT"], "redist", "intel64")
+            dal_root_redist = os.path.join(os.environ["DALROOT"], "redist", arch_dir)
             if os.path.exists(dal_root_redist):
                 os.add_dll_directory(dal_root_redist)
         os.add_dll_directory(path_to_libs)

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -1,5 +1,6 @@
 # ==============================================================================
 # Copyright 2021 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@
 import platform
 
 from daal4py.sklearn._utils import daal_check_version
-    
+
 if "Windows" in platform.system():
     import os
     import site
@@ -25,13 +26,13 @@ if "Windows" in platform.system():
 
     plt_arch = platform.machine()
     arch_dir = None
-    if plt_arch=="x86_64":
+    if plt_arch == "x86_64":
         arch_dir = "intel64"
     elif plt_arch == "aarch64":
         arch_dir = "arm"
     else:
         arch_dir = plt_arch
- 
+
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
     if sys.version_info.minor >= 8:

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -169,15 +169,9 @@ def custom_build_cmake_clib(
         else:
             MPI_LIBS = "mpi"
 
-    plt_arch = plt.machine()
-    arch_dir = None
-    if plt_arch == "x86_64":
-        arch_dir = "intel64"
-    elif plt_arch == "aarch64":
-        arch_dir = "arm"
-    else:
-        arch_dir = plt_arch
-
+    arch_dir = plt.machine()
+    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     use_parameters_arg = "yes" if use_parameters_lib else "no"
     log.info(f"Build using parameters library: {use_parameters_arg}")
 

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 # ===============================================================================
 # Copyright 2021 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,13 +18,14 @@
 
 import multiprocessing
 import os
+import platform as plt
 import subprocess
 import sys
 from distutils import log
 from distutils.sysconfig import get_config_var, get_python_inc
 from math import floor
 from os.path import join as jp
-import platform as plt
+
 import numpy as np
 
 IS_WIN = False
@@ -166,10 +168,10 @@ def custom_build_cmake_clib(
             assert MPI_LIBS, "Couldn't find MPI library"
         else:
             MPI_LIBS = "mpi"
-    
+
     plt_arch = plt.machine()
     arch_dir = None
-    if plt_arch=="x86_64":
+    if plt_arch == "x86_64":
         arch_dir = "intel64"
     elif plt_arch == "aarch64":
         arch_dir = "arm"

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -170,7 +170,7 @@ def custom_build_cmake_clib(
             MPI_LIBS = "mpi"
 
     arch_dir = plt.machine()
-    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
+    plt_dict = {"x86_64": "intel64", "AMD64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     use_parameters_arg = "yes" if use_parameters_lib else "no"
     log.info(f"Build using parameters library: {use_parameters_arg}")

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -23,7 +23,7 @@ from distutils import log
 from distutils.sysconfig import get_config_var, get_python_inc
 from math import floor
 from os.path import join as jp
-
+import platform as plt
 import numpy as np
 
 IS_WIN = False
@@ -166,6 +166,15 @@ def custom_build_cmake_clib(
             assert MPI_LIBS, "Couldn't find MPI library"
         else:
             MPI_LIBS = "mpi"
+    
+    plt_arch = plt.machine()
+    arch_dir = None
+    if plt_arch=="x86_64":
+        arch_dir = "intel64"
+    elif plt_arch == "aarch64":
+        arch_dir = "arm"
+    else:
+        arch_dir = plt_arch
 
     use_parameters_arg = "yes" if use_parameters_lib else "no"
     log.info(f"Build using parameters library: {use_parameters_arg}")
@@ -184,7 +193,7 @@ def custom_build_cmake_clib(
         "-DNUMPY_INCLUDE_DIRS=" + numpy_include,
         "-DPYTHON_LIBRARY_DIR=" + python_library_dir,
         "-DoneDAL_INCLUDE_DIRS=" + jp(os.environ["DALROOT"], "include"),
-        "-DoneDAL_LIBRARY_DIR=" + jp(os.environ["DALROOT"], "lib", "intel64"),
+        "-DoneDAL_LIBRARY_DIR=" + jp(os.environ["DALROOT"], "lib", arch_dir),
         "-Dpybind11_DIR=" + pybind11.get_cmake_dir(),
         "-DoneDAL_USE_PARAMETERS_LIB=" + use_parameters_arg,
     ]

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -170,7 +170,7 @@ def custom_build_cmake_clib(
             MPI_LIBS = "mpi"
 
     arch_dir = plt.machine()
-    plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+    plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
     arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
     use_parameters_arg = "yes" if use_parameters_lib else "no"
     log.info(f"Build using parameters library: {use_parameters_arg}")

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ dal_root = os.environ.get("DALROOT")
 n_threads = int(os.environ.get("NTHREADS", os.cpu_count() or 1))
 
 arch_dir = plt.machine()
-plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
 arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 if dal_root is None:
     raise RuntimeError("Not set DALROOT variable")

--- a/setup.py
+++ b/setup.py
@@ -52,15 +52,9 @@ IS_LIN = False
 dal_root = os.environ.get("DALROOT")
 n_threads = int(os.environ.get("NTHREADS", os.cpu_count() or 1))
 
-plt_arch = plt.machine()
-arch_dir = None
-if plt_arch == "x86_64":
-    arch_dir = "intel64"
-elif plt_arch == "aarch64":
-    arch_dir = "arm"
-else:
-    arch_dir = plt_arch
-
+arch_dir = plt.machine()
+plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 if dal_root is None:
     raise RuntimeError("Not set DALROOT variable")
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+
 #! /usr/bin/env python
 # ==============================================================================
 # Copyright 2014 Intel Corporation
@@ -38,6 +39,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 import scripts.build_backend as build_backend
 from scripts.package_helpers import get_packages_with_tests
 from scripts.version import get_onedal_version
+import platform as plt
 
 try:
     from ctypes.utils import find_library
@@ -51,18 +53,27 @@ IS_LIN = False
 dal_root = os.environ.get("DALROOT")
 n_threads = int(os.environ.get("NTHREADS", os.cpu_count() or 1))
 
+plt_arch = plt.machine()
+arch_dir = None
+if plt_arch=="x86_64":
+    arch_dir = "intel64"
+elif plt_arch == "aarch64":
+    arch_dir = "arm"
+else:
+    arch_dir = plt_arch
+
 if dal_root is None:
     raise RuntimeError("Not set DALROOT variable")
 
 if "linux" in sys.platform:
     IS_LIN = True
-    lib_dir = jp(dal_root, "lib", "intel64")
+    lib_dir = jp(dal_root, "lib", arch_dir)
 elif sys.platform == "darwin":
     IS_MAC = True
     lib_dir = jp(dal_root, "lib")
 elif sys.platform in ["win32", "cygwin"]:
     IS_WIN = True
-    lib_dir = jp(dal_root, "lib", "intel64")
+    lib_dir = jp(dal_root, "lib", arch_dir)
 else:
     assert False, sys.platform + " not supported"
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ dal_root = os.environ.get("DALROOT")
 n_threads = int(os.environ.get("NTHREADS", os.cpu_count() or 1))
 
 arch_dir = plt.machine()
-plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
+plt_dict = {"x86_64": "intel64", "AMD64": "intel64", "aarch64": "arm"}
 arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 if dal_root is None:
     raise RuntimeError("Not set DALROOT variable")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env python
 # ==============================================================================
 # Copyright 2014 Intel Corporation
@@ -23,6 +22,7 @@ import glob
 # System imports
 import os
 import pathlib
+import platform as plt
 import shutil
 import sys
 import time
@@ -39,7 +39,6 @@ from setuptools.command.build_ext import build_ext as _build_ext
 import scripts.build_backend as build_backend
 from scripts.package_helpers import get_packages_with_tests
 from scripts.version import get_onedal_version
-import platform as plt
 
 try:
     from ctypes.utils import find_library
@@ -55,7 +54,7 @@ n_threads = int(os.environ.get("NTHREADS", os.cpu_count() or 1))
 
 plt_arch = plt.machine()
 arch_dir = None
-if plt_arch=="x86_64":
+if plt_arch == "x86_64":
     arch_dir = "intel64"
 elif plt_arch == "aarch64":
     arch_dir = "arm"

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -1,5 +1,6 @@
 # ==============================================================================
 # Copyright 2014 Intel Corporation
+# Copyright 2024 Fujitsu Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +17,13 @@
 
 import argparse
 import os
+import platform as plt
 import struct
 import subprocess
 import sys
 from collections import defaultdict
 from os.path import join as jp
 from time import gmtime, strftime
-import platform as plt
 
 from daal4py import __has_dist__
 from daal4py.sklearn._utils import get_daal_version
@@ -60,7 +61,7 @@ else:
 
 plt_arch = plt.machine()
 arch_dir = None
-if plt_arch=="x86_64":
+if plt_arch == "x86_64":
     arch_dir = "intel64"
 elif plt_arch == "aarch64":
     arch_dir = "arm"

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -60,7 +60,7 @@ else:
     assert False, sys.platform + " not supported"
 
 arch_dir = plt.machine()
-plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
+plt_dict = {"x86_64": "intel64", "AMD64": "intel64", "aarch64": "arm"}
 arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 assert 8 * struct.calcsize("P") in [32, 64]
 

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -60,7 +60,7 @@ else:
     assert False, sys.platform + " not supported"
 
 arch_dir = plt.machine()
-plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+plt_dict = {"x86_64": "intel64", "aarch64": "arm"}
 arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 assert 8 * struct.calcsize("P") in [32, 64]
 

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -59,15 +59,9 @@ elif sys.platform in ["win32", "cygwin"]:
 else:
     assert False, sys.platform + " not supported"
 
-plt_arch = plt.machine()
-arch_dir = None
-if plt_arch == "x86_64":
-    arch_dir = "intel64"
-elif plt_arch == "aarch64":
-    arch_dir = "arm"
-else:
-    arch_dir = plt_arch
-
+arch_dir = plt.machine()
+plt_dict = {"x86_64":"intel64", "aarch64":"arm"}
+arch_dir = plt_dict[arch_dir] if arch_dir in plt_dict else arch_dir
 assert 8 * struct.calcsize("P") in [32, 64]
 
 if 8 * struct.calcsize("P") == 32:

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -22,6 +22,7 @@ import sys
 from collections import defaultdict
 from os.path import join as jp
 from time import gmtime, strftime
+import platform as plt
 
 from daal4py import __has_dist__
 from daal4py.sklearn._utils import get_daal_version
@@ -57,12 +58,21 @@ elif sys.platform in ["win32", "cygwin"]:
 else:
     assert False, sys.platform + " not supported"
 
+plt_arch = plt.machine()
+arch_dir = None
+if plt_arch=="x86_64":
+    arch_dir = "intel64"
+elif plt_arch == "aarch64":
+    arch_dir = "arm"
+else:
+    arch_dir = plt_arch
+
 assert 8 * struct.calcsize("P") in [32, 64]
 
 if 8 * struct.calcsize("P") == 32:
     logdir = jp(runner_dir, "_results", "ia32")
 else:
-    logdir = jp(runner_dir, "_results", "intel64")
+    logdir = jp(runner_dir, "_results", arch_dir)
 
 ex_log_dirs = [
     (jp(examples_rootdir, "daal4py"), jp(logdir, "daal4py")),


### PR DESCRIPTION
# Description
### Enable scikit-learn-intelex build on ARM(SVE) cpu -
Now since oneDAL officially support arm CPUs [PR-2614](https://github.com/oneapi-src/oneDAL/pull/2614), this PR will enable Scikit-learn-intelex build on arm CPUs. 
# Changes proposed in this PR :
  - Remove hardcoded architecture directory (`arch_dir`) name (intel64). Implemented run time selection of `arch_dir` based on backend CPU. 


 
