### PR TITLE
Update sklearnex estimators to support sklearn 1.5

### DIFF
--- a/daal4py/sklearn/cluster/k_means.py
+++ b/daal4py/sklearn/cluster/k_means.py
@@ -258,23 +258,6 @@ def _daal4py_k_means_fit(
 
 
 def _fit(self, X, y=None, sample_weight=None):
-    """Compute k-means clustering.
-
-    Parameters
-    ----------
-    X : array-like or sparse matrix, shape=(n_samples, n_features)
-        Training instances to cluster. It must be noted that the data
-        will be converted to C ordering, which will cause a memory
-        copy if the given data is not C-contiguous.
-
-    y : Ignored
-        not used, present here for API consistency by convention.
-
-    sample_weight : array-like, shape (n_samples,), optional
-        The weights for each observation in X. If None, all observations
-        are assigned equal weight (default: None)
-
-    """
     init = self.init
     if sklearn_check_version("1.1"):
         if sklearn_check_version("1.2"):
@@ -447,26 +430,6 @@ def _daal4py_check_test_data(self, X):
 
 
 def _predict(self, X, sample_weight=None):
-    """Predict the closest cluster each sample in X belongs to.
-
-    In the vector quantization literature, `cluster_centers_` is called
-    the code book and each value returned by `predict` is the index of
-    the closest code in the code book.
-
-    Parameters
-    ----------
-    X : {array-like, sparse matrix}, shape = [n_samples, n_features]
-       New data to predict.
-
-    sample_weight : array-like, shape (n_samples,), optional
-        The weights for each observation in X. If None, all observations
-        are assigned equal weight (default: None)
-
-    Returns
-    -------
-    labels : array, shape [n_samples,]
-        Index of the cluster each sample belongs to.
-    """
     check_is_fitted(self)
 
     X = _daal4py_check_test_data(self, X)
@@ -614,86 +577,29 @@ class KMeans(KMeans_original):
 
     @support_usm_ndarray()
     def fit(self, X, y=None, sample_weight=None):
-        """
-        Compute k-means clustering.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training instances to cluster. It must be noted that the data
-            will be converted to C ordering, which will cause a memory
-            copy if the given data is not C-contiguous.
-            If a sparse matrix is passed, a copy will be made if it's not in
-            CSR format.
-
-        y : Ignored
-            Not used, present here for API consistency by convention.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-            .. versionadded:: 0.20
-
-        Returns
-        -------
-        self : object
-            Fitted estimator.
-        """
         return _fit(self, X, y=y, sample_weight=sample_weight)
 
-    @support_usm_ndarray()
-    def predict(
-        self, X, sample_weight="deprecated" if sklearn_check_version("1.3") else None
-    ):
-        """
-        Predict the closest cluster each sample in X belongs to.
+    if sklearn_check_version("1.5"):
 
-        In the vector quantization literature, `cluster_centers_` is called
-        the code book and each value returned by `predict` is the index of
-        the closest code in the code book.
+        @support_usm_ndarray()
+        def predict(self, X):
+            return _predict(self, X)
 
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data to predict.
+    else:
 
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-        Returns
-        -------
-        labels : ndarray of shape (n_samples,)
-            Index of the cluster each sample belongs to.
-        """
-        return _predict(self, X, sample_weight=sample_weight)
+        @support_usm_ndarray()
+        def predict(
+            self, X, sample_weight="deprecated" if sklearn_check_version("1.3") else None
+        ):
+            return _predict(self, X, sample_weight=sample_weight)
 
     @support_usm_ndarray()
     def fit_predict(self, X, y=None, sample_weight=None):
-        """
-        Compute cluster centers and predict cluster index for each sample.
-
-        Convenience method; equivalent to calling fit(X) followed by
-        predict(X).
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data to transform.
-
-        y : Ignored
-            Not used, present here for API consistency by convention.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-        Returns
-        -------
-        labels : ndarray of shape (n_samples,)
-            Index of the cluster each sample belongs to.
-        """
         return super().fit_predict(X, y, sample_weight)
 
     score = support_usm_ndarray()(KMeans_original.score)
+
+    fit.__doc__ = KMeans_original.fit.__doc__
+    predict.__doc__ = KMeans_original.predict.__doc__
+    fit_predict.__doc__ = KMeans_original.fit_predict.__doc__
+    score.__doc__ = KMeans_original.score.__doc__

--- a/daal4py/sklearn/manifold/_t_sne.py
+++ b/daal4py/sklearn/manifold/_t_sne.py
@@ -44,52 +44,15 @@ from ..neighbors import NearestNeighbors
 class TSNE(BaseTSNE):
     __doc__ = BaseTSNE.__doc__
 
+    if sklearn_check_version("1.2"):
+        _parameter_constraints: dict = {**BaseTSNE._parameter_constraints}
+
     @support_usm_ndarray()
     def fit_transform(self, X, y=None):
-        """
-        Fit X into an embedded space and return that transformed output.
-
-        Parameters
-        ----------
-        X : ndarray of shape (n_samples, n_features) or (n_samples, n_samples)
-            If the metric is 'precomputed' X must be a square distance
-            matrix. Otherwise it contains a sample per row. If the method
-            is 'exact', X may be a sparse matrix of type 'csr', 'csc'
-            or 'coo'. If the method is 'barnes_hut' and the metric is
-            'precomputed', X may be a precomputed sparse graph.
-
-        y : None
-            Ignored.
-
-        Returns
-        -------
-        X_new : ndarray of shape (n_samples, n_components)
-            Embedding of the training data in low-dimensional space.
-        """
         return super().fit_transform(X, y)
 
     @support_usm_ndarray()
     def fit(self, X, y=None):
-        """
-        Fit X into an embedded space.
-
-        Parameters
-        ----------
-        X : ndarray of shape (n_samples, n_features) or (n_samples, n_samples)
-            If the metric is 'precomputed' X must be a square distance
-            matrix. Otherwise it contains a sample per row. If the method
-            is 'exact', X may be a sparse matrix of type 'csr', 'csc'
-            or 'coo'. If the method is 'barnes_hut' and the metric is
-            'precomputed', X may be a precomputed sparse graph.
-
-        y : None
-            Ignored.
-
-        Returns
-        -------
-        X_new : array of shape (n_samples, n_components)
-            Embedding of the training data in low-dimensional space.
-        """
         return super().fit(X, y)
 
     def _daal_tsne(self, P, n_samples, X_embedded):
@@ -101,11 +64,27 @@ class TSNE(BaseTSNE):
         # * final optimization with momentum at 0.8
 
         # N, nnz, n_iter_without_progress, n_iter
-        size_iter = [[n_samples], [P.nnz], [self.n_iter_without_progress], [self.n_iter]]
+        size_iter = [
+            [n_samples],
+            [P.nnz],
+            [self.n_iter_without_progress],
+            [self._max_iter if sklearn_check_version("1.5") else self.n_iter],
+        ]
 
         # Pass params to daal4py backend
         if daal_check_version((2023, "P", 1)):
-            size_iter.extend([[self._EXPLORATION_N_ITER], [self._N_ITER_CHECK]])
+            size_iter.extend(
+                [
+                    [
+                        (
+                            self._EXPLORATION_MAX_ITER
+                            if sklearn_check_version("1.5")
+                            else self._EXPLORATION_N_ITER
+                        )
+                    ],
+                    [self._N_ITER_CHECK],
+                ]
+            )
 
         size_iter = np.array(size_iter, dtype=P.dtype)
 
@@ -254,9 +233,6 @@ class TSNE(BaseTSNE):
                     self.early_exaggeration
                 )
             )
