### PR TITLE
Fix incorrect numpy to table conversion on windows

### DIFF
--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -18,6 +18,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <iostream>
 
 #include "oneapi/dal/table/homogen.hpp"
 #include "oneapi/dal/table/detail/homogen_utils.hpp"
@@ -153,8 +154,10 @@ dal::table convert_to_table(PyObject *obj) {
     if (is_array(obj)) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
         if (array_is_behaved(ary) || array_is_behaved_F(ary)) {
+        std::cout << "Type: " << PyArray_DESCR(ary)->type << " Elsize: " << PyArray_DESCR(ary)->elsize << std::endl;
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
             SET_NPY_FEATURE(PyArray_DESCR(ary)->type,
+                            PyArray_DESCR(ary)->elsize,
                             MAKE_HOMOGEN_TABLE,
                             throw std::invalid_argument("Found unsupported array type"));
 #undef MAKE_HOMOGEN_TABLE
@@ -206,7 +209,9 @@ dal::table convert_to_table(PyObject *obj) {
                                      np_row_indices,    \
                                      row_count,         \
                                      column_count);
+        std::cout << "Type: " << array_type(np_data) << " Elsize: " << array_type_sizeof(np_data) << std::endl;
         SET_NPY_FEATURE(array_type(np_data),
+                        array_type_sizeof(np_data),
                         MAKE_CSR_TABLE,
                         throw std::invalid_argument("Found unsupported data type in csr_matrix"));
 #undef MAKE_CSR_TABLE

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -18,7 +18,6 @@
 
 #include <stdexcept>
 #include <string>
-#include <iostream>
 
 #include "oneapi/dal/table/homogen.hpp"
 #include "oneapi/dal/table/detail/homogen_utils.hpp"
@@ -154,7 +153,6 @@ dal::table convert_to_table(PyObject *obj) {
     if (is_array(obj)) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
         if (array_is_behaved(ary) || array_is_behaved_F(ary)) {
-        std::cout << "Type: " << PyArray_DESCR(ary)->type << " Elsize: " << PyArray_DESCR(ary)->elsize << std::endl;
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
             SET_NPY_FEATURE(PyArray_DESCR(ary)->type,
                             PyArray_DESCR(ary)->elsize,
@@ -209,7 +207,6 @@ dal::table convert_to_table(PyObject *obj) {
                                      np_row_indices,    \
                                      row_count,         \
                                      column_count);
-        std::cout << "Type: " << array_type(np_data) << " Elsize: " << array_type_sizeof(np_data) << std::endl;
         SET_NPY_FEATURE(array_type(np_data),
                         array_type_sizeof(np_data),
                         MAKE_CSR_TABLE,

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -154,8 +154,8 @@ dal::table convert_to_table(PyObject *obj) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
         if (array_is_behaved(ary) || array_is_behaved_F(ary)) {
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
-            SET_NPY_FEATURE(PyArray_DESCR(ary)->type,
-                            PyArray_DESCR(ary)->elsize,
+            SET_NPY_FEATURE(array_type(ary),
+                            array_type_sizeof(ary),
                             MAKE_HOMOGEN_TABLE,
                             throw std::invalid_argument("Found unsupported array type"));
 #undef MAKE_HOMOGEN_TABLE

--- a/onedal/datatypes/data_conversion_dpctl.cpp
+++ b/onedal/datatypes/data_conversion_dpctl.cpp
@@ -108,6 +108,7 @@ dal::table convert_from_dptensor(py::object obj) {
     auto tensor = pybind11::cast<dpctl::tensor::usm_ndarray>(obj);
 
     const auto type = tensor.get_typenum();
+    const auto elsize = tensor.get_elemsize();
 
     dal::table res{};
 
@@ -115,6 +116,7 @@ dal::table convert_from_dptensor(py::object obj) {
     res = convert_to_homogen_impl<CType>(obj, tensor);
 
     SET_NPY_FEATURE(type,
+                    elsize,
                     MAKE_HOMOGEN_TABLE, //
                     report_problem_from_dptensor(": unknown data type"));
 

--- a/onedal/datatypes/data_conversion_dpctl.cpp
+++ b/onedal/datatypes/data_conversion_dpctl.cpp
@@ -108,7 +108,6 @@ dal::table convert_from_dptensor(py::object obj) {
     auto tensor = pybind11::cast<dpctl::tensor::usm_ndarray>(obj);
 
     const auto type = tensor.get_typenum();
-    const auto elsize = tensor.get_elemsize();
 
     dal::table res{};
 
@@ -116,7 +115,6 @@ dal::table convert_from_dptensor(py::object obj) {
     res = convert_to_homogen_impl<CType>(obj, tensor);
 
     SET_NPY_FEATURE(type,
-                    elsize,
                     MAKE_HOMOGEN_TABLE, //
                     report_problem_from_dptensor(": unknown data type"));
 

--- a/onedal/datatypes/numpy_helpers.hpp
+++ b/onedal/datatypes/numpy_helpers.hpp
@@ -65,7 +65,7 @@
         default: _EXCEPTION;                                 \
     };
 
-#define SET_NPY_FEATURE(_T, _FUNCT, _EXCEPTION) \
+#define SET_NPY_FEATURE(_T, _S, _FUNCT, _EXCEPTION) \
     switch (_T) {                               \
         case NPY_FLOAT:                         \
         case NPY_CFLOAT:                        \
@@ -91,23 +91,34 @@
             _FUNCT(std::uint32_t);              \
             break;                              \
         }                                       \
-        case NPY_LONGLTR:                       \
         case NPY_LONGLONGLTR:                   \
         case NPY_INT64: {                       \
             _FUNCT(std::int64_t);               \
             break;                              \
         }                                       \
-        case NPY_ULONGLTR:                      \
         case NPY_ULONGLONGLTR:                  \
         case NPY_UINT64: {                      \
             _FUNCT(std::uint64_t);              \
             break;                              \
         }                                       \
+        case NPY_LONGLTR: {\
+            if (_S == 4) {_FUNCT(std::int32_t);} \
+            else if (_S == 8)  {_FUNCT(std::int64_t);} \
+            else {_EXCEPTION;} \
+            break; \
+        } \
+        case NPY_ULONGLTR: {\
+            if (_S == 4) {_FUNCT(std::uint32_t);} \
+            else if (_S == 8)  {_FUNCT(std::uint64_t);} \
+            else {_EXCEPTION;} \
+            break; \
+        }\
         default: _EXCEPTION;                    \
     };
 
 #define is_array(a)         ((a) && PyArray_Check(a))
 #define array_type(a)       PyArray_TYPE((PyArrayObject *)a)
+#define array_type_sizeof(a) PyArray_DESCR((PyArrayObject *)a)->elsize
 #define array_is_behaved(a) (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_behaved_F(a) \
     (PyArray_ISFARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)

--- a/onedal/datatypes/numpy_helpers.hpp
+++ b/onedal/datatypes/numpy_helpers.hpp
@@ -118,7 +118,7 @@
 
 #define is_array(a)         ((a) && PyArray_Check(a))
 #define array_type(a)       PyArray_TYPE((PyArrayObject *)a)
-#define array_type_sizeof(a) PyArray_DESCR((PyArrayObject *)a)->elsize
+#define array_type_sizeof(a) PyArray_ITEMSIZE((PyArrayObject *)a)
 #define array_is_behaved(a) (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_behaved_F(a) \
     (PyArray_ISFARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -19,6 +19,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from onedal import _backend
+from onedal.datatypes import from_table, to_table
 from onedal.primitives import linear_kernel
 from onedal.tests.utils._device_selection import get_queues
 
@@ -142,6 +143,19 @@ def _test_input_format_f_contiguous_pandas(queue, dtype):
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_f_contiguous_pandas(queue, dtype):
     _test_input_format_f_contiguous_pandas(queue, dtype)
+
+
+def _test_conversion_to_table(dtype):
+    x = np.random.randint(0, 10, (15, 3), dtype=dtype)
+    x_table = to_table(x)
+    x2 = from_table(x_table)
+    assert x.dtype == x2.dtype
+    assert np.array_equal(x, x2)
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_conversion_to_table(dtype):
+    _test_conversion_to_table(dtype)
 
 
 # TODO:

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -146,14 +146,18 @@ def test_input_format_f_contiguous_pandas(queue, dtype):
 
 
 def _test_conversion_to_table(dtype):
-    x = np.random.randint(0, 10, (15, 3), dtype=dtype)
+    np.random.seed()
+    if dtype in [np.int32, np.int64]:
+        x = np.random.randint(0, 10, (15, 3), dtype=dtype)
+    else:
+        x = np.random.uniform(-2, 2, (18, 6)).astype(dtype)
     x_table = to_table(x)
     x2 = from_table(x_table)
     assert x.dtype == x2.dtype
     assert np.array_equal(x, x2)
 
 
-@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
 def test_conversion_to_table(dtype):
     _test_conversion_to_table(dtype)
 


### PR DESCRIPTION
### Description 
np.int32 type is considered as NPY_INTLTR on linux and as NPY_LONGLTR on windows. Because of that numpy array with type np.int32 was incorrectly converted to table with type std::int64_t which lead to data corruption. In this PR we take sizeof of numpy array element into account for correct conversion. Also a new test was added to ensure that this change helps to overcome described issue.
