### PR TITLE
[bug, testing] remove estimator state indeterminacy from SPECIAL INSTANCES

### DIFF
--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -17,6 +17,7 @@
 from inspect import isclass
 
 import numpy as np
+from sklearn import clone
 from sklearn.base import (
     BaseEstimator,
     ClassifierMixin,
@@ -25,7 +26,6 @@ from sklearn.base import (
     RegressorMixin,
     TransformerMixin,
 )
-from sklearn import clone
 from sklearn.datasets import load_diabetes, load_iris
 from sklearn.neighbors._base import KNeighborsMixin
 

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -88,13 +88,13 @@ mixin_map = [
 ]
 
 
-class sklearn_clone_dict(dict):
+class _sklearn_clone_dict(dict):
 
     def __getitem__(self, key):
         return clone(super().__getitem__(key))
 
 
-SPECIAL_INSTANCES = sklearn_clone_dict(
+SPECIAL_INSTANCES = _sklearn_clone_dict(
     {
         str(i): i
         for i in [

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -87,18 +87,26 @@ mixin_map = [
 ]
 
 
-SPECIAL_INSTANCES = {
-    str(i): i
-    for i in [
-        LocalOutlierFactor(novelty=True),
-        SVC(probability=True),
-        NuSVC(probability=True),
-        KNeighborsClassifier(algorithm="brute"),
-        KNeighborsRegressor(algorithm="brute"),
-        NearestNeighbors(algorithm="brute"),
-        LogisticRegression(solver="newton-cg"),
-    ]
-}
+class sklearn_clone_dict(dict):
+
+    def __getitem__(self, key):
+        return super().__getitem__(key).clone()
+
+
+SPECIAL_INSTANCES = sklearn_clone_dict(
+    {
+        str(i): i
+        for i in [
+            LocalOutlierFactor(novelty=True),
+            SVC(probability=True),
+            NuSVC(probability=True),
+            KNeighborsClassifier(algorithm="brute"),
+            KNeighborsRegressor(algorithm="brute"),
+            NearestNeighbors(algorithm="brute"),
+            LogisticRegression(solver="newton-cg"),
+        ]
+    }
+)
 
 
 def gen_models_info(algorithms):

--- a/sklearnex/tests/_utils.py
+++ b/sklearnex/tests/_utils.py
@@ -25,6 +25,7 @@ from sklearn.base import (
     RegressorMixin,
     TransformerMixin,
 )
+from sklearn import clone
 from sklearn.datasets import load_diabetes, load_iris
 from sklearn.neighbors._base import KNeighborsMixin
 
@@ -90,7 +91,7 @@ mixin_map = [
 class sklearn_clone_dict(dict):
 
     def __getitem__(self, key):
-        return super().__getitem__(key).clone()
+        return clone(super().__getitem__(key))
 
 
 SPECIAL_INSTANCES = sklearn_clone_dict(


### PR DESCRIPTION
# Description
SPECIAL_INSTANCES only works with a single instance of sklearnex estimators. This dict is needed for specifically testing oneDAL supported sklearnex features.  By using a single instance, tests may impact one another. By using clone, a new estimator is created using the same parameters without state. Clone depends on the ```__init__``` parameters of the estimator only.

Changes proposed in this pull request:
- create a special dictionary object which will clone the special estimator instances for use
- use sklearn clone in ```__getitem__```

 