-
-        if self.n_iter < 250:
-            raise ValueError("n_iter should be at least 250")
 
         n_samples = X.shape[0]
 
@@ -423,3 +399,6 @@ class TSNE(BaseTSNE):
             neighbors=neighbors_nn,
             skip_num_points=skip_num_points,
         )
+
+    fit.__doc__ = BaseTSNE.fit.__doc__
+    fit_transform.__doc__ = BaseTSNE.fit_transform.__doc__

--- a/daal4py/sklearn/manifold/_t_sne.py
+++ b/daal4py/sklearn/manifold/_t_sne.py
@@ -234,6 +234,10 @@ class TSNE(BaseTSNE):
                 )
             )
 
+        if not sklearn_check_version("1.2"):
+            if self.n_iter < 250:
+                raise ValueError("n_iter should be at least 250")
+
         n_samples = X.shape[0]
 
         neighbors_nn = None

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -60,6 +60,14 @@ deselected_tests:
   - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est2] >=0.23 darwin
   - inspection/tests/test_partial_dependence.py::test_partial_dependence_easy_target[2-est3] >=0.23 darwin
 
+  # Sklearnex RandomForestClassifier RNG is different from scikit-learn and daal4py
+  # resulting in different feature importances for small number of trees (10).
+  # Issue dissappears with bigger number of trees (>=20)
+  - inspection/tests/test_permutation_importance.py::test_permutation_importance_correlated_feature_regression_pandas[0.5-1]
+  - inspection/tests/test_permutation_importance.py::test_permutation_importance_correlated_feature_regression_pandas[0.5-2]
+  - inspection/tests/test_permutation_importance.py::test_permutation_importance_correlated_feature_regression_pandas[1.0-1]
+  - inspection/tests/test_permutation_importance.py::test_permutation_importance_correlated_feature_regression_pandas[1.0-2]
+
   # Random forest classifier selects a different most-important feature
   # Feature importances:
   # scikit-learn-intelex  [0.             0.00553064     0.71323666     0.2812327 ]

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -289,6 +289,9 @@ deselected_tests:
   # The test fails because of changing of 'auto' strategy in PCA to improve performance.
   # 'randomized' PCA expected, but 'full' is given.
   - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
