### PR TITLE
[bug] fix dpnp/dpctl speed issue with LocalOutlierFactor

### DIFF
--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -182,7 +182,6 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
         """
         return self._predict(X)
 
-
     def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
         if sklearn_check_version("1.0") and X is not None:

--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -182,8 +182,8 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
         """
         return self._predict(X)
 
-    @wrap_output_data
-    def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
+
+    def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
         if sklearn_check_version("1.0") and X is not None:
             self._check_feature_names(X, reset=False)
@@ -198,6 +198,52 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
             n_neighbors=n_neighbors,
             return_distance=return_distance,
         )
+
+    kneighbors = wrap_output_data(_kneighbors)    
+
+    @available_if(sklearn_LocalOutlierFactor._check_novelty_score_samples)
+    @wrap_output_data
+    def score_samples(self, X):
+        """Opposite of the Local Outlier Factor of X.
+
+        It is the opposite as bigger is better, i.e. large values correspond
+        to inliers.
+
+        **Only available for novelty detection (when novelty is set to True).**
+        The argument X is supposed to contain *new data*: if X contains a
+        point from training, it considers the later in its own neighborhood.
+        Also, the samples in X are not considered in the neighborhood of any
+        point. Because of this, the scores obtained via ``score_samples`` may
+        differ from the standard LOF scores.
+        The standard LOF scores for the training data is available via the
+        ``negative_outlier_factor_`` attribute.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The query sample or samples to compute the Local Outlier Factor
+            w.r.t. the training samples.
+
+        Returns
+        -------
+        opposite_lof_scores : ndarray of shape (n_samples,)
+            The opposite of the Local Outlier Factor of each input samples.
+            The lower, the more abnormal.
+        """
+        check_is_fitted(self)
+
+        distances_X, neighbors_indices_X = self._kneighbors(
+            X, n_neighbors=self.n_neighbors_
+        )
+
+        X_lrd = self._local_reachability_density(
+            distances_X,
+            neighbors_indices_X,
+        )
+
+        lrd_ratios_array = self._lrd[neighbors_indices_X] / X_lrd[:, np.newaxis]
+
+        return -np.mean(lrd_ratios_array, axis=1)
 
     fit.__doc__ = sklearn_LocalOutlierFactor.fit.__doc__
     kneighbors.__doc__ = sklearn_LocalOutlierFactor.kneighbors.__doc__

--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -198,7 +198,7 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
             return_distance=return_distance,
         )
 
-    kneighbors = wrap_output_data(_kneighbors)    
+    kneighbors = wrap_output_data(_kneighbors)
 
     @available_if(sklearn_LocalOutlierFactor._check_novelty_score_samples)
     @wrap_output_data

--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -29,7 +29,7 @@ from .common import KNeighborsDispatchingBase
 from .knn_unsupervised import NearestNeighbors
 
 
-@control_n_jobs(decorated_methods=["fit", "kneighbors"])
+@control_n_jobs(decorated_methods=["fit", "_kneighbors"])
 class LocalOutlierFactor(KNeighborsDispatchingBase, sklearn_LocalOutlierFactor):
     __doc__ = (
         sklearn_LocalOutlierFactor.__doc__


### PR DESCRIPTION
# Description
predict call leads to decision_function which leads to score_samples which calls kneighbors, the result of which has interactions afterward between numpy and dpctl/dpnp which can be slow. This strips away wrap_output_data and interacts with score_samples. It is a close copy of sklearn's score_sample: https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/neighbors/_lof.py#L439

Changes proposed in this pull request:
- add score_samples to LocalOutlierFactor
- subtly change kneighbors to _kneighbors to allow use without wrap_output_data

 
