### PR TITLE
[enhancement] remove sklearn_check_version dependence from `onedal/svm`

### DIFF
--- a/onedal/svm/svm.cpp
+++ b/onedal/svm/svm.cpp
@@ -135,6 +135,17 @@ void init_train_ops(py::module_& m) {
               train_ops ops(policy, input_t{ data, responses, weights }, params2desc{});
               return fptype2t{ method2t{ Task{}, kernel2t{ ops } } }(params);
           });
+    m.def("train",
+          [](const Policy& policy,
+             const py::dict& params,
+             const table& data,
+             const table& responses) {
+              using namespace dal::svm;
+              using input_t = train_input<Task>;
+
+              train_ops ops(policy, input_t{ data, responses}, params2desc{});
+              return fptype2t{ method2t{ Task{}, kernel2t{ ops } } }(params);
+          });
 }
 
 template <typename Policy, typename Task>

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -130,6 +130,24 @@ class BaseSVM(metaclass=ABCMeta):
             accept_sparse="csr",
         )
         y = self._validate_targets(y, X.dtype)
+        if sample_weight is not None and len(sample_weight) > 0:
+            sample_weight = _check_array(
+                sample_weight,
+                accept_sparse=False,
+                ensure_2d=False,
+                dtype=X.dtype,
+                order="C",
+            )
+        elif self.class_weight is not None:
+            sample_weight = np.ones(X.shape[0], dtype=X.dtype)
+
+        if sample_weight is not None:
+            if self.class_weight_ is not None:
+                for i, v in enumerate(self.class_weight_):
+                    sample_weight[y == i] *= v
+            data = (X, y, sample_weight)
+        else:
+            data = (X, y)
         self._sparse = sp.issparse(X)
 
         if self.kernel == "linear":
@@ -155,9 +173,9 @@ class BaseSVM(metaclass=ABCMeta):
                 _gamma = self.gamma
             self._scale_, self._sigma_ = _gamma, np.sqrt(0.5 / _gamma)
 
-        policy = _get_policy(queue, X, y, sample_weight)
+        policy = _get_policy(queue, *data)
         params = self._get_onedal_params(X)
-        result = module.train(policy, params, *to_table(X, y, sample_weight))
+        result = module.train(policy, params, *to_table(*data))
 
         if self._sparse:
             self.dual_coef_ = sp.csr_matrix(from_table(result.coeffs).T)

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -16,13 +16,10 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from numbers import Number, Real
 
 import numpy as np
 from scipy import sparse as sp
-from sklearn.base import BaseEstimator
 
-from daal4py.sklearn._utils import sklearn_check_version
 from onedal import _backend
 
 from ..common._estimator_checks import _check_is_fitted
@@ -45,7 +42,7 @@ class SVMtype(Enum):
     nu_svr = 3
 
 