+  # sporadic failure of svd solver tests with approx. 2e-07 rel. difference
+  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-400-full]
+  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-0.5-full]
 
   # Scikit-learn logistic regression predict depends from decision_function while d4p is not.
   # Assertion error in check_estimator (PoorScoreLogisticRegression())

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -294,6 +294,10 @@ deselected_tests:
   # The results are also not stable.
   - decomposition/tests/test_incremental_pca.py::test_whitening
 
+  # The test fails because of changing of 'auto' strategy in PCA to improve performance.
+  # 'randomized' PCA expected, but 'full' is given.
+  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
+
   # Scikit-learn logistic regression predict depends from decision_function while d4p is not.
   # Assertion error in check_estimator (PoorScoreLogisticRegression())
   - utils/tests/test_estimator_checks.py::test_check_estimator >=0.24

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -294,13 +294,6 @@ deselected_tests:
   # The results are also not stable.
   - decomposition/tests/test_incremental_pca.py::test_whitening
 
-  # The test fails because of changing of 'auto' strategy in PCA to improve performance.
-  # 'randomized' PCA expected, but 'full' is given.
-  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[data3-10-randomized]
-  # sporadic failure of svd solver tests with approx. 2e-07 rel. difference
-  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-400-full]
-  - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-0.5-full]
-
   # Scikit-learn logistic regression predict depends from decision_function while d4p is not.
   # Assertion error in check_estimator (PoorScoreLogisticRegression())
   - utils/tests/test_estimator_checks.py::test_check_estimator >=0.24

--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -157,7 +157,7 @@ Dimensionality reduction
    * - `PCA`
      - All parameters are supported except:
 
-       - ``svd_solver`` != `'full'`
+       - ``svd_solver`` not in [`'full'`, `'covariance_eigh'`]
      - Sparse data is not supported
    * - `TSNE`
      - All parameters are supported except:
@@ -340,7 +340,7 @@ Dimensionality reduction
    * - `PCA`
      - All parameters are supported except:
      
-       - ``svd_solver`` != `'full'`
+       - ``svd_solver`` not in [`'full'`, `'covariance_eigh'`]
      - Sparse data is not supported
 
 Nearest Neighbors

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -35,6 +35,9 @@ if daal_check_version((2024, "P", 100)):
     if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
         from sklearn.utils import check_scalar
 
+    if sklearn_check_version("1.2"):
+        from sklearn.utils._param_validation import StrOptions
+
     from sklearn.decomposition import PCA as sklearn_PCA
 
     from onedal.decomposition import PCA as onedal_PCA
@@ -46,6 +49,10 @@ if daal_check_version((2024, "P", 100)):
 
         if sklearn_check_version("1.2"):
             _parameter_constraints: dict = {**sklearn_PCA._parameter_constraints}
+            if not sklearn_check_version("1.5"):
+                _parameter_constraints["svd_solver"] = StrOptions(
+                    {"auto", "full", "covariance_eigh", "arpack", "randomized"}
+                )
 
         if sklearn_check_version("1.1"):
 

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -162,20 +162,20 @@ if daal_check_version((2024, "P", 100)):
 
         def _onedal_transform(self, X, queue=None):
             check_is_fitted(self)
+            if sklearn_check_version("1.0"):
+                self._check_feature_names(X, reset=False)
             X = self._validate_data(
                 X,
                 dtype=[np.float64, np.float32],
                 reset=False,
             )
             self._validate_n_features_in_after_fitting(X)
-            if sklearn_check_version("1.0"):
-                self._check_feature_names(X, reset=False)
 
             return self._onedal_estimator.predict(X, queue=queue)
 
         def fit_transform(self, X, y=None):
             if sklearn_check_version("1.5"):
-                U, S, Vt, X, x_is_centered, xp = self._fit(X)
+                U, S, Vt, X_fit, x_is_centered, xp = self._fit(X)
             else:
                 U, S, Vt = self._fit(X)
             if hasattr(self, "_onedal_estimator"):
@@ -186,14 +186,14 @@ if daal_check_version((2024, "P", 100)):
                 U = U[:, : self.n_components_]
 
                 if self.whiten:
-                    U *= sqrt(X.shape[0] - 1)
+                    U *= sqrt(X_fit.shape[0] - 1)
                 else:
                     U *= S[: self.n_components_]
 
                 return U
             else:
                 # Scikit-learn PCA["covariance_eigh"] was fit
-                return self._transform(X, xp, x_is_centered=x_is_centered)
+                return self._transform(X_fit, xp, x_is_centered=x_is_centered)
 
         def _onedal_supported(self, method_name, X):
             class_name = self.__class__.__name__

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -50,9 +50,11 @@ if daal_check_version((2024, "P", 100)):
         if sklearn_check_version("1.2"):
             _parameter_constraints: dict = {**sklearn_PCA._parameter_constraints}
             if not sklearn_check_version("1.5"):
-                _parameter_constraints["svd_solver"] = StrOptions(
-                    {"auto", "full", "covariance_eigh", "arpack", "randomized"}
-                )
+                _parameter_constraints["svd_solver"] = [
+                    StrOptions(
+                        {"auto", "full", "covariance_eigh", "arpack", "randomized"}
+                    )
+                ]
 
         if sklearn_check_version("1.1"):
 

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -178,6 +178,7 @@ if daal_check_version((2024, "P", 100)):
                 U, S, Vt, X_fit, x_is_centered, xp = self._fit(X)
             else:
                 U, S, Vt = self._fit(X)
+                X_fit = X
             if hasattr(self, "_onedal_estimator"):
                 # oneDAL PCA was fit
                 return self.transform(X)
@@ -266,11 +267,7 @@ if daal_check_version((2024, "P", 100)):
 
             if self._fit_svd_solver == "auto":
                 if sklearn_check_version("1.1"):
