### PR TITLE
[enhancement] remove sklearn_check_version dependence from `onedal/ensemble`

### DIFF
--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -24,7 +24,7 @@ import numpy as np
 from sklearn.ensemble import BaseEnsemble
 from sklearn.utils import check_random_state
 
-from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
+from daal4py.sklearn._utils import daal_check_version
 from onedal import _backend
 
 from ..common._base import BaseEstimator
@@ -97,73 +97,17 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
         self.variable_importance_mode = variable_importance_mode
         self.algorithm = algorithm
 
-    def _to_absolute_max_features(
-        self, max_features, n_features, is_classification=False
-    ):
-        if max_features is None:
-            return n_features
-        if isinstance(max_features, str):
-            if max_features == "auto":
-                if not sklearn_check_version("1.3"):
-                    if sklearn_check_version("1.1"):
-                        warnings.warn(
-                            "`max_features='auto'` has been deprecated in 1.1 "
-                            "and will be removed in 1.3. To keep the past behaviour, "
-                            "explicitly set `max_features=1.0` or remove this "
-                            "parameter as it is also the default value for "
-                            "RandomForestRegressors and ExtraTreesRegressors.",
-                            FutureWarning,
-                        )
-                    return (
-                        max(1, int(np.sqrt(n_features)))
-                        if is_classification
-                        else n_features
-                    )
-            if max_features == "sqrt":
-                return max(1, int(np.sqrt(n_features)))
-            if max_features == "log2":
-                return max(1, int(np.log2(n_features)))
-            allowed_string_values = (
-                '"sqrt" or "log2"'
-                if sklearn_check_version("1.3")
-                else '"auto", "sqrt" or "log2"'
-            )
-            raise ValueError(
-                "Invalid value for max_features. Allowed string "
-                f"values are {allowed_string_values}."
-            )
-        if isinstance(max_features, (numbers.Integral, np.integer)):
-            return max_features
-        if max_features > 0.0:
-            return max(1, int(max_features * n_features))
-        return 0
-
     def _get_observations_per_tree_fraction(self, n_samples, max_samples):
         if max_samples is None:
             return 1.0
 
         if isinstance(max_samples, numbers.Integral):
-            if not sklearn_check_version("1.2"):
-                if not (1 <= max_samples <= n_samples):
-                    msg = "`max_samples` must be in range 1 to {} but got value {}"
-                    raise ValueError(msg.format(n_samples, max_samples))
-            else:
-                if max_samples > n_samples:
-                    msg = "`max_samples` must be <= n_samples={} but got value {}"
-                    raise ValueError(msg.format(n_samples, max_samples))
+            if not (1 <= max_samples <= n_samples):
+                msg = "`max_samples` must be in range 1 to {} but got value {}"
+                raise ValueError(msg.format(n_samples, max_samples))
             return max(float(max_samples / n_samples), 1 / n_samples)
 
         if isinstance(max_samples, numbers.Real):
-            if sklearn_check_version("1.2"):
-                pass
-            elif sklearn_check_version("1.0"):
-                if not (0 < float(max_samples) <= 1):
-                    msg = "`max_samples` must be in range (0.0, 1.0] but got value {}"
-                    raise ValueError(msg.format(max_samples))
-            else:
-                if not (0 < float(max_samples) < 1):
-                    msg = "`max_samples` must be in range (0, 1) but got value {}"
-                    raise ValueError(msg.format(max_samples))
             return max(float(max_samples), 1 / n_samples)
 
         msg = "`max_samples` should be int or float, but got type '{}'"
@@ -171,9 +115,6 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
 
     def _get_onedal_params(self, data):
         n_samples, n_features = data.shape