-class BaseSVM(BaseEstimator, metaclass=ABCMeta):
+class BaseSVM(metaclass=ABCMeta):
     @abstractmethod
     def __init__(
         self,
@@ -87,132 +84,10 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
         self.algorithm = algorithm
         self.svm_type = svm_type
 
-    def _compute_gamma_sigma(self, gamma, X):
-        if isinstance(gamma, str):
-            if gamma == "scale":
-                if sp.issparse(X):
-                    # var = E[X^2] - E[X]^2
-                    X_sc = (X.multiply(X)).mean() - (X.mean()) ** 2
-                else:
-                    X_sc = X.var()
-                _gamma = 1.0 / (X.shape[1] * X_sc) if X_sc != 0 else 1.0
-            elif gamma == "auto":
-                _gamma = 1.0 / X.shape[1]
-            else:
-                raise ValueError(
-                    "When 'gamma' is a string, it should be either 'scale' or "
-                    "'auto'. Got '{}' instead.".format(gamma)
-                )
-        else:
-            if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
-                if isinstance(gamma, Real):
-                    if gamma <= 0:
-                        msg = (
-                            f"gamma value must be > 0; {gamma!r} is invalid. Use"
-                            " a positive number or use 'auto' to set gamma to a"
-                            " value of 1 / n_features."
-                        )
-                        raise ValueError(msg)
-                    _gamma = gamma
-                else:
-                    msg = (
-                        "The gamma value should be set to 'scale', 'auto' or a"
-                        f" positive float value. {gamma!r} is not a valid option"
-                    )
-                    raise ValueError(msg)
-            else:
-                _gamma = gamma
-        return _gamma, np.sqrt(0.5 / _gamma)
-
     def _validate_targets(self, y, dtype):
         self.class_weight_ = None
         self.classes_ = None
         return _column_or_1d(y, warn=True).astype(dtype, copy=False)
-
-    def _get_sample_weight(self, X, y, sample_weight):
-        n_samples = X.shape[0]
-        dtype = X.dtype
-        if n_samples == 1:
-            raise ValueError("n_samples=1")
-
-        sample_weight = np.asarray(
-            [] if sample_weight is None else sample_weight, dtype=np.float64
-        )
-
-        sample_weight_count = sample_weight.shape[0]
-        if sample_weight_count != 0 and sample_weight_count != n_samples:
-            raise ValueError(
-                "sample_weight and X have incompatible shapes: "
-                "%r vs %r\n"
-                "Note: Sparse matrices cannot be indexed w/"
-                "boolean masks (use `indices=True` in CV)."
-                % (len(sample_weight), X.shape)
-            )
-
-        ww = None
-        if sample_weight_count == 0 and self.class_weight_ is None:
-            return ww
-
-        if sample_weight_count == 0:
-            sample_weight = np.ones(n_samples, dtype=dtype)
-        elif isinstance(sample_weight, Number):
-            sample_weight = np.full(n_samples, sample_weight, dtype=dtype)
-        else:
-            sample_weight = _check_array(
-                sample_weight,
-                accept_sparse=False,
-                ensure_2d=False,
-                dtype=dtype,
-                order="C",
-            )
-            if sample_weight.ndim != 1:
-                raise ValueError("Sample weights must be 1D array or scalar")
-
-            if sample_weight.shape != (n_samples,):
-                raise ValueError(
-                    "sample_weight.shape == {}, expected {}!".format(
-                        sample_weight.shape, (n_samples,)
-                    )
-                )
-
-        if self.svm_type == SVMtype.nu_svc:
-            weight_per_class = [
-                np.sum(sample_weight[y == class_label]) for class_label in np.unique(y)
-            ]
-
-            for i in range(len(weight_per_class)):
-                for j in range(i + 1, len(weight_per_class)):
-                    if self.nu * (weight_per_class[i] + weight_per_class[j]) / 2 > min(
-                        weight_per_class[i], weight_per_class[j]
-                    ):
-                        raise ValueError("specified nu is infeasible")
-
-        if np.all(sample_weight <= 0):
-            if self.svm_type == SVMtype.nu_svc:
-                err_msg = "negative dimensions are not allowed"
-            else:
-                err_msg = "Invalid input - all samples have zero or negative weights."
-            raise ValueError(err_msg)
-        if np.any(sample_weight <= 0):
-            if self.svm_type == SVMtype.c_svc and len(
-                np.unique(y[sample_weight > 0])
-            ) != len(self.classes_):
-                raise ValueError(
-                    "Invalid input - all samples with positive weights "
-                    "belong to the same class"
-                    if sklearn_check_version("1.2")
-                    else "Invalid input - all samples with positive weights "
-                    "have the same label."
-                )
-        ww = sample_weight
-        if self.class_weight_ is not None:
-            for i, v in enumerate(self.class_weight_):
-                ww[y == i] *= v
-
-        if not ww.flags.c_contiguous and not ww.flags.f_contiguous:
-            ww = np.ascontiguousarray(ww, dtype)
-
-        return ww
 
     def _get_onedal_params(self, data):
         max_iter = 10000 if self.max_iter == -1 else self.max_iter
@@ -247,12 +122,6 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
                     f"got {self.decision_function_shape}."
                 )
 
-        if y is None:
-            if self._get_tags()["requires_y"]:
-                raise ValueError(
-                    f"This {self.__class__.__name__} estimator "
-                    f"requires y to be passed, but the target y is None."
-                )
         X, y = _check_X_y(
             X,
             y,
@@ -261,15 +130,30 @@ class BaseSVM(BaseEstimator, metaclass=ABCMeta):
             accept_sparse="csr",
         )
         y = self._validate_targets(y, X.dtype)
-        sample_weight = self._get_sample_weight(X, y, sample_weight)
-
         self._sparse = sp.issparse(X)
 
         if self.kernel == "linear":
             self._scale_, self._sigma_ = 1.0, 1.0
             self.coef0 = 0.0
         else:
