### PR TITLE
Update python to 3.11 in Docs CI job

### DIFF
--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -50,7 +50,7 @@ jobs:
     displayName: 'System info'
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.9'
+      versionSpec: '3.11'
       addToPath: true
   - script: sudo apt-get update && sudo apt-get install -y clang-format
     displayName: 'apt-get'


### PR DESCRIPTION
### Description 
Update Python version to 3.11 in Docs CI job for newer dependencies versions support.

Fixes Docs job failure in https://github.com/intel/scikit-learn-intelex/pull/1820

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

