### PR TITLE
[enhancement] add assume_centered capability to EmpiricalCovariance

### DIFF
--- a/onedal/covariance/covariance.cpp
+++ b/onedal/covariance/covariance.cpp
@@ -52,6 +52,11 @@ struct params2desc {
             desc.set_bias(params["bias"].cast<bool>());
         }
 #endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20240001
+#if defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20240400
+        if (params.contains("assumeCentered")) {
+            desc.set_assume_centered(params["assumeCentered"].cast<bool>());
+        }
+#endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION>=20240400
         return desc;
     }
 };

--- a/onedal/covariance/covariance.py
+++ b/onedal/covariance/covariance.py
@@ -26,9 +26,10 @@ from ..datatypes import _convert_to_supported, from_table, to_table
 
 
 class BaseEmpiricalCovariance(BaseEstimator, metaclass=ABCMeta):
-    def __init__(self, method="dense", bias=False):
+    def __init__(self, method="dense", bias=False, assume_centered=False):
         self.method = method
         self.bias = bias
+        self.assume_centered = assume_centered
 
     def _get_onedal_params(self, dtype=np.float32):
         params = {
@@ -37,6 +38,8 @@ class BaseEmpiricalCovariance(BaseEstimator, metaclass=ABCMeta):
         }
         if daal_check_version((2024, "P", 1)):
             params["bias"] = self.bias
+        if daal_check_version((2024, "P", 400)):
+            params["assumeCentered"] = self.assume_centered
 
         return params
 

--- a/onedal/covariance/covariance.py
+++ b/onedal/covariance/covariance.py
@@ -58,6 +58,12 @@ class EmpiricalCovariance(BaseEmpiricalCovariance):
         If True biased estimation of covariance is computed which equals to
         the unbiased one multiplied by (n_samples - 1) / n_samples.
 
+    assume_centered : bool, default=False
+        If True, data are not centered before computation.
+        Useful when working with data whose mean is almost, but not exactly
+        zero.
+        If False (default), data are centered before computation.
+
     Attributes
     ----------
     location_ : ndarray of shape (n_features,)

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -22,7 +22,7 @@ from sklearn.covariance import EmpiricalCovariance as sklearn_EmpiricalCovarianc
 from sklearn.utils import check_array
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
-from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from onedal.common.hyperparameters import get_hyperparameters
 from onedal.covariance import EmpiricalCovariance as onedal_EmpiricalCovariance
 from sklearnex import config_context
@@ -44,7 +44,7 @@ class EmpiricalCovariance(sklearn_EmpiricalCovariance):
 
     def _save_attributes(self):
         assert hasattr(self, "_onedal_estimator")
-        if not daal_check_versions((2024, "P", 400)) and self.assume_centered:
+        if not daal_check_version((2024, "P", 400)) and self.assume_centered:
             location = self._onedal_estimator.location_
             self._onedal_estimator.covariance_ += np.dot(location.T, location)
             self._onedal_estimator.location_ = np.zeros_like(location)

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -45,9 +45,9 @@ class EmpiricalCovariance(sklearn_EmpiricalCovariance):
     def _save_attributes(self):
         assert hasattr(self, "_onedal_estimator")
         if not daal_check_version((2024, "P", 400)) and self.assume_centered:
-            location = self._onedal_estimator.location_
+            location = self._onedal_estimator.location_[None, :]
             self._onedal_estimator.covariance_ += np.dot(location.T, location)
-            self._onedal_estimator.location_ = np.zeros_like(location)
+            self._onedal_estimator.location_ = np.zeros_like(np.squeeze(location))
         self._set_covariance(self._onedal_estimator.covariance_)
         self.location_ = self._onedal_estimator.location_
 

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -78,10 +78,6 @@ class EmpiricalCovariance(sklearn_EmpiricalCovariance):
             (X,) = data
             patching_status.and_conditions(
                 [
-                    (
-                        self.assume_centered == False,
-                        "assume_centered parameter is not supported on oneDAL side",
-                    ),
                     (not sp.issparse(X), "X is sparse. Sparse input is not supported."),
                 ]
             )

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -44,6 +44,10 @@ class EmpiricalCovariance(sklearn_EmpiricalCovariance):
 
     def _save_attributes(self):
         assert hasattr(self, "_onedal_estimator")
+        if not daal_check_versions((2024, "P", 400)) and self.assume_centered:
+            location = self._onedal_estimator.location_
+            self._onedal_estimator.covariance_ += np.dot(location.T, location)
+            self._onedal_estimator.location_ = np.zeros_like(location)
         self._set_covariance(self._onedal_estimator.covariance_)
         self.location_ = self._onedal_estimator.location_
 
@@ -58,6 +62,7 @@ class EmpiricalCovariance(sklearn_EmpiricalCovariance):
         onedal_params = {
             "method": "dense",
             "bias": True,
+            "assume_centered": self.assume_centered,
         }
 
         self._onedal_estimator = self._onedal_covariance(**onedal_params)


### PR DESCRIPTION
# Description
A recent PR in onedal ( oneapi-src/oneDAL#2658 ) enabled the assume_centered capability. This is needed to match the abilities of sklearn's EmpiricalCovariance.  It assumes that the data has a 0 mean adjusted, and can therefore calculate the covariance matrix via X.T*X. 

Changes proposed in this pull request:
- Add proper guards and access oneDAL assumed_centered calculations
- Remove check from onedal_gpu_supported and onedal_cpu_supported (since it is now supported)
- Add tests to sklearnex/preview/covariance/tests/test_covariance.py

 
