### PR TITLE
[testing] re-enable deselected PCA and LogisticRegression tests

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -174,7 +174,7 @@ deselected_tests:
   - cluster/tests/test_k_means.py::test_kmeans_relocated_clusters >=0.24
 
   # In scikit-learn, these algorithms are not included in this test. However, scikit-learn-intelex
-  # does and throws an error. This is due to t#he different structure of the transformer.__module__.split(".").
+  # does and throws an error. This is due to the different structure of the transformer.__module__.split(".").
   - tests/test_common.py::test_transformers_get_feature_names_out[KMeans()] >=1.0
   #- tests/test_common.py::test_transformers_get_feature_names_out[PCA()] >=1.0
 
@@ -313,7 +313,7 @@ deselected_tests:
   - tests/test_config.py::test_config_context
 
   # HalvingGridSearchCV with Ridge and PCA didn't have feature_name_in. Need to fix.
-  #- tests/test_common.py::test_pandas_column_name_consistency >=1.0.1
+  - tests/test_common.py::test_pandas_column_name_consistency >=1.0.1
 
   # Some scikit-learn-intelex docstrings differ from scikit-learn.
   - tests/test_docstrings.py >=1.0.2

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -174,9 +174,9 @@ deselected_tests:
   - cluster/tests/test_k_means.py::test_kmeans_relocated_clusters >=0.24
 
   # In scikit-learn, these algorithms are not included in this test. However, scikit-learn-intelex
-  # does and throws an error. This is due to the different structure of the transformer.__module__.split(".").
+  # does and throws an error. This is due to t#he different structure of the transformer.__module__.split(".").
   - tests/test_common.py::test_transformers_get_feature_names_out[KMeans()] >=1.0
-  - tests/test_common.py::test_transformers_get_feature_names_out[PCA()] >=1.0
+  #- tests/test_common.py::test_transformers_get_feature_names_out[PCA()] >=1.0
 
   # oneAPI Data Analytics Library (oneDAL) does not check convergence for tol == 0.0 for ease of benchmarking
   - cluster/tests/test_k_means.py::test_kmeans_convergence >=0.23
@@ -289,14 +289,14 @@ deselected_tests:
   # Some values in PCA.components_ (in the last component) aren't equal (0.6 on average
   # for absolute error in this test) because of different implementations of PCA.
   # The results are also not stable.
-  - decomposition/tests/test_incremental_pca.py::test_whitening
+  #- decomposition/tests/test_incremental_pca.py::test_whitening
 
   # Stability issue with max absolute difference: 0.00015992. Remove in the next release.
-  - decomposition/tests/test_pca.py::test_pca_dtype_preservation >=0.24,<1.0
+  #- decomposition/tests/test_pca.py::test_pca_dtype_preservation >=0.24,<1.0
 
   # The test fails because of changing of 'auto' strategy in PCA to improve performance.
   # 'randomized' PCA expected, but 'full' is given.
-  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
+  #- decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
 
   # Scikit-learn logistic regression predict depends from decision_function while d4p is not.
   # Assertion error in check_estimator (PoorScoreLogisticRegression())
@@ -313,7 +313,7 @@ deselected_tests:
   - tests/test_config.py::test_config_context
 
   # HalvingGridSearchCV with Ridge and PCA didn't have feature_name_in. Need to fix.
-  - tests/test_common.py::test_pandas_column_name_consistency >=1.0.1
+  #- tests/test_common.py::test_pandas_column_name_consistency >=1.0.1
 
   # Some scikit-learn-intelex docstrings differ from scikit-learn.
   - tests/test_docstrings.py >=1.0.2
@@ -445,7 +445,7 @@ gpu:
   - cluster/tests/test_k_means.py::test_k_means_fit_predict
   - cluster/tests/test_k_means.py::test_predict
 
-  - decomposition/tests/test_pca.py::test_pca_dtype_preservation
+  #- decomposition/tests/test_pca.py::test_pca_dtype_preservation
 
   - ensemble/tests/test_bagging.py::test_gridsearch
   - ensemble/tests/test_bagging.py::test_estimators_samples