-        features_per_node = self._to_absolute_max_features(
-            self.max_features, n_features, self.is_classification
-        )
 
         self.observations_per_tree_fraction = self._get_observations_per_tree_fraction(
             n_samples=n_samples, max_samples=self.max_samples
@@ -218,7 +159,11 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
             "min_weight_fraction_in_leaf_node": self.min_weight_fraction_leaf,
             "min_impurity_decrease_in_split_node": self.min_impurity_decrease,
             "tree_count": int(self.n_estimators),
-            "features_per_node": features_per_node,
+            "features_per_node": (
+                self.max_features
+                if not isinstance(self.max_features, str)
+                else max(1, int(getattr(np, self.max_features)(n_features)))
+            ),
             "max_tree_depth": int(0 if self.max_depth is None else self.max_depth),
             "min_observations_in_leaf_node": min_observations_in_leaf_node,
             "min_observations_in_split_node": min_observations_in_split_node,
@@ -231,7 +176,7 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
             "error_metric_mode": self.error_metric_mode,
             "variable_importance_mode": self.variable_importance_mode,
         }
-        if self.is_classification:
+        if isinstance(self, ClassifierMixin):
             onedal_params["class_count"] = (
                 0 if self.classes_ is None else len(self.classes_)
             )
@@ -348,8 +293,6 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
         y = self._validate_targets(y, X.dtype)
 
         self.n_features_in_ = X.shape[1]
-        if not sklearn_check_version("1.0"):
-            self.n_features_ = self.n_features_in_
 
         if sample_weight is not None and len(sample_weight) > 0:
             sample_weight = self._get_sample_weight(sample_weight, X)
@@ -364,7 +307,7 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
         self._onedal_model = train_result.model
 
         if self.oob_score:
-            if self.is_classification:
+            if isinstance(self, ClassifierMixin):
                 self.oob_score_ = from_table(train_result.oob_err_accuracy)[0, 0]
                 self.oob_decision_function_ = from_table(
                     train_result.oob_err_decision_function
@@ -437,7 +380,7 @@ class RandomForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
         min_samples_split=2,
         min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
-        max_features="sqrt" if sklearn_check_version("1.1") else "auto",
+        max_features="sqrt",
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         min_impurity_split=None,
@@ -485,7 +428,6 @@ class RandomForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             variable_importance_mode=variable_importance_mode,
             algorithm=algorithm,
         )
-        self.is_classification = True
 
     def _validate_targets(self, y, dtype):
         y, self.class_weight_, self.classes_ = _validate_targets(
@@ -530,7 +472,7 @@ class RandomForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
         min_samples_split=2,
         min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
-        max_features=1.0 if sklearn_check_version("1.1") else "auto",
+        max_features=1.0,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         min_impurity_split=None,
@@ -578,7 +520,6 @@ class RandomForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
             variable_importance_mode=variable_importance_mode,
             algorithm=algorithm,
         )
-        self.is_classification = False
 
     def fit(self, X, y, sample_weight=None, queue=None):
         if sample_weight is not None:
@@ -610,7 +551,7 @@ class ExtraTreesClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
         min_samples_split=2,
         min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
-        max_features="auto",
+        max_features="sqrt",
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         min_impurity_split=None,
@@ -658,7 +599,6 @@ class ExtraTreesClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             variable_importance_mode=variable_importance_mode,
             algorithm=algorithm,
         )
-        self.is_classification = True
 
     def _validate_targets(self, y, dtype):
         y, self.class_weight_, self.classes_ = _validate_targets(
@@ -703,7 +643,7 @@ class ExtraTreesRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
         min_samples_split=2,
         min_samples_leaf=1,
         min_weight_fraction_leaf=0.0,
-        max_features="auto",
+        max_features=1.0,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         min_impurity_split=None,
@@ -751,7 +691,6 @@ class ExtraTreesRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
             variable_importance_mode=variable_importance_mode,
             algorithm=algorithm,
         )
-        self.is_classification = False
 
     def fit(self, X, y, sample_weight=None, queue=None):
         if sample_weight is not None:

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -97,6 +97,17 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
         self.variable_importance_mode = variable_importance_mode
         self.algorithm = algorithm
 
