### PR TITLE
Fixed linting in doc/daal4py/conf.py

### DIFF
--- a/doc/daal4py/conf.py
+++ b/doc/daal4py/conf.py
@@ -78,7 +78,7 @@ master_doc = "contents"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store","note.rst"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "note.rst"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -112,7 +112,6 @@ html_css_files = ["style.css"]
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
-
 
 
 # -- Options for HTMLHelp output ---------------------------------------------
@@ -177,5 +176,3 @@ texinfo_documents = [
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-


### PR DESCRIPTION
### Description 
Fixed linting in doc/daal4py/conf.py. The file had been changed in https://github.com/intel/scikit-learn-intelex/pull/1823 and it was not formatted properly because linting job was not started for docs change. Currently it forces public CI failure in any PR linting job is started. This PR is proposed to fix it.

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