-            self._scale_, self._sigma_ = self._compute_gamma_sigma(self.gamma, X)
+            if isinstance(self.gamma, str):
+                if self.gamma == "scale":
+                    if sp.issparse(X):
+                        # var = E[X^2] - E[X]^2
+                        X_sc = (X.multiply(X)).mean() - (X.mean()) ** 2
+                    else:
+                        X_sc = X.var()
+                    _gamma = 1.0 / (X.shape[1] * X_sc) if X_sc != 0 else 1.0
+                elif self.gamma == "auto":
+                    _gamma = 1.0 / X.shape[1]
+                else:
+                    raise ValueError(
+                        "When 'gamma' is a string, it should be either 'scale' or "
+                        "'auto'. Got '{}' instead.".format(self.gamma)
+                    )
+            else:
+                _gamma = self.gamma
+            self._scale_, self._sigma_ = _gamma, np.sqrt(0.5 / _gamma)
 
         policy = _get_policy(queue, X, y, sample_weight)
         params = self._get_onedal_params(X)

--- a/onedal/svm/tests/test_csr_svm.py
+++ b/onedal/svm/tests/test_csr_svm.py
@@ -19,7 +19,6 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse as sp
 from sklearn import datasets
-from sklearn.base import clone as clone_estimator
 from sklearn.datasets import make_classification
 
 from onedal.svm import SVC, SVR
@@ -33,9 +32,9 @@ def is_classifier(estimator):
     return getattr(estimator, "_estimator_type", None) == "classifier"
 
 
-def check_svm_model_equal(queue, svm, X_train, y_train, X_test, decimal=6):
-    sparse_svm = clone_estimator(svm)
-    dense_svm = clone_estimator(svm)
+def check_svm_model_equal(
+    queue, dense_svm, sparse_svm, X_train, y_train, X_test, decimal=6
+):
     dense_svm.fit(X_train.toarray(), y_train, queue=queue)
     if sp.issparse(X_test):
         X_test_dense = X_test.toarray()
@@ -73,8 +72,9 @@ def _test_simple_dataset(queue, kernel):
     sparse_X2 = sp.dok_matrix(X2)
 
     dataset = sparse_X, Y, sparse_X2
-    clf = SVC(kernel=kernel, gamma=1)
-    check_svm_model_equal(queue, clf, *dataset)
+    clf0 = SVC(kernel=kernel, gamma=1)
+    clf1 = SVC(kernel=kernel, gamma=1)
+    check_svm_model_equal(queue, clf0, clf1, *dataset)
 
 
 @pass_if_not_implemented_for_gpu(reason="csr svm is not implemented")
@@ -101,8 +101,9 @@ def _test_binary_dataset(queue, kernel):
     sparse_X = sp.csr_matrix(X)
 
     dataset = sparse_X, y, sparse_X
-    clf = SVC(kernel=kernel)
-    check_svm_model_equal(queue, clf, *dataset)
+    clf0 = SVC(kernel=kernel)
+    clf1 = SVC(kernel=kernel)
+    check_svm_model_equal(queue, clf0, clf1, *dataset)
 
 
 @pass_if_not_implemented_for_gpu(reason="csr svm is not implemented")
@@ -135,8 +136,9 @@ def _test_iris(queue, kernel):
 
     dataset = sparse_iris_data, iris.target, sparse_iris_data
 
-    clf = SVC(kernel=kernel)
-    check_svm_model_equal(queue, clf, *dataset, decimal=2)
+    clf0 = SVC(kernel=kernel)
+    clf1 = SVC(kernel=kernel)
+    check_svm_model_equal(queue, clf0, clf1, *dataset, decimal=2)
 
 
 @pass_if_not_implemented_for_gpu(reason="csr svm is not implemented")
@@ -152,8 +154,9 @@ def _test_diabetes(queue, kernel):
     sparse_diabetes_data = sp.csr_matrix(diabetes.data)
     dataset = sparse_diabetes_data, diabetes.target, sparse_diabetes_data
 
-    clf = SVR(kernel=kernel, C=0.1)
-    check_svm_model_equal(queue, clf, *dataset)
+    clf0 = SVR(kernel=kernel, C=0.1)
+    clf1 = SVR(kernel=kernel, C=0.1)
+    check_svm_model_equal(queue, clf0, clf1, *dataset)
 
 
 @pass_if_not_implemented_for_gpu(reason="csr svm is not implemented")

--- a/onedal/svm/tests/test_csr_svm.py
+++ b/onedal/svm/tests/test_csr_svm.py
@@ -21,15 +21,12 @@ from scipy import sparse as sp
 from sklearn import datasets
 from sklearn.datasets import make_classification
 
+from onedal.common._mixin import ClassifierMixin
 from onedal.svm import SVC, SVR
 from onedal.tests.utils._device_selection import (
     get_queues,
     pass_if_not_implemented_for_gpu,
 )