+    def _to_absolute_max_features(self, n_features):
+        if self.max_features is None:
+            return n_features
+        elif isinstance(self.max_features, str):
+            return max(1, int(getattr(np, self.max_features)(n_features)))
+        elif isinstance(self.max_features, (numbers.Integral, np.integer)):
+            return self.max_features
+        elif self.max_features > 0.0:
+            return max(1, int(self.max_features * n_features))
+        return 0
+
     def _get_observations_per_tree_fraction(self, n_samples, max_samples):
         if max_samples is None:
             return 1.0
@@ -159,11 +170,7 @@ class BaseForest(BaseEstimator, BaseEnsemble, metaclass=ABCMeta):
             "min_weight_fraction_in_leaf_node": self.min_weight_fraction_leaf,
             "min_impurity_decrease_in_split_node": self.min_impurity_decrease,
             "tree_count": int(self.n_estimators),
-            "features_per_node": (
-                self.max_features
-                if not isinstance(self.max_features, str)
-                else max(1, int(getattr(np, self.max_features)(n_features)))
-            ),
+            "features_per_node": self._to_absolute_max_features(n_features),
             "max_tree_depth": int(0 if self.max_depth is None else self.max_depth),
             "min_observations_in_leaf_node": min_observations_in_leaf_node,
             "min_observations_in_split_node": min_observations_in_split_node,

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -114,7 +114,9 @@ class BaseForest(ABC):
             "min_samples_split": self.min_samples_split,
             "min_samples_leaf": self.min_samples_leaf,
             "min_weight_fraction_leaf": self.min_weight_fraction_leaf,
-            "max_features": self.max_features,
+            "max_features": self._to_absolute_max_features(
+                self.max_features, self.n_features_in_
+            ),
             "max_leaf_nodes": self.max_leaf_nodes,
             "min_impurity_decrease": self.min_impurity_decrease,
             "bootstrap": self.bootstrap,
@@ -173,6 +175,45 @@ class BaseForest(ABC):
             self._n_samples_bootstrap = None
         self._validate_estimator()
         return self
+
+    def _to_absolute_max_features(self, max_features, n_features):
+        if max_features is None:
+            return n_features
+        if isinstance(max_features, str):
+            if max_features == "auto":
+                if not sklearn_check_version("1.3"):
+                    if sklearn_check_version("1.1"):
+                        warnings.warn(
+                            "`max_features='auto'` has been deprecated in 1.1 "
+                            "and will be removed in 1.3. To keep the past behaviour, "
+                            "explicitly set `max_features=1.0` or remove this "
+                            "parameter as it is also the default value for "
+                            "RandomForestRegressors and ExtraTreesRegressors.",
+                            FutureWarning,
+                        )
+                    return (
+                        max(1, int(np.sqrt(n_features)))
+                        if isinstance(self, ForestClassifier)
+                        else n_features
+                    )
+            if max_features == "sqrt":
+                return max(1, int(np.sqrt(n_features)))
+            if max_features == "log2":
+                return max(1, int(np.log2(n_features)))
+            allowed_string_values = (
+                '"sqrt" or "log2"'
+                if sklearn_check_version("1.3")
+                else '"auto", "sqrt" or "log2"'
+            )
+            raise ValueError(
+                "Invalid value for max_features. Allowed string "
+                f"values are {allowed_string_values}."
+            )
+        if isinstance(max_features, (numbers.Integral, np.integer)):
+            return max_features
+        if max_features > 0.0:
+            return max(1, int(max_features * n_features))
+        return 0
 
     def _check_parameters(self):
         if isinstance(self.min_samples_leaf, numbers.Integral):


### PR DESCRIPTION
### Description 
Add a design rule which forces all sklearn-related interfacing to occur in its proper package, namely sklearnex.  This prevents bad estimator architectures which place too much of the sklearn-related aspects in the wrong area.   Ideally this test would have no exceptions going forward.

This is a subsegment of #1829 which handles just the ensemble algorithm so that sklearn_check_version is not in onedal/ensemble


Tasks -

- [ ] Initial compile
- [ ] correct public CI failures
- [ ] Split into separate PRs as necessary (and merge them)
- [ ] pass private CI