@@ -625,7 +625,7 @@ gpu:
   - tests/test_common.py::test_estimators[TSNE()-check_n_features_in]
   - tests/test_common.py::test_search_cv[RandomizedSearchCV(estimator=LogisticRegression(),param_distributions={'C':[0.1,1.0]})-check_classifiers_classes]
   - tests/test_common.py::test_search_cv[RandomizedSearchCV(estimator=LogisticRegression(),param_distributions={'C':[0.1,1.0]})-check_decision_proba_consistency]
-  - tests/test_common.py::test_search_cv[RandomizedSearchCV(error_score='raise',estimator=Pipeline(steps=[('pca',PCA()),('logisticregression',LogisticRegression())]),param_distributions={'logisticregression__C':[0.1,1.0]})-check_decision_proba_consistency]
+  #- tests/test_common.py::test_search_cv[RandomizedSearchCV(error_score='raise',estimator=Pipeline(steps=[('pca',PCA()),('logisticregression',LogisticRegression())]),param_distributions={'logisticregression__C':[0.1,1.0]})-check_decision_proba_consistency]
   - tests/test_common.py::test_check_n_features_in_after_fitting[TSNE()]
 
   - tests/test_multiclass.py::test_ovr_fit_predict_sparse
@@ -677,19 +677,19 @@ gpu:
   - tests/test_common.py::test_transformers_get_feature_names_out[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_transformers_get_feature_names_out[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   - tests/test_common.py::test_transformers_get_feature_names_out[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_set_output_transform[PCA()]
+  #- tests/test_common.py::test_set_output_transform[PCA()]
   - tests/test_common.py::test_set_output_transform[RFE(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform[RFECV(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   - tests/test_common.py::test_set_output_transform[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_set_output_transform_pandas[PCA()]
+  #- tests/test_common.py::test_set_output_transform_pandas[PCA()]
   - tests/test_common.py::test_set_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_set_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   - tests/test_common.py::test_set_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_global_output_transform_pandas[PCA()]
+  #- tests/test_common.py::test_global_output_transform_pandas[PCA()]
   - tests/test_common.py::test_global_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_global_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
   - tests/test_common.py::test_global_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
@@ -710,7 +710,7 @@ gpu:
   - tests/test_multioutput.py::test_classifier_chain_tuple_order[array]
   - tests/test_multioutput.py::test_classifier_chain_tuple_order[tuple]
   - tests/test_pipeline.py::test_pipeline_methods_anova
-  - tests/test_pipeline.py::test_pipeline_methods_pca_svm
+  #- tests/test_pipeline.py::test_pipeline_methods_pca_svm
   - tests/test_pipeline.py::test_score_samples_on_pipeline_without_score_samples
   - tests/test_pipeline.py::test_pipeline_methods_preprocessing_svm
   - tests/test_pipeline.py::test_pipeline_transform
@@ -1180,7 +1180,7 @@ gpu:
   - tests/test_common.py::test_check_n_features_in_after_fitting[DBSCAN()]
   - tests/test_common.py::test_check_n_features_in_after_fitting[SVC()]
   # originated with pca dpctl/dpnp fit, to be re-assesed with pca out-of-preview
-  - decomposition/tests/test_pca.py::test_pca_n_components_mostly_explained_variance_ratio
+  #- decomposition/tests/test_pca.py::test_pca_n_components_mostly_explained_variance_ratio
 
 preview:
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -289,14 +289,14 @@ deselected_tests:
   # Some values in PCA.components_ (in the last component) aren't equal (0.6 on average
   # for absolute error in this test) because of different implementations of PCA.
   # The results are also not stable.
-  #- decomposition/tests/test_incremental_pca.py::test_whitening
+  - decomposition/tests/test_incremental_pca.py::test_whitening
 
   # Stability issue with max absolute difference: 0.00015992. Remove in the next release.
   #- decomposition/tests/test_pca.py::test_pca_dtype_preservation >=0.24,<1.0
 
   # The test fails because of changing of 'auto' strategy in PCA to improve performance.
   # 'randomized' PCA expected, but 'full' is given.
-  #- decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
+  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
 
   # Scikit-learn logistic regression predict depends from decision_function while d4p is not.
   # Assertion error in check_estimator (PoorScoreLogisticRegression())

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -104,7 +104,7 @@ deselected_tests:
   - linear_model/tests/test_logistic.py::test_warm_start[multinomial-False-True-lbfgs]
 
   # Base scikit-learn estimator is N/A for scikit-learn-intelex ensembles
-  - ensemble/tests/test_forest.py::test_base_estimator_property_deprecated
+  #- ensemble/tests/test_forest.py::test_base_estimator_property_deprecated
 
   # Difference of assigned dtype: int64 (scikit-learn) vs. int32 (oneDAL/scikit-learn-intelex)
   - cluster/_dbscan.py::sklearn.cluster._dbscan.DBSCAN
@@ -157,10 +157,10 @@ deselected_tests:
   - svm/tests/test_svm.py::test_custom_kernel_not_array_input[SVR]
 
   # This test needs a warning from scikit-learn. scikit-learn-intelex raises the same warning
-  - tests/test_common.py::test_estimators[SVC()-check_supervised_y_2d]
-  - tests/test_common.py::test_estimators[SVR()-check_supervised_y_2d]
-  - tests/test_common.py::test_estimators[NuSVC()-check_supervised_y_2d]
-  - tests/test_common.py::test_estimators[NuSVR()-check_supervised_y_2d]
+  #- tests/test_common.py::test_estimators[SVC()-check_supervised_y_2d]
+  #- tests/test_common.py::test_estimators[SVR()-check_supervised_y_2d]
+  #- tests/test_common.py::test_estimators[NuSVC()-check_supervised_y_2d]
+  #- tests/test_common.py::test_estimators[NuSVR()-check_supervised_y_2d]
 
   # Bitwise comparison of probabilities using a print.
   - metrics/tests/test_classification.py >=0.22,<0.24
@@ -268,8 +268,8 @@ deselected_tests:
   - ensemble/tests/test_forest.py::test_memory_layout[float32-ExtraTreesRegressor]
 
   # The bugs are fixed in 2021.2 release
-  - ensemble/tests/test_stacking.py::test_stacking_cv_influence
-  - utils/tests/test_estimator_checks.py::test_check_estimator_clones
+  #- ensemble/tests/test_stacking.py::test_stacking_cv_influence
+  #- utils/tests/test_estimator_checks.py::test_check_estimator_clones
 
   # module name should starts with 'sklearn.' but we have 'daal4py.sklearn.'
   - tests/test_common.py::test_check_n_features_in_after_fitting[LogisticRegression()] >=0.24,<1.0
@@ -305,7 +305,7 @@ deselected_tests:
   # RandomForestRegressor sum(y_pred)!=sum(y_true)
   - ensemble/tests/test_forest.py::test_balance_property_random_forest[squared_error] >=1.0
 
-  # This tests fail on mac mini 8.1 with stock scikit-learn
+  # This test fails on mac mini 8.1 with stock scikit-learn
   - semi_supervised/tests/test_label_propagation.py
 
   # This test fails because with patch config_context with new options, but the
@@ -456,10 +456,10 @@ gpu:
   - feature_selection/tests/test_rfe.py::test_number_of_subsets_of_features
 
   - linear_model/tests/test_coordinate_descent.py::test_model_pipeline_same_as_normalize_true
-  - linear_model/tests/test_logistic.py::test_predict_3_classes
-  - linear_model/tests/test_logistic.py::test_logistic_cv_sparse
-  - linear_model/tests/test_logistic.py::test_ovr_multinomial_iris
-  - linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
+  #- linear_model/tests/test_logistic.py::test_predict_3_classes
+  #- linear_model/tests/test_logistic.py::test_logistic_cv_sparse
+  #- linear_model/tests/test_logistic.py::test_ovr_multinomial_iris
+  #- linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
 
   - manifold/tests/test_t_sne.py::test_preserve_trustworthiness_approximately
   - manifold/tests/test_t_sne.py::test_uniform_grid
@@ -585,23 +585,23 @@ gpu:
   - tests/test_common.py::test_estimators[GaussianMixture()-check_fit2d_predict1d]
   - tests/test_common.py::test_estimators[KMeans()-check_clustering]
   - tests/test_common.py::test_estimators[KMeans()-check_clustering(readonly_memmap=True)]
-  - tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=ones)]
-  - tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=zeros)]
-  - tests/test_common.py::test_estimators[LogisticRegression()-check_classifiers_classes]
-  - tests/test_common.py::test_estimators[LogisticRegression()-check_decision_proba_consistency]
-  - tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
-  - tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifier_multioutput]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True)]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True,X_dtype=float32)]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
-  - tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_classifiers_classes]
-  - tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
-  - tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_classifiers_classes]
-  - tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
+  #- tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=ones)]
+  #- tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=zeros)]
+  #- tests/test_common.py::test_estimators[LogisticRegression()-check_classifiers_classes]
+  #- tests/test_common.py::test_estimators[LogisticRegression()-check_decision_proba_consistency]
+  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
+  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifier_multioutput]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True)]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True,X_dtype=float32)]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
+  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_classifiers_classes]
+  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
+  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_classifiers_classes]
+  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
   - tests/test_common.py::test_estimators[RandomForestClassifier()-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_pandas_series]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_not_an_array]
