### PR TITLE
[bug] fix dpnp/dpctl slowdown in fit method of neighbors algorithms

### DIFF
--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -100,7 +100,6 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
         return self
 
     def fit(self, X, y=None):
-        self._fit_validation(X, y)
         result = dispatch(
             self,
             "fit",

--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -137,6 +137,9 @@ class KNeighborsDispatchingBase:
             self.n_features_in_ = X.data.shape[1]
 
     def _onedal_supported(self, device, method_name, *data):
+        if method_name == "fit":
+            self._fit_validation(data[0], data[1])
+
         class_name = self.__class__.__name__
         is_classifier = "Classifier" in class_name
         is_regressor = "Regressor" in class_name

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -192,7 +192,6 @@ class KNeighborsClassifier(KNeighborsClassifier_, KNeighborsDispatchingBase):
             )
 
     def fit(self, X, y):
-        self._fit_validation(X, y)
         dispatch(
             self,
             "fit",

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -188,7 +188,6 @@ class KNeighborsRegressor(KNeighborsRegressor_, KNeighborsDispatchingBase):
             )
 
     def fit(self, X, y):
-        self._fit_validation(X, y)
         dispatch(
             self,
             "fit",

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -118,7 +118,6 @@ class NearestNeighbors(NearestNeighbors_, KNeighborsDispatchingBase):
         )
 
     def fit(self, X, y=None):
-        self._fit_validation(X, y)
         dispatch(
             self,
             "fit",


### PR DESCRIPTION
# Description
There is a 400x performance difference in running fit using dpnp arrays/dpctl tensors vs config_context with a device offload. This is not due to the movement off of GPU, but due to numpy calls on dpnp/dpctl in _fit_validation.  By moving that call within the onedal_cpu_supported and onedal_gpu_supported, the input data is guaranteed to by numpy arrays, and therefore gets the equivalent performance of config_context.

There issues were discovered in #1737 and #1776 and should speed up CI in those cases substantially for both CPU and GPU offloading via dpnp/dpctl.

Changes proposed in this pull request:
- move _fit_validation for LocalOutlierFactor
- move _fit_validation for NearestNeighbors
- move _fit_validation for KNeighborsClassifier
- move _fit_validation for KNeighborsRegressor

 