-
-
-def is_classifier(estimator):
-    return getattr(estimator, "_estimator_type", None) == "classifier"
 
 
 def check_svm_model_equal(
@@ -55,7 +52,7 @@ def check_svm_model_equal(
         sparse_svm.predict(X_test, queue=queue),
     )
 
-    if is_classifier(svm):
+    if isinstance(dense_svm, ClassifierMixin) and isinstance(sparse_svm, ClassifierMixin):
         assert_array_almost_equal(
             dense_svm.decision_function(X_test_dense, queue=queue),
             sparse_svm.decision_function(X_test, queue=queue),

--- a/onedal/svm/tests/test_svc.py
+++ b/onedal/svm/tests/test_svc.py
@@ -22,49 +22,12 @@ from sklearn import datasets
 from sklearn.datasets import make_blobs
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.model_selection import train_test_split
-from sklearn.utils.estimator_checks import check_estimator
 
 from onedal.svm import SVC
 from onedal.tests.utils._device_selection import (
     get_queues,
     pass_if_not_implemented_for_gpu,
 )
-
-
-def _replace_and_save(md, fns, replacing_fn):
-    saved = dict()
-    for check_f in fns:
-        try:
-            fn = getattr(md, check_f)
-            setattr(md, check_f, replacing_fn)
-            saved[check_f] = fn
-        except RuntimeError:
-            pass
-    return saved
-
-
-def _restore_from_saved(md, saved_dict):
-    for check_f in saved_dict:
-        setattr(md, check_f, saved_dict[check_f])
-
-
-def test_estimator():
-    def dummy(*args, **kwargs):
-        pass
-
-    md = sklearn.utils.estimator_checks
-    saved = _replace_and_save(
-        md,
-        [
-            "check_sample_weights_invariance",  # Max absolute difference: 0.0008
-            "check_estimators_fit_returns_self",  # ValueError: empty metadata
-            "check_classifiers_train",  # assert y_pred.shape == (n_samples,)
-            "check_estimators_unfitted",  # Call 'fit' with appropriate arguments
-        ],
-        dummy,
-    )
-    check_estimator(SVC())
-    _restore_from_saved(md, saved)
 
 
 def _test_libsvm_parameters(queue, array_constr, dtype):

--- a/onedal/svm/tests/test_svr.py
+++ b/onedal/svm/tests/test_svr.py
@@ -16,12 +16,10 @@
 
 import numpy as np
 import pytest
-import sklearn.utils.estimator_checks
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 from sklearn import datasets
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.svm import SVR as SklearnSVR
-from sklearn.utils.estimator_checks import check_estimator
 
 from onedal.svm import SVR
 from onedal.tests.utils._device_selection import (
@@ -30,42 +28,6 @@ from onedal.tests.utils._device_selection import (
 )
 
 synth_params = {"n_samples": 500, "n_features": 100, "random_state": 42}
-
-
-def _replace_and_save(md, fns, replacing_fn):
-    saved = dict()
-    for check_f in fns:
-        try:
-            fn = getattr(md, check_f)
-            setattr(md, check_f, replacing_fn)
-            saved[check_f] = fn
-        except RuntimeError:
-            pass
-    return saved
-
-
-def _restore_from_saved(md, saved_dict):
-    for check_f in saved_dict:
-        setattr(md, check_f, saved_dict[check_f])
-
-
-def test_estimator():
-    def dummy(*args, **kwargs):
-        pass
-
-    md = sklearn.utils.estimator_checks
-    saved = _replace_and_save(
-        md,
-        [
-            "check_sample_weights_invariance",  # Max absolute difference: 0.0002
-            "check_estimators_fit_returns_self",  # ???
-            "check_regressors_train",  # Cannot get data type from empty metadata
-            "check_estimators_unfitted",  # expected NotFittedError from sklearn
-        ],
-        dummy,
-    )
-    check_estimator(SVR())
-    _restore_from_saved(md, saved)
 
 
 @pass_if_not_implemented_for_gpu(reason="svr is not implemented")

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -180,11 +180,9 @@ class BaseSVM(BaseEstimator, ABC):
                 % (len(sample_weight), X.shape)
             )
 
-        ww = None
-        if sample_weight_count == 0 and not isinstance(self, ClassifierMixin):
-            return ww
-
         if sample_weight_count == 0:
+            if not isinstance(self, ClassifierMixin) or self.class_weight_ is None:
+                return None
             sample_weight = np.ones(n_samples, dtype=dtype)
         elif isinstance(sample_weight, Number):
             sample_weight = np.full(n_samples, sample_weight, dtype=dtype)

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -56,7 +56,6 @@ def set_intercept(self, value):
 
 
 class BaseSVM(BaseEstimator, ABC):
-    _err_msg = "Invalid input - all samples have zero or negative weights."
 
     def _onedal_gpu_supported(self, method_name, *data):
         patching_status = PatchingConditionsChain(f"sklearn.{method_name}")

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -15,14 +15,17 @@
 # ==============================================================================
 
 from abc import ABC
+from numbers import Number, Real
 
 import numpy as np
+from scipy import sparse as sp
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.model_selection import StratifiedKFold
 from sklearn.preprocessing import LabelEncoder
 
 from daal4py.sklearn._utils import sklearn_check_version
-from onedal.utils import _column_or_1d
+from onedal.utils import _check_array, _check_X_y, _column_or_1d
 
 from .._utils import PatchingConditionsChain
 
@@ -51,7 +54,9 @@ def set_intercept(self, value):
             del self._onedal_estimator._onedal_model
 
 
-class BaseSVM(ABC):
+class BaseSVM(BaseEstimator, ABC):
+    _err_msg = "Invalid input - all samples have zero or negative weights."
+
     def _onedal_gpu_supported(self, method_name, *data):
         patching_status = PatchingConditionsChain(f"sklearn.{method_name}")
         patching_status.and_conditions([(False, "GPU offloading is not supported.")])
@@ -85,6 +90,127 @@ class BaseSVM(ABC):
             return patching_status
         raise RuntimeError(f"Unknown method {method_name} in {class_name}")
 
+    def _compute_gamma_sigma(self, X):
+        # only run extended conversion if kernel is not linear
+        # set to a value = 1.0, so gamma will always be passed to
+        # the onedal estimator as a float type
+        if self.kernel == "linear":
+            return 1.0
+
+        if isinstance(self.gamma, str):
+            if self.gamma == "scale":
+                if sp.issparse(X):
+                    # var = E[X^2] - E[X]^2
+                    X_sc = (X.multiply(X)).mean() - (X.mean()) ** 2
+                else:
+                    X_sc = X.var()
+                _gamma = 1.0 / (X.shape[1] * X_sc) if X_sc != 0 else 1.0
+            elif self.gamma == "auto":
+                _gamma = 1.0 / X.shape[1]
+            else:
+                raise ValueError(
+                    "When 'gamma' is a string, it should be either 'scale' or "
+                    "'auto'. Got '{}' instead.".format(self.gamma)
+                )
+        else:
+            if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
+                if isinstance(self.gamma, Real):
+                    if self.gamma <= 0:
+                        msg = (
+                            f"gamma value must be > 0; {self.gamma!r} is invalid. Use"
+                            " a positive number or use 'auto' to set gamma to a"
+                            " value of 1 / n_features."
+                        )
+                        raise ValueError(msg)
+                    _gamma = self.gamma
+                else:
+                    msg = (
+                        "The gamma value should be set to 'scale', 'auto' or a"
+                        f" positive float value. {self.gamma!r} is not a valid option"
+                    )
+                    raise ValueError(msg)
+            else:
+                _gamma = self.gamma
+        return _gamma
+
+    def _onedal_fit_checks(self, X, y, sample_weight=None):
+        if hasattr(self, "decision_function_shape"):
+            if self.decision_function_shape not in ("ovr", "ovo", None):
+                raise ValueError(
+                    f"decision_function_shape must be either 'ovr' or 'ovo', "
+                    f"got {self.decision_function_shape}."
+                )
+
+        if y is None:
+            if self._get_tags()["requires_y"]:
+                raise ValueError(
+                    f"This {self.__class__.__name__} estimator "
+                    f"requires y to be passed, but the target y is None."
+                )
+        # using onedal _check_X_y to insure X and y are contiguous
+        # finite check occurs in onedal estimator
+        X, y = _check_X_y(
+            X,
+            y,
+            dtype=[np.float64, np.float32],
+            force_all_finite=False,
+            accept_sparse="csr",
+        )
+        y = self._validate_targets(y)
+        sample_weight = self._get_sample_weight(X, y, sample_weight)
+        return X, y, sample_weight
+
+    def _get_sample_weight(self, X, y, sample_weight):
+        n_samples = X.shape[0]
+        dtype = X.dtype
+        if n_samples == 1:
+            raise ValueError("n_samples=1")
+
+        sample_weight = np.ascontiguousarray(
+            [] if sample_weight is None else sample_weight, dtype=np.float64
+        )
+
+        sample_weight_count = sample_weight.shape[0]
+        if sample_weight_count != 0 and sample_weight_count != n_samples:
+            raise ValueError(
+                "sample_weight and X have incompatible shapes: "
+                "%r vs %r\n"
+                "Note: Sparse matrices cannot be indexed w/"
+                "boolean masks (use `indices=True` in CV)."
+                % (len(sample_weight), X.shape)
+            )
+
+        ww = None
+        if sample_weight_count == 0 and not isinstance(self, ClassifierMixin):
+            return ww
+
+        if sample_weight_count == 0:
+            sample_weight = np.ones(n_samples, dtype=dtype)
+        elif isinstance(sample_weight, Number):
+            sample_weight = np.full(n_samples, sample_weight, dtype=dtype)
+        else:
+            sample_weight = _check_array(
+                sample_weight,
+                accept_sparse=False,
+                ensure_2d=False,
+                dtype=dtype,
+                order="C",
+            )
+            if sample_weight.ndim != 1:
+                raise ValueError("Sample weights must be 1D array or scalar")
+
+            if sample_weight.shape != (n_samples,):
+                raise ValueError(
+                    "sample_weight.shape == {}, expected {}!".format(
+                        sample_weight.shape, (n_samples,)
+                    )
+                )
+
+        if np.all(sample_weight <= 0):
+            raise ValueError(self._err_msg)
+
+        return sample_weight
+
 
 class BaseSVC(BaseSVM):
     def _compute_balanced_class_weight(self, y):
@@ -100,27 +226,38 @@ class BaseSVC(BaseSVM):
         return recip_freq[le.transform(classes)]
 
     def _fit_proba(self, X, y, sample_weight=None, queue=None):
+        from .._config import config_context, get_config
+
         params = self.get_params()
         params["probability"] = False
         params["decision_function_shape"] = "ovr"
         clf_base = self.__class__(**params)
 
-        try:
-            n_splits = 5
-            n_jobs = n_splits if queue is None or queue.sycl_device.is_cpu else 1
-            cv = StratifiedKFold(
-                n_splits=n_splits, shuffle=True, random_state=self.random_state
-            )
-            self.clf_prob = CalibratedClassifierCV(
-                clf_base, ensemble=False, cv=cv, method="sigmoid", n_jobs=n_jobs
-            )
-            self.clf_prob.fit(X, y, sample_weight)
-        except ValueError:
-            clf_base = clf_base.fit(X, y, sample_weight)
-            self.clf_prob = CalibratedClassifierCV(
-                clf_base, cv="prefit", method="sigmoid"
-            )
-            self.clf_prob.fit(X, y, sample_weight)
+        # We use stock metaestimators below, so the only way
+        # to pass a queue is using config_context.
+        cfg = get_config()
+        cfg["target_offload"] = queue
+        with config_context(**cfg):
+            try:
+                n_splits = 5
+                n_jobs = n_splits if queue is None or queue.sycl_device.is_cpu else 1
+                cv = StratifiedKFold(
+                    n_splits=n_splits, shuffle=True, random_state=self.random_state
+                )
+                self.clf_prob = CalibratedClassifierCV(
+                    clf_base,
+                    ensemble=False,
+                    cv=cv,
+                    method="sigmoid",
+                )
+                self.clf_prob.fit(X, y, sample_weight)
+
+            except ValueError:
+                clf_base = clf_base.fit(X, y, sample_weight)
+                self.clf_prob = CalibratedClassifierCV(
+                    clf_base, cv="prefit", method="sigmoid"
+                )
+                self.clf_prob.fit(X, y, sample_weight)
 
     def _save_attributes(self):
         self.support_vectors_ = self._onedal_estimator.support_vectors_
@@ -129,7 +266,8 @@ class BaseSVC(BaseSVM):
         self.dual_coef_ = self._onedal_estimator.dual_coef_
         self.shape_fit_ = self._onedal_estimator.class_weight_
         self.classes_ = self._onedal_estimator.classes_
-        self.class_weight_ = self._onedal_estimator.class_weight_
+        if isinstance(self, ClassifierMixin) or not sklearn_check_version("1.2"):
+            self.class_weight_ = self._onedal_estimator.class_weight_
         self.support_ = self._onedal_estimator.support_
 
         self._intercept_ = self._onedal_estimator.intercept_

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -208,7 +208,9 @@ class BaseSVM(BaseEstimator, ABC):
             if "nusvc" in self.__module__:
                 raise ValueError("negative dimensions are not allowed")
             else:
-                raise ValueError("Invalid input - all samples have zero or negative weights.")
+                raise ValueError(
+                    "Invalid input - all samples have zero or negative weights."
+                )
 
         return sample_weight
 

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -27,6 +27,7 @@ from sklearn.preprocessing import LabelEncoder
 from daal4py.sklearn._utils import sklearn_check_version
 from onedal.utils import _check_array, _check_X_y, _column_or_1d
 
+from .._config import config_context, get_config
 from .._utils import PatchingConditionsChain
 
 
@@ -224,8 +225,6 @@ class BaseSVC(BaseSVM):
         return recip_freq[le.transform(classes)]
 
     def _fit_proba(self, X, y, sample_weight=None, queue=None):
-        from .._config import config_context, get_config
-
         params = self.get_params()
         params["probability"] = False
         params["decision_function_shape"] = "ovr"

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -206,7 +206,10 @@ class BaseSVM(BaseEstimator, ABC):
                 )
 
         if np.all(sample_weight <= 0):
-            raise ValueError(self._err_msg)
+            if "nusvc" in self.__module__:
+                raise ValueError("negative dimensions are not allowed")
+            else:
+                raise ValueError("Invalid input - all samples have zero or negative weights.")
 
         return sample_weight
 

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -38,6 +38,8 @@ from onedal.svm import NuSVC as onedal_NuSVC
 )
 class NuSVC(sklearn_NuSVC, BaseSVC):
     __doc__ = sklearn_NuSVC.__doc__
