### PR TITLE
[testing, enhancement] add IncrementalBasicStatistics to SPECIAL_INSTANCES

### DIFF
--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -119,6 +119,12 @@ def gen_models_info(algorithms):
                 methods |= candidates & set(method)
 
         output += [[i, j] for j in methods]
+
+    # In the case that no methods are available, set method to None.
+    # This will allow estimators without mixins to still test the fit
+    # method in various tests.
+    if not output:
+        output = [[i, None]]
     return output
 
 

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -106,10 +106,13 @@ SPECIAL_INSTANCES = {
 def gen_models_info(algorithms):
     output = []
     for i in algorithms:
-        # split handles SPECIAL_INSTANCES or custom inputs
-        # custom sklearn inputs must be a dict of estimators
-        # with keys set by the __str__ method
-        est = PATCHED_MODELS[i.split("(")[0]]
+
+        if i in PATCHED_MODELS:
+            est = PATCHED_MODELS[i]
+        elif i in SPECIAL_INSTANCES:
+            est = SPECIAL_INSTANCES[i].__class__
+        else:
+            raise KeyError(f"Unrecognized sklearnex estimator: {i}")
 
         methods = set()
         candidates = set(

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -30,6 +30,7 @@ from sklearn.neighbors._base import KNeighborsMixin
 
 from onedal.tests.utils._dataframes_support import _convert_to_dataframe
 from sklearnex import get_patch_map, patch_sklearn, sklearn_is_patched, unpatch_sklearn
+from sklearnex.basic_statistics import IncrementalBasicStatistics
 from sklearnex.linear_model import LogisticRegression
 from sklearnex.neighbors import (
     KNeighborsClassifier,
@@ -97,6 +98,7 @@ SPECIAL_INSTANCES = {
         KNeighborsRegressor(algorithm="brute"),
         NearestNeighbors(algorithm="brute"),
         LogisticRegression(solver="newton-cg"),
+        IncrementalBasicStatistics(),
     ]
 }
 

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -123,13 +123,11 @@ def gen_models_info(algorithms):
             if issubclass(est, mixin):
                 methods |= candidates & set(method)
 
-        output += [[i, j] for j in methods]
+        output += [[i, j] for j in methods] if methods else [[i, None]]
 
     # In the case that no methods are available, set method to None.
     # This will allow estimators without mixins to still test the fit
     # method in various tests.
-    if not output:
-        output = [[i, None]]
     return output
 
 

--- a/sklearnex/tests/test_patching.py
+++ b/sklearnex/tests/test_patching.py
@@ -26,14 +26,6 @@ from inspect import signature
 import numpy as np
 import numpy.random as nprnd
 import pytest
-from sklearn.base import (
-    BaseEstimator,
-    ClassifierMixin,
-    ClusterMixin,
-    OutlierMixin,
-    RegressorMixin,
-    TransformerMixin,
-)
 
 from daal4py.sklearn._utils import sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
@@ -149,16 +141,17 @@ def test_standard_estimator_patching(caplog, dataframe, queue, dtype, estimator,
             and dtype in [np.uint32, np.uint64]
         ):
             pytest.skip("Windows segmentation fault for Ridge.predict for unsigned ints")
-        elif not hasattr(est, method):
+        elif method and not hasattr(est, method):
             pytest.skip(f"sklearn available_if prevents testing {estimator}.{method}")
 
         X, y = gen_dataset(est, queue=queue, target_df=dataframe, dtype=dtype)
         est.fit(X, y)
 
-        if method != "score":
-            getattr(est, method)(X)
-        else:
-            est.score(X, y)
+        if method:
+            if method != "score":
+                getattr(est, method)(X)
+            else:
+                est.score(X, y)
     assert all(
         [
             "running accelerated version" in i.message
@@ -186,12 +179,15 @@ def test_special_estimator_patching(caplog, dataframe, queue, dtype, estimator, 
         X, y = gen_dataset(est, queue=queue, target_df=dataframe, dtype=dtype)
         est.fit(X, y)
 
-        if not hasattr(est, method):
+        if method and not hasattr(est, method):
             pytest.skip(f"sklearn available_if prevents testing {estimator}.{method}")
-        if method != "score":
-            getattr(est, method)(X)
-        else:
-            est.score(X, y)
+        
+        if method:
+            if method != "score":
+                getattr(est, method)(X)
+            else:
+                est.score(X, y)
+
     assert all(
         [
             "running accelerated version" in i.message
@@ -336,18 +332,6 @@ def test_if_estimator_inherits_sklearn(estimator):
         ), f"{estimator} does not inherit from the patched sklearn estimator"
     else:
         assert issubclass(est, BaseEstimator)
-        assert any(
-            [
-                issubclass(est, i)
-                for i in [
-                    ClassifierMixin,
-                    ClusterMixin,
-                    OutlierMixin,
-                    RegressorMixin,
-                    TransformerMixin,
-                ]
-            ]
-        ), f"{estimator} does not inherit a sklearn Mixin"
 
 
 @pytest.mark.parametrize("estimator", UNPATCHED_MODELS.keys())

--- a/sklearnex/tests/test_patching.py
+++ b/sklearnex/tests/test_patching.py
@@ -181,7 +181,7 @@ def test_special_estimator_patching(caplog, dataframe, queue, dtype, estimator, 
 
         if method and not hasattr(est, method):
             pytest.skip(f"sklearn available_if prevents testing {estimator}.{method}")
-        
+
         if method:
             if method != "score":
                 getattr(est, method)(X)


### PR DESCRIPTION
# Description
Since basic_statistics module estimators cannot be added to the patch map in the current setup, they are missing useful tests to verify compliance with sklearnex design rules and operational testing. This adds them to a secondary list in sklearnex/tests/_utils.py SPECIAL_INSTANCES which is meant for adding test coverage for forms of estimators which are not covered in standardized testing but are important for oneDAL. This includes changes in #1795 .

Changes proposed in this pull request:
- Add IncrementalBasicStatistics to SPECIAL_INSTANCES

Tasks
- [x] Add IncrementalBasicStatistics
- [ ] Correct CI failures
- [ ] Correct issues in IncrementalBasicStatistics
- [ ] Pass public CI
- [ ] Pass private CI

 