-                    if (
-                        sklearn_check_version("1.5")
-                        and shape_tuple[1] <= 1_000
-                        and shape_tuple[0] >= 10 * shape_tuple[1]
-                    ):
+                    if shape_tuple[1] <= 1_000 and shape_tuple[0] >= 10 * shape_tuple[1]:
                         self._fit_svd_solver = "covariance_eigh"
                     elif max(shape_tuple) <= 500 or n_components == "mle":
                         self._fit_svd_solver = "full"

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -129,7 +129,7 @@ if daal_check_version((2024, "P", 100)):
             onedal_params = {
                 "n_components": self.n_components,
                 "is_deterministic": True,
-                "method": "cov",
+                "method": "cov" if self._fit_svd_solver == "covariance_eigh" else "svd",
                 "whiten": self.whiten,
             }
             self._onedal_estimator = onedal_PCA(**onedal_params)
@@ -211,7 +211,7 @@ if daal_check_version((2024, "P", 100)):
                         ),
                         (
                             self._is_solver_compatible_with_onedal(shape_tuple),
-                            f"Only 'full' svd solver is supported.",
+                            "Only 'full' and 'covariance_eigh' solvers are supported.",
                         ),
                         (not issparse(X), "oneDAL PCA does not support sparse data"),
                     ]
@@ -306,7 +306,7 @@ if daal_check_version((2024, "P", 100)):
                         else:
                             self._fit_svd_solver = "full"
 
-            if self._fit_svd_solver == "full":
+            if self._fit_svd_solver in ["full", "covariance_eigh"]:
                 return True
             else:
                 return False

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -226,7 +226,13 @@ if daal_check_version((2024, "P", 100)):
                         ),
                         (
                             self._is_solver_compatible_with_onedal(shape_tuple),
-                            "Only 'full' and 'covariance_eigh' solvers are supported.",
+                            (
+                                "Only 'covariance_eigh' and 'onedal_svd' "
+                                "solvers are supported."
+                                if sklearn_check_version("1.5")
+                                else "Only 'full', 'covariance_eigh' and 'onedal_svd' "
+                                "solvers are supported."
+                            ),
                         ),
                         (not issparse(X), "oneDAL PCA does not support sparse data"),
                     ]
@@ -324,8 +330,12 @@ if daal_check_version((2024, "P", 100)):
             # Use oneDAL in next cases:
             # 1. oneDAL SVD solver is explicitly set
             # 2. solver is set or dispatched to "covariance_eigh"
-            # 3. solver is set to "auto" and dipatched to "full"
+            # 3. solver is set or dispatched to "full" and sklearn version < 1.5
+            # 4. solver is set to "auto" and dispatched to "full"
             if self._fit_svd_solver in ["onedal_svd", "covariance_eigh"]:
+                return True
+            elif not sklearn_check_version("1.5") and self._fit_svd_solver == "full":
+                self._fit_svd_solver = "covariance_eigh"
                 return True
             elif self.svd_solver == "auto" and self._fit_svd_solver == "full":
                 warn(

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -35,12 +35,10 @@ if daal_check_version((2024, "P", 100)):
     if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
         from sklearn.utils import check_scalar
 
-    if sklearn_check_version("1.4"):
-        from sklearn.utils._array_api import get_namespace
-
     from sklearn.decomposition import PCA as sklearn_PCA
 
     from onedal.decomposition import PCA as onedal_PCA
+    from sklearnex.utils import get_namespace
 
     @control_n_jobs(decorated_methods=["fit", "transform", "fit_transform"])
     class PCA(sklearn_PCA):

--- a/sklearnex/decomposition/tests/test_pca.py
+++ b/sklearnex/decomposition/tests/test_pca.py
@@ -41,10 +41,10 @@ def test_sklearnex_import(dataframe, queue):
         [3.6053038, 0.04224385],
     ]
 
-    pca = PCA(n_components=2, svd_solver="full")
+    pca = PCA(n_components=2, svd_solver="covariance_eigh")
     pca.fit(X)
     X_transformed = pca.transform(X)
