### PR TITLE
deselect test_estimators[PCA()-check_methods_subset_invariance]

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -704,6 +704,9 @@ gpu:
   - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=zeros)]
   - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=ones)]
 
+  # Single value incorrect in some CI runs with Linux and GPU hardware, requires further analysis
+  - test_estimators[PCA()-check_methods_subset_invariance]
+
   # RuntimeError: Device support is not implemented, failing as result of fallback to cpu false
   # NearestNeighbors
   - cluster/tests/test_dbscan.py

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -705,7 +705,7 @@ gpu:
   - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=ones)]
 
   # Single value incorrect in some CI runs with Linux and GPU hardware, requires further analysis
-  - test_estimators[PCA()-check_methods_subset_invariance]
+  - tests/test_common.py::test_estimators[PCA()-check_methods_subset_invariance]
 
   # RuntimeError: Device support is not implemented, failing as result of fallback to cpu false
   # NearestNeighbors


### PR DESCRIPTION
# Description
Intermittent but consistent failure for PCA on GPU, deselect test_estimators[PCA()-check_methods_subset_invariance]

Changes proposed in this pull request:
- add test_estimators[PCA()-check_methods_subset_invariance] to deselected_tests.yaml

 
