### PR TITLE
[enhancement] clarify math in LinearRegression

### DIFF
--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -157,7 +157,7 @@ class LinearRegression(sklearn_LinearRegression):
         n_features = _num_features(X, fallback_1d=True)
 
         # Check if equations are well defined
-        is_good_for_onedal = n_samples >= (n_features + int(self.fit_intercept))
+        is_underdetermined = n_samples < (n_features + int(self.fit_intercept))
 
         dal_ready = patching_status.and_conditions(
             [
@@ -172,7 +172,7 @@ class LinearRegression(sklearn_LinearRegression):
                     "Forced positive coefficients are not supported.",
                 ),
                 (
-                    is_good_for_onedal,
+                    not is_underdetermined,
                     "The shape of X (fitting) does not satisfy oneDAL requirements:"
                     "Number of features + 1 >= number of samples.",
                 ),


### PR DESCRIPTION
# Description
Previous variable name is_good_for_onedal is based off of the naming scheme in daal4py.  This naming covers-up an important characteristic of the input data that should be known to the developer and the user, namely that the input data should not be underdetermined (https://en.wikipedia.org/wiki/Underdetermined_system).  This PR changes that to simplify understanding going forward.

Changes proposed in this pull request:
- is_good_for_onedal -> is_underdetermined

 