+    # needed to match sklearn sample weight peculiarities
+    _err_msg = "negative dimensions are not allowed"
 
     if sklearn_check_version("1.2"):
         _parameter_constraints: dict = {**sklearn_NuSVC._parameter_constraints}
@@ -94,7 +96,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
             },
             X,
             y,
-            sample_weight,
+            sample_weight=sample_weight,
         )
 
         return self
@@ -242,12 +244,35 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
 
     decision_function.__doc__ = sklearn_NuSVC.decision_function.__doc__
 
+    def _get_sample_weight(self, X, y, sample_weight=None):
+        sample_weight = super()._get_sample_weight(X, y, sample_weight)
+        if sample_weight is None:
+            return sample_weight
+
+        weight_per_class = [
+            np.sum(sample_weight[y == class_label]) for class_label in np.unique(y)
+        ]
+
+        for i in range(len(weight_per_class)):
+            for j in range(i + 1, len(weight_per_class)):
+                if self.nu * (weight_per_class[i] + weight_per_class[j]) / 2 > min(
+                    weight_per_class[i], weight_per_class[j]
+                ):
+                    raise ValueError("specified nu is infeasible")
+
+        ww = sample_weight
+        if self.class_weight_ is not None:
+            for i, v in enumerate(self.class_weight_):
+                ww[y == i] *= v
+        return ww
+
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        X, _, sample_weight = self._onedal_fit_checks(X, y, sample_weight)
         onedal_params = {
             "nu": self.nu,
             "kernel": self.kernel,
             "degree": self.degree,
-            "gamma": self.gamma,
+            "gamma": self._compute_gamma_sigma(X),
             "coef0": self.coef0,
             "tol": self.tol,
             "shrinking": self.shrinking,
@@ -262,7 +287,8 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         self._onedal_estimator.fit(X, y, sample_weight, queue=queue)
 
         if self.probability:
-            self._fit_proba(X, y, sample_weight, queue=queue)
+            self._fit_proba(X, y, sample_weight=sample_weight, queue=queue)
+
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -38,8 +38,6 @@ from onedal.svm import NuSVC as onedal_NuSVC
 )
 class NuSVC(sklearn_NuSVC, BaseSVC):
     __doc__ = sklearn_NuSVC.__doc__