@@ -667,34 +667,34 @@ gpu:
   - tests/test_pipeline.py::test_fit_predict_on_pipeline
   - tests/test_discriminant_analysis.py::test_lda_predict
   # Other device issues
-  - tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
-  - tests/test_common.py::test_estimators[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
-  - tests/test_common.py::test_check_n_features_in_after_fitting[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_check_n_features_in_after_fitting[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_check_n_features_in_after_fitting[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_transformers_get_feature_names_out[RFE(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_transformers_get_feature_names_out[RFECV(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_transformers_get_feature_names_out[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_transformers_get_feature_names_out[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_transformers_get_feature_names_out[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
+  #- tests/test_common.py::test_estimators[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
+  #- tests/test_common.py::test_check_n_features_in_after_fitting[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_check_n_features_in_after_fitting[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_check_n_features_in_after_fitting[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_transformers_get_feature_names_out[RFE(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_transformers_get_feature_names_out[RFECV(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_transformers_get_feature_names_out[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_transformers_get_feature_names_out[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_transformers_get_feature_names_out[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   #- tests/test_common.py::test_set_output_transform[PCA()]
-  - tests/test_common.py::test_set_output_transform[RFE(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform[RFECV(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_set_output_transform[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_set_output_transform[RFE(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform[RFECV(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_set_output_transform[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   #- tests/test_common.py::test_set_output_transform_pandas[PCA()]
-  - tests/test_common.py::test_set_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_set_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_set_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_set_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_set_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_set_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   #- tests/test_common.py::test_global_output_transform_pandas[PCA()]
-  - tests/test_common.py::test_global_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_global_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_global_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  - tests/test_common.py::test_global_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  - tests/test_common.py::test_global_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_global_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_global_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_global_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
+  #- tests/test_common.py::test_global_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
+  #- tests/test_common.py::test_global_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   - tests/test_metaestimators.py::test_meta_estimators_delegate_data_validation[StackingClassifier]
   - tests/test_multiclass.py::test_ovr_always_present
   - tests/test_multiclass.py::test_support_missing_values[OneVsRestClassifier]
@@ -1113,15 +1113,15 @@ gpu:
   - svm/tests/test_svm.py::test_svm_class_weights_deprecation[NuSVR]
   # possible cause of timeout
   - tests/test_common.py::test_estimators[CalibratedClassifierCV(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[LogisticRegression()-
-  - tests/test_common.py::test_estimators[LogisticRegressionCV()-
-  - tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[OutputCodeClassifier(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[SelfTrainingClassifier(base_estimator=LogisticRegression(C=1))-
-  - tests/test_common.py::test_estimators[SequentialFeatureSelector(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[LogisticRegression()-
+  #- tests/test_common.py::test_estimators[LogisticRegressionCV()-
+  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[OutputCodeClassifier(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[SelfTrainingClassifier(base_estimator=LogisticRegression(C=1))-
+  #- tests/test_common.py::test_estimators[SequentialFeatureSelector(estimator=LogisticRegression(C=1))-
   # Sporadic failures on Max series with 2024.0 toolchain update that require deeper investigation
   - tests/test_multiclass.py::test_ovo_consistent_binary_classification
   # Python 3.8 failures on Max series with 2024.0 toolchain update

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -437,8 +437,6 @@ gpu:
   - cluster/tests/test_k_means.py::test_k_means_fit_predict
   - cluster/tests/test_k_means.py::test_predict
 
-  #- decomposition/tests/test_pca.py::test_pca_dtype_preservation
-
   - ensemble/tests/test_bagging.py::test_gridsearch
   - ensemble/tests/test_bagging.py::test_estimators_samples
   - ensemble/tests/test_common.py::test_ensemble_heterogeneous_estimators_behavior

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -103,9 +103,6 @@ deselected_tests:
   - linear_model/tests/test_logistic.py::test_warm_start[multinomial-False-True-newton-cg]
   - linear_model/tests/test_logistic.py::test_warm_start[multinomial-False-True-lbfgs]
 
-  # Base scikit-learn estimator is N/A for scikit-learn-intelex ensembles
-  #- ensemble/tests/test_forest.py::test_base_estimator_property_deprecated
-
   # Difference of assigned dtype: int64 (scikit-learn) vs. int32 (oneDAL/scikit-learn-intelex)
   - cluster/_dbscan.py::sklearn.cluster._dbscan.DBSCAN
   - neighbors/_base.py::sklearn.neighbors._base.KNeighborsMixin.kneighbors
@@ -157,10 +154,10 @@ deselected_tests:
   - svm/tests/test_svm.py::test_custom_kernel_not_array_input[SVR]
 
   # This test needs a warning from scikit-learn. scikit-learn-intelex raises the same warning
-  #- tests/test_common.py::test_estimators[SVC()-check_supervised_y_2d]
-  #- tests/test_common.py::test_estimators[SVR()-check_supervised_y_2d]
-  #- tests/test_common.py::test_estimators[NuSVC()-check_supervised_y_2d]
-  #- tests/test_common.py::test_estimators[NuSVR()-check_supervised_y_2d]
+  - tests/test_common.py::test_estimators[SVC()-check_supervised_y_2d]
+  - tests/test_common.py::test_estimators[SVR()-check_supervised_y_2d]
+  - tests/test_common.py::test_estimators[NuSVC()-check_supervised_y_2d]
+  - tests/test_common.py::test_estimators[NuSVR()-check_supervised_y_2d]
 
   # Bitwise comparison of probabilities using a print.
   - metrics/tests/test_classification.py >=0.22,<0.24
@@ -176,7 +173,6 @@ deselected_tests:
   # In scikit-learn, these algorithms are not included in this test. However, scikit-learn-intelex
   # does and throws an error. This is due to the different structure of the transformer.__module__.split(".").
   - tests/test_common.py::test_transformers_get_feature_names_out[KMeans()] >=1.0
-  #- tests/test_common.py::test_transformers_get_feature_names_out[PCA()] >=1.0
 
   # oneAPI Data Analytics Library (oneDAL) does not check convergence for tol == 0.0 for ease of benchmarking
   - cluster/tests/test_k_means.py::test_kmeans_convergence >=0.23
@@ -268,8 +264,7 @@ deselected_tests:
   - ensemble/tests/test_forest.py::test_memory_layout[float32-ExtraTreesRegressor]
 
   # The bugs are fixed in 2021.2 release
-  #- ensemble/tests/test_stacking.py::test_stacking_cv_influence
-  #- utils/tests/test_estimator_checks.py::test_check_estimator_clones
+  - ensemble/tests/test_stacking.py::test_stacking_cv_influence
 
   # module name should starts with 'sklearn.' but we have 'daal4py.sklearn.'
   - tests/test_common.py::test_check_n_features_in_after_fitting[LogisticRegression()] >=0.24,<1.0
@@ -290,9 +285,6 @@ deselected_tests:
   # for absolute error in this test) because of different implementations of PCA.
   # The results are also not stable.
   - decomposition/tests/test_incremental_pca.py::test_whitening
-
-  # Stability issue with max absolute difference: 0.00015992. Remove in the next release.
-  #- decomposition/tests/test_pca.py::test_pca_dtype_preservation >=0.24,<1.0
 
   # The test fails because of changing of 'auto' strategy in PCA to improve performance.
   # 'randomized' PCA expected, but 'full' is given.
@@ -455,12 +447,6 @@ gpu:
 
   - feature_selection/tests/test_rfe.py::test_number_of_subsets_of_features
 
-  - linear_model/tests/test_coordinate_descent.py::test_model_pipeline_same_as_normalize_true
-  #- linear_model/tests/test_logistic.py::test_predict_3_classes
-  #- linear_model/tests/test_logistic.py::test_logistic_cv_sparse
-  #- linear_model/tests/test_logistic.py::test_ovr_multinomial_iris
-  #- linear_model/tests/test_logistic.py::test_logistic_regression_multinomial
-
   - manifold/tests/test_t_sne.py::test_preserve_trustworthiness_approximately
   - manifold/tests/test_t_sne.py::test_uniform_grid
   - manifold/tests/test_t_sne.py::test_tsne_different_square_distances
@@ -585,23 +571,6 @@ gpu:
   - tests/test_common.py::test_estimators[GaussianMixture()-check_fit2d_predict1d]
   - tests/test_common.py::test_estimators[KMeans()-check_clustering]
   - tests/test_common.py::test_estimators[KMeans()-check_clustering(readonly_memmap=True)]
-  #- tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=ones)]
-  #- tests/test_common.py::test_estimators[LogisticRegression()-check_sample_weights_invariance(kind=zeros)]
-  #- tests/test_common.py::test_estimators[LogisticRegression()-check_classifiers_classes]
-  #- tests/test_common.py::test_estimators[LogisticRegression()-check_decision_proba_consistency]
-  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
-  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifier_multioutput]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True)]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_classifiers_train(readonly_memmap=True,X_dtype=float32)]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_sample_order_invariance]
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-check_methods_subset_invariance]
-  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_classifiers_classes]
-  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
-  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_classifiers_classes]
-  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-check_decision_proba_consistency]
   - tests/test_common.py::test_estimators[RandomForestClassifier()-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_pandas_series]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_not_an_array]
@@ -625,7 +594,6 @@ gpu:
   - tests/test_common.py::test_estimators[TSNE()-check_n_features_in]
   - tests/test_common.py::test_search_cv[RandomizedSearchCV(estimator=LogisticRegression(),param_distributions={'C':[0.1,1.0]})-check_classifiers_classes]
   - tests/test_common.py::test_search_cv[RandomizedSearchCV(estimator=LogisticRegression(),param_distributions={'C':[0.1,1.0]})-check_decision_proba_consistency]
-  #- tests/test_common.py::test_search_cv[RandomizedSearchCV(error_score='raise',estimator=Pipeline(steps=[('pca',PCA()),('logisticregression',LogisticRegression())]),param_distributions={'logisticregression__C':[0.1,1.0]})-check_decision_proba_consistency]
   - tests/test_common.py::test_check_n_features_in_after_fitting[TSNE()]
 
   - tests/test_multiclass.py::test_ovr_fit_predict_sparse
@@ -667,34 +635,6 @@ gpu:
   - tests/test_pipeline.py::test_fit_predict_on_pipeline
   - tests/test_discriminant_analysis.py::test_lda_predict
   # Other device issues
-  #- tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
-  #- tests/test_common.py::test_estimators[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])
-  #- tests/test_common.py::test_check_n_features_in_after_fitting[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_check_n_features_in_after_fitting[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_check_n_features_in_after_fitting[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_transformers_get_feature_names_out[RFE(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_transformers_get_feature_names_out[RFECV(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_transformers_get_feature_names_out[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_transformers_get_feature_names_out[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_transformers_get_feature_names_out[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_set_output_transform[PCA()]
-  #- tests/test_common.py::test_set_output_transform[RFE(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform[RFECV(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_set_output_transform[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_set_output_transform_pandas[PCA()]
-  #- tests/test_common.py::test_set_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_set_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_set_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_global_output_transform_pandas[PCA()]
-  #- tests/test_common.py::test_global_output_transform_pandas[RFE(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_global_output_transform_pandas[RFECV(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_global_output_transform_pandas[SequentialFeatureSelector(estimator=LogisticRegression(C=1))]
-  #- tests/test_common.py::test_global_output_transform_pandas[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
-  #- tests/test_common.py::test_global_output_transform_pandas[VotingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])]
   - tests/test_metaestimators.py::test_meta_estimators_delegate_data_validation[StackingClassifier]
   - tests/test_multiclass.py::test_ovr_always_present
   - tests/test_multiclass.py::test_support_missing_values[OneVsRestClassifier]
@@ -710,7 +650,6 @@ gpu:
   - tests/test_multioutput.py::test_classifier_chain_tuple_order[array]
   - tests/test_multioutput.py::test_classifier_chain_tuple_order[tuple]
   - tests/test_pipeline.py::test_pipeline_methods_anova
-  #- tests/test_pipeline.py::test_pipeline_methods_pca_svm
   - tests/test_pipeline.py::test_score_samples_on_pipeline_without_score_samples
   - tests/test_pipeline.py::test_pipeline_methods_preprocessing_svm
   - tests/test_pipeline.py::test_pipeline_transform
@@ -1111,17 +1050,6 @@ gpu:
   - svm/tests/test_svm.py::test_n_iter_libsvm[dataset2-NuSVR-int]
   - svm/tests/test_svm.py::test_svm_class_weights_deprecation[SVR]
   - svm/tests/test_svm.py::test_svm_class_weights_deprecation[NuSVR]
-  # possible cause of timeout
-  - tests/test_common.py::test_estimators[CalibratedClassifierCV(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[LogisticRegression()-
-  #- tests/test_common.py::test_estimators[LogisticRegressionCV()-
-  #- tests/test_common.py::test_estimators[OneVsOneClassifier(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[OneVsRestClassifier(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[OutputCodeClassifier(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[RFE(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[RFECV(estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[SelfTrainingClassifier(base_estimator=LogisticRegression(C=1))-
-  #- tests/test_common.py::test_estimators[SequentialFeatureSelector(estimator=LogisticRegression(C=1))-
   # Sporadic failures on Max series with 2024.0 toolchain update that require deeper investigation
   - tests/test_multiclass.py::test_ovo_consistent_binary_classification
   # Python 3.8 failures on Max series with 2024.0 toolchain update
@@ -1179,8 +1107,6 @@ gpu:
   - tests/test_common.py::test_estimators[DBSCAN()-check_fit2d_predict1d]
   - tests/test_common.py::test_check_n_features_in_after_fitting[DBSCAN()]
   - tests/test_common.py::test_check_n_features_in_after_fitting[SVC()]
-  # originated with pca dpctl/dpnp fit, to be re-assesed with pca out-of-preview
-  #- decomposition/tests/test_pca.py::test_pca_n_components_mostly_explained_variance_ratio
 
 preview:
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results


### PR DESCRIPTION
# Description
PCA and GPU LogisticRegression are now out of preview, this PR checks to see what the status of CI. (There were no changes in moving PCA and LogisticRegression out of preview in #1570 and #1649, and frankly should have been done in those PRs).

Changes proposed in this pull request:
- modify deselected_tests.yaml

 
