### PR TITLE
[enhancement] block use of target_offload in `/sklearnex`

### DIFF
--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -19,7 +19,7 @@ from glob import glob
 
 import pytest
 
-ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test"]
+ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svc.py"]
 
 
 def test_target_offload_ban():

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -1,0 +1,48 @@
+# ==============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+from glob import glob
+
+import pytest
+
+ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test"]
+
+
+def test_target_offload_ban():
+    """This test blocks the use of target_offload in
+    in sklearnex files. Offloading computation to devices
+    via target_offload should only occur externally, and not
+    within the architecture of the sklearnex classes. This
+    is for clarity, traceability and maintainability.
+    """
+    from sklearnex import __file__ as loc
+
+    path = loc.replace("__init__.py", "")
+    files = [y for x in os.walk(path) for y in glob(os.path.join(x[0], "*.py"))]
+
+    output = []
+
+    for f in files:
+        if open(f, "r").read().find("target_offload") != -1:
+            output += [f.replace(path, "sklearnex" + os.sep)]
+
+    # remove this file from the list
+    for allowed in ALLOWED_LOCATIONS:
+        output = [i for i in output if allowed not in i]
+
+    output = "\n".join(output)
+    assert output == "", f"sklearn versioning is occuring in: \n{output}"


### PR DESCRIPTION
### Description 
Add a design rule which forces all estimators to properly offload to GPU not using config_context via target_offload.  This prevents bad estimator architectures which can hide queues. This test crawls through the sklearnex folder and greps for "target_offload".  Ideally this test would have no exceptions going forward (currently an exception is grandfathered for nuSVC and SVC). This adds the sklearnex/tests/test_common.py file, which will likely be expanded in the future with more sklearnex folder design checks.


Tasks -

- [ ] Initial compile
- [ ] correct public CI failures
- [ ] Split into separate PRs as necessary (and merge them)
- [ ] pass private CI