### PR TITLE
[bug, testing] fix `sklearnex/` target_offload ban

### DIFF
--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -24,7 +24,7 @@ ALLOWED_LOCATIONS = [
     "_device_offload.py",
     "test",
     "svc.py",
-    "svm/_common.py",
+    "svm" + os.sep + "_common.py",
 ]
 
 

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -19,7 +19,7 @@ from glob import glob
 
 import pytest
 
-ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svc.py"]
+ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svm/_common.py"]
 
 
 def test_target_offload_ban():

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -19,7 +19,13 @@ from glob import glob
 
 import pytest
 
-ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svc.py", "svm/_common.py"]
+ALLOWED_LOCATIONS = [
+    "_config.py",
+    "_device_offload.py",
+    "test",
+    "svc.py",
+    "svm/_common.py",
+]
 
 
 def test_target_offload_ban():

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -19,7 +19,7 @@ from glob import glob
 
 import pytest
 
-ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svm/_common.py"]
+ALLOWED_LOCATIONS = ["_config.py", "_device_offload.py", "test", "svc.py", "svm/_common.py"]
 
 
 def test_target_offload_ban():


### PR DESCRIPTION
### Description 
SVC and nuSVC algorithms contain additional target_offloads for fit_proba which weren't accounted for. This corrects that error to return CI to green.