-    # needed to match sklearn sample weight peculiarities
-    _err_msg = "negative dimensions are not allowed"
 
     if sklearn_check_version("1.2"):
         _parameter_constraints: dict = {**sklearn_NuSVC._parameter_constraints}

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -260,14 +260,10 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
                 ):
                     raise ValueError("specified nu is infeasible")
 
-        ww = sample_weight
-        if self.class_weight_ is not None:
-            for i, v in enumerate(self.class_weight_):
-                ww[y == i] *= v
-        return ww
+        return sample_weight
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
-        X, _, sample_weight = self._onedal_fit_checks(X, y, sample_weight)
+        X, _, weights = self._onedal_fit_checks(X, y, sample_weight)
         onedal_params = {
             "nu": self.nu,
             "kernel": self.kernel,
@@ -284,10 +280,15 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         }
 
         self._onedal_estimator = onedal_NuSVC(**onedal_params)
-        self._onedal_estimator.fit(X, y, sample_weight, queue=queue)
+        self._onedal_estimator.fit(X, y, weights, queue=queue)
 
         if self.probability:
-            self._fit_proba(X, y, sample_weight=sample_weight, queue=queue)
+            self._fit_proba(
+                X,
+                y,
+                sample_weight=sample_weight,
+                queue=queue,
+            )
 
         self._save_attributes()
 

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -76,7 +76,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             },
             X,
             y,
-            sample_weight,
+            sample_weight=sample_weight,
         )
         return self
 
@@ -95,12 +95,13 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         )
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        X, _, sample_weight = self._onedal_fit_checks(X, y, sample_weight)
         onedal_params = {
             "C": self.C,
             "nu": self.nu,
             "kernel": self.kernel,
             "degree": self.degree,
-            "gamma": self.gamma,
+            "gamma": self._compute_gamma_sigma(X),
             "coef0": self.coef0,
             "tol": self.tol,
             "shrinking": self.shrinking,

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -96,8 +96,9 @@ class SVC(sklearn_SVC, BaseSVC):
             },
             X,
             y,
-            sample_weight,
+            sample_weight=sample_weight,
         )
+
         return self
 
     @wrap_output_data
@@ -270,12 +271,39 @@ class SVC(sklearn_SVC, BaseSVC):
             return patching_status
         raise RuntimeError(f"Unknown method {method_name} in {class_name}")
 
+    def _get_sample_weight(self, X, y, sample_weight=None):
+        sample_weight = super()._get_sample_weight(X, y, sample_weight)
+        if sample_weight is None:
+            return sample_weight
+
+        weight_per_class = [
+            np.sum(sample_weight[y == class_label]) for class_label in np.unique(y)
+        ]
+
+        if np.any(sample_weight <= 0) and len(np.unique(y[sample_weight > 0])) != len(
+            self.classes_
+        ):
+            raise ValueError(
+                "Invalid input - all samples with positive weights "
+                "belong to the same class"
+                if sklearn_check_version("1.2")
+                else "Invalid input - all samples with positive weights "
+                "have the same label."
+            )
+        ww = sample_weight
+        if self.class_weight_ is not None:
+            for i, v in enumerate(self.class_weight_):
+                ww[y == i] *= v
+
+        return ww
+
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        X, _, sample_weight = self._onedal_fit_checks(X, y, sample_weight)
         onedal_params = {
             "C": self.C,
             "kernel": self.kernel,
             "degree": self.degree,
-            "gamma": self.gamma,
+            "gamma": self._compute_gamma_sigma(X),
             "coef0": self.coef0,
             "tol": self.tol,
             "shrinking": self.shrinking,
@@ -290,7 +318,8 @@ class SVC(sklearn_SVC, BaseSVC):
         self._onedal_estimator.fit(X, y, sample_weight, queue=queue)
 
         if self.probability:
-            self._fit_proba(X, y, sample_weight, queue=queue)
+            self._fit_proba(X, y, sample_weight=sample_weight, queue=queue)
+
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -76,7 +76,7 @@ class SVR(sklearn_SVR, BaseSVR):
             },
             X,
             y,
-            sample_weight,
+            sample_weight=sample_weight,
         )
 
         return self
@@ -96,12 +96,13 @@ class SVR(sklearn_SVR, BaseSVR):
         )
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        X, _, sample_weight = self._onedal_fit_checks(X, y, sample_weight)
         onedal_params = {
             "C": self.C,
             "epsilon": self.epsilon,
             "kernel": self.kernel,
             "degree": self.degree,
-            "gamma": self.gamma,
+            "gamma": self._compute_gamma_sigma(X),
             "coef0": self.coef0,
             "tol": self.tol,
             "shrinking": self.shrinking,


### PR DESCRIPTION
### Description 
Add a design rule which forces all sklearn-related interfacing to occur in its proper package, namely sklearnex.  This prevents bad estimator architectures which place too much of the sklearn-related aspects in the wrong area.   Ideally this test would have no exceptions going forward.

This is a subsegment of #1829 which handles just the svm algorithms so that sklearn_check_version is not in onedal/svm

This also solves the PR #1727 by removing sklearn inheritance from onedal/svm classes

This also solves issues with gpu offloading with fit_proba that had been removed errantly in #1361 

This also fixes an issue where sample_weights are always generated, which may impact performance.


Tasks -

- [x] Initial compile
- [x] correct public CI failures
- [x] Split into separate PRs as necessary (and merge them)
- [ ] pass private CI