### PR TITLE
CI deps update: dpctl 0.16 and dpnp 0.14

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -46,7 +46,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.16.0 dpnp=0.14.0; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.16.1 dpnp=0.14.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -46,7 +46,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.15.0 dpnp=0.13.0; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.16.0 dpnp=0.14.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -46,7 +46,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.16.1 dpnp=0.14.0; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10') ]; then conda install -q -y -c intel dpctl=0.16.0 dpnp=0.14.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -135,9 +135,11 @@ def _daal4py_fit_enet(self, X, y_, check_input):
     if (
         isinstance(self.precompute, np.ndarray)
         and self.fit_intercept
-        and not np.allclose(X_offset, np.zeros(X.shape[1]))
-        or _normalize
-        and not np.allclose(X_scale, np.ones(X.shape[1]))
+        and (
+            not np.allclose(X_offset, np.zeros(X.shape[1]))
+            or _normalize
+            and not np.allclose(X_scale, np.ones(X.shape[1]))
+        )
     ):
         if sklearn_check_version("1.4"):
             warnings.warn(
@@ -307,9 +309,11 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
     if (
         isinstance(self.precompute, np.ndarray)
         and self.fit_intercept
-        and not np.allclose(X_offset, np.zeros(X.shape[1]))
-        or _normalize
-        and not np.allclose(X_scale, np.ones(X.shape[1]))
+        and (
+            not np.allclose(X_offset, np.zeros(X.shape[1]))
+            or _normalize
+            and not np.allclose(X_scale, np.ones(X.shape[1]))
+        )
     ):
         warnings.warn(
             "Gram matrix was provided but X was centered"

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -244,6 +244,14 @@ deselected_tests:
   - model_selection/tests/test_search.py::test_grid_search_pipeline_steps
   - linear_model/tests/test_base.py::test_linear_regression_pd_sparse_dataframe_warning
 
+  # L1 Linear models with sklearn 1.1 + numpy > 1.25 - extra warnings from numpy lead to test fail
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[True-1-LassoCV] >=1.1,<1.2
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[True-1-ElasticNetCV] >=1.1,<1.2
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[False-1-LassoCV] >=1.1,<1.2
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[False-1-ElasticNetCV] >=1.1,<1.2
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[deprecated-0-LassoCV] >=1.1,<1.2
+  - linear_model/tests/test_coordinate_descent.py::test_assure_warning_when_normalize[deprecated-0-ElasticNetCV] >=1.1,<1.2
+
   # Different results scikit-learn-intelex and scikit-learn linear regression with weights. Need to investigate.
   - inspection/tests/test_permutation_importance.py::test_permutation_importance_sample_weight >=0.24
 


### PR DESCRIPTION
Changes:
- Update dpctl to 0.16 and dpnp to 0.14 versions
- Solve additional sklearn test failures due to extra warnings in newer numpy version:
  - Deselect tests related to them
  - Fix for warning condition in L1 linear models