-    X_fit_transformed = PCA(n_components=2, svd_solver="full").fit_transform(X)
+    X_fit_transformed = PCA(n_components=2, svd_solver="covariance_eigh").fit_transform(X)
 
     if daal_check_version((2024, "P", 100)):
         assert "sklearnex" in pca.__module__

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -777,15 +777,16 @@ class ForestClassifier(sklearn_ForestClassifier, BaseForest):
         return patching_status
 
     def _onedal_predict(self, X, queue=None):
+        check_is_fitted(self, "_onedal_estimator")
+
+        if sklearn_check_version("1.0"):
+            self._check_feature_names(X, reset=False)
+
         X = check_array(
             X,
             dtype=[np.float64, np.float32],
             force_all_finite=False,
         )  # Warning, order of dtype matters
-        check_is_fitted(self, "_onedal_estimator")
-
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
 
         res = self._onedal_estimator.predict(X, queue=queue)
         return np.take(self.classes_, res.ravel().astype(np.int64, casting="unsafe"))

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -24,6 +24,7 @@ from sklearn.datasets import make_classification
 
 from sklearnex.dispatcher import get_patch_map
 from sklearnex.svm import SVC, NuSVC
+from sklearnex.decomposition import PCA
 
 ESTIMATORS = set(
     filter(
@@ -73,6 +74,9 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
     # by default, [Nu]SVC.predict_proba is restricted by @available_if decorator
     if estimator_class in [SVC, NuSVC]:
         estimator_kwargs["probability"] = True
+    # by default, sklearn 1.5 PCA selects non-patched method
+    if estimator_class == PCA:
+        estimator_kwargs["svd_solver"] = "full"
     estimator_instance = estimator_class(**estimator_kwargs)
     # check `n_jobs` parameter doc entry
     check_estimator_doc(estimator_class)

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -74,9 +74,9 @@ def test_n_jobs_support(caplog, estimator_class, n_jobs):
     # by default, [Nu]SVC.predict_proba is restricted by @available_if decorator
     if estimator_class in [SVC, NuSVC]:
         estimator_kwargs["probability"] = True
-    # by default, sklearn 1.5 PCA selects non-patched method
+    # explicitly request oneDAL's PCA-Covariance algorithm
     if estimator_class == PCA:
-        estimator_kwargs["svd_solver"] = "full"
+        estimator_kwargs["svd_solver"] = "covariance_eigh"
     estimator_instance = estimator_class(**estimator_kwargs)
     # check `n_jobs` parameter doc entry
     check_estimator_doc(estimator_class)

--- a/sklearnex/tests/test_n_jobs_support.py
+++ b/sklearnex/tests/test_n_jobs_support.py
@@ -22,9 +22,9 @@ import pytest
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification
 
+from sklearnex.decomposition import PCA
 from sklearnex.dispatcher import get_patch_map
 from sklearnex.svm import SVC, NuSVC
-from sklearnex.decomposition import PCA
 
 ESTIMATORS = set(
     filter(

--- a/sklearnex/tests/test_run_to_run_stability_tests.py
+++ b/sklearnex/tests/test_run_to_run_stability_tests.py
@@ -294,7 +294,7 @@ MODELS_INFO = [
         "dataset": "regression",
     },
     {
-        "model": PCA(n_components=0.5, svd_solver="full", random_state=0),
+        "model": PCA(n_components=0.5, svd_solver="covariance_eigh", random_state=0),
         "methods": ["transform", "get_covariance", "get_precision", "score_samples"],
         "dataset": "classifier",
     },


### PR DESCRIPTION
Changes related to sklearn 1.5:
 - Apply renaming of `n_iter` parameter to `max_iter` in TSNE
 - Apply array API support in PCA internal functions
 - Apply `covariance_eigh` solver support in PCA
 - Change PCA "auto" solver choice to complete compliance with sklearn