### PR TITLE
[testing] deselect PCA from test_run_to_run_stability::test_standard_estimator_stability

### DIFF
--- a/sklearnex/tests/test_run_to_run_stability.py
+++ b/sklearnex/tests/test_run_to_run_stability.py
@@ -151,7 +151,6 @@ def test_standard_estimator_stability(estimator, method, dataframe, queue):
     if estimator in ["KMeans", "PCA"] and method == "score" and queue == None:
         pytest.skip(f"variation observed in {estimator}.score")
 
-
     est = PATCHED_MODELS[estimator]()
 
     if method and not hasattr(est, method):

--- a/sklearnex/tests/test_run_to_run_stability.py
+++ b/sklearnex/tests/test_run_to_run_stability.py
@@ -148,8 +148,9 @@ STABILITY_INSTANCES = _sklearn_clone_dict(
 def test_standard_estimator_stability(estimator, method, dataframe, queue):
     if estimator in ["LogisticRegression", "TSNE"]:
         pytest.skip(f"stability not guaranteed for {estimator}")
-    if "KMeans" in estimator and method == "score" and queue == None:
-        pytest.skip(f"variation observed in KMeans.score")
+    if estimator in ["KMeans", "PCA"] and method == "score" and queue == None:
+        pytest.skip(f"variation observed in {estimator}.score")
+
 
     est = PATCHED_MODELS[estimator]()
 


### PR DESCRIPTION
### Description 
Currently an intermittent deviation is observed with the PCA score method with numpy inputs. The variation is of the order of 1e-14.  This deselects that test via a pytest.skip, and will be addressed by future work.  This has recently come about due to expanded testing introduced in the refactor of test_run_to_run_stability ( #1827 ).  This only impacts numpy.
