### PR TITLE
MAINT: drop predict from PCA spmd

### DIFF
--- a/onedal/spmd/decomposition/pca.py
+++ b/onedal/spmd/decomposition/pca.py
@@ -24,7 +24,3 @@ class PCA(BaseEstimatorSPMD, PCABatch):
     @support_usm_ndarray()
     def fit(self, X, y=None, queue=None):
         return super().fit(X, queue=queue)
-
-    @support_usm_ndarray()
-    def predict(self, X, queue=None):
-        return super().predict(X, queue=queue)


### PR DESCRIPTION
# Description
We do not support this in OneDAL and error occurs when user tries to call predict() from spmd object

 
