### PR TITLE
[bug] fix sample_weight check for IncrementalBasicStatistics

### DIFF
--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -251,7 +251,7 @@ class IncrementalBasicStatistics(BaseEstimator):
                 "sklearn": None,
             },
             X,
-            weights,
+            sample_weights,
         )
         return self
 

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -232,7 +232,10 @@ class IncrementalBasicStatistics(BaseEstimator):
             Data for compute, where `n_samples` is the number of samples and
             `n_features` is the number of features.
 
-        sample_weight : array-like of shape (n_samples,)
+        y : Ignored
+            Not used, present for API consistency by convention.
+
+        sample_weight : array-like of shape (n_samples,), default=None
             Weights for compute weighted statistics, where `n_samples` is the number of samples.
 
         Returns
@@ -261,7 +264,10 @@ class IncrementalBasicStatistics(BaseEstimator):
             Data for compute, where `n_samples` is the number of samples and
             `n_features` is the number of features.
 
-        sample_weight : array-like of shape (n_samples,)
+        y : Ignored
+            Not used, present for API consistency by convention.
+
+        sample_weight : array-like of shape (n_samples,), default=None
             Weights for compute weighted statistics, where `n_samples` is the number of samples.
 
         Returns

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -171,7 +171,7 @@ class IncrementalBasicStatistics(BaseEstimator):
             self._onedal_estimator = self._onedal_incremental_basic_statistics(
                 **onedal_params
             )
-        self._onedal_estimator.partial_fit(X, weights, queue)
+        self._onedal_estimator.partial_fit(X, sample_weights, queue)
         self._need_to_finalize = True
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):
@@ -195,7 +195,7 @@ class IncrementalBasicStatistics(BaseEstimator):
 
         for batch in gen_batches(X.shape[0], self.batch_size_):
             X_batch = X[batch]
-            weights_batch = weights[batch] if weights is not None else None
+            weights_batch = sample_weight[batch] if sample_weight is not None else None
             self._onedal_partial_fit(X_batch, weights_batch, queue=queue)
 
         if sklearn_check_version("1.2"):
@@ -232,7 +232,7 @@ class IncrementalBasicStatistics(BaseEstimator):
             Data for compute, where `n_samples` is the number of samples and
             `n_features` is the number of features.
 
-        weights : array-like of shape (n_samples,)
+        sample_weight : array-like of shape (n_samples,)
             Weights for compute weighted statistics, where `n_samples` is the number of samples.
 
         Returns
@@ -261,7 +261,7 @@ class IncrementalBasicStatistics(BaseEstimator):
             Data for compute, where `n_samples` is the number of samples and
             `n_features` is the number of features.
 
-        weights : array-like of shape (n_samples,)
+        sample_weight : array-like of shape (n_samples,)
             Weights for compute weighted statistics, where `n_samples` is the number of samples.
 
         Returns

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -17,7 +17,7 @@
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_array, gen_batches
-from sklearn.utils.validation import _check_sample_weights
+from sklearn.utils.validation import _check_sample_weight
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -171,7 +171,7 @@ class IncrementalBasicStatistics(BaseEstimator):
             self._onedal_estimator = self._onedal_incremental_basic_statistics(
                 **onedal_params
             )
-        self._onedal_estimator.partial_fit(X, sample_weights, queue)
+        self._onedal_estimator.partial_fit(X, sample_weight, queue)
         self._need_to_finalize = True
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -251,7 +251,7 @@ class IncrementalBasicStatistics(BaseEstimator):
                 "sklearn": None,
             },
             X,
-            sample_weights,
+            sample_weight,
         )
         return self
 

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -182,7 +182,7 @@ class IncrementalBasicStatistics(BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
-        
+
         n_samples, n_features = X.shape
         if self.batch_size is None:
             self.batch_size_ = 5 * n_features

--- a/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -272,7 +272,7 @@ def test_fit_single_option_on_random_data(
     X = X.astype(dtype=dtype)
     X_df = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     if weighted:
-        weights = gen.uniform(low=0.0, high=1.0, size=row_count)
+        weights = gen.uniform(low=-0.5, high=1.0, size=row_count)
         weights = weights.astype(dtype=dtype)
         weights_df = _convert_to_dataframe(weights, sycl_queue=queue, target_df=dataframe)
     incbs = IncrementalBasicStatistics(
@@ -311,7 +311,7 @@ def test_partial_fit_multiple_options_on_random_data(
     X = X.astype(dtype=dtype)
     X_df = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     if weighted:
-        weights = gen.uniform(low=0.0, high=1.0, size=row_count)
+        weights = gen.uniform(low=-0.5, high=1.0, size=row_count)
         weights = weights.astype(dtype=dtype)
         weights_df = _convert_to_dataframe(weights, sycl_queue=queue, target_df=dataframe)
     incbs = IncrementalBasicStatistics(

--- a/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -52,7 +52,7 @@ def test_partial_fit_multiple_options_on_gold_data(dataframe, queue, weighted, d
             weights_split_df = _convert_to_dataframe(
                 weights_split[i], sycl_queue=queue, target_df=dataframe
             )
-            result = incbs.partial_fit(X_split_df, weights_split_df)
+            result = incbs.partial_fit(X_split_df, sample_weight=weights_split_df)
         else:
             result = incbs.partial_fit(X_split_df)
 
@@ -103,7 +103,7 @@ def test_partial_fit_single_option_on_random_data(
             weights_split_df = _convert_to_dataframe(
                 weights_split[i], sycl_queue=queue, target_df=dataframe
             )
-            result = incbs.partial_fit(X_split_df, weights_split_df)
+            result = incbs.partial_fit(X_split_df, sample_weight=weights_split_df)
         else:
             result = incbs.partial_fit(X_split_df)
 
@@ -146,7 +146,7 @@ def test_partial_fit_multiple_options_on_random_data(
             weights_split_df = _convert_to_dataframe(
                 weights_split[i], sycl_queue=queue, target_df=dataframe
             )
-            result = incbs.partial_fit(X_split_df, weights_split_df)
+            result = incbs.partial_fit(X_split_df, sample_weight=weights_split_df)
         else:
             result = incbs.partial_fit(X_split_df)
 
@@ -199,7 +199,7 @@ def test_partial_fit_all_option_on_random_data(
             weights_split_df = _convert_to_dataframe(
                 weights_split[i], sycl_queue=queue, target_df=dataframe
             )
-            result = incbs.partial_fit(X_split_df, weights_split_df)
+            result = incbs.partial_fit(X_split_df, sample_weight=weights_split_df)
         else:
             result = incbs.partial_fit(X_split_df)
 
@@ -233,7 +233,7 @@ def test_fit_multiple_options_on_gold_data(dataframe, queue, weighted, dtype):
     incbs = IncrementalBasicStatistics(batch_size=1)
 
     if weighted:
-        result = incbs.fit(X_df, weights_df)
+        result = incbs.fit(X_df, sample_weight=weights_df)
     else:
         result = incbs.fit(X_df)
 
@@ -272,7 +272,7 @@ def test_fit_single_option_on_random_data(
     X = X.astype(dtype=dtype)
     X_df = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     if weighted:
-        weights = gen.uniform(low=-0.5, high=+1.0, size=row_count)
+        weights = gen.uniform(low=0.0, high=1.0, size=row_count)
         weights = weights.astype(dtype=dtype)
         weights_df = _convert_to_dataframe(weights, sycl_queue=queue, target_df=dataframe)
     incbs = IncrementalBasicStatistics(
@@ -280,7 +280,7 @@ def test_fit_single_option_on_random_data(
     )
 
     if weighted:
-        result = incbs.fit(X_df, weights_df)
+        result = incbs.fit(X_df, sample_weight=weights_df)
     else:
         result = incbs.fit(X_df)
 
@@ -311,7 +311,7 @@ def test_partial_fit_multiple_options_on_random_data(
     X = X.astype(dtype=dtype)
     X_df = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     if weighted:
-        weights = gen.uniform(low=-0.5, high=+1.0, size=row_count)
+        weights = gen.uniform(low=0.0, high=1.0, size=row_count)
         weights = weights.astype(dtype=dtype)
         weights_df = _convert_to_dataframe(weights, sycl_queue=queue, target_df=dataframe)
     incbs = IncrementalBasicStatistics(
@@ -319,7 +319,7 @@ def test_partial_fit_multiple_options_on_random_data(
     )
 
     if weighted:
-        result = incbs.fit(X_df, weights_df)
+        result = incbs.fit(X_df, sample_weight=weights_df)
     else:
         result = incbs.fit(X_df)
 
@@ -366,7 +366,7 @@ def test_fit_all_option_on_random_data(
     incbs = IncrementalBasicStatistics(result_options="all", batch_size=batch_size)
 
     if weighted:
-        result = incbs.fit(X_df, weights_df)
+        result = incbs.fit(X_df, sample_weight=weights_df)
     else:
         result = incbs.fit(X_df)
 


### PR DESCRIPTION
# Description
Uncovered in #1763, IncrementalBasicStatistics assumes a numpy, dpnp or dpctl array. Passing other elements (i.e. pandas dataframes, pandas series etc) will not work properly, also doesn't seem like there are element size/shape checks vs X either. This will also add finite checks as well.

Changes proposed in this pull request:
- Add _check_sample_weight from sklearn.utils.validation (used commonly in sklearn)
- switch weights keyword to sample_weights to match sklearn convention
- add y=None to fit to follow sklearn convention
- remove call to self.copy_X which doesn't exist in any instance.
 
