### PR TITLE
[bug] fix windows build failure for Azure Pipelines

### DIFF
--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -36,6 +36,7 @@ steps:
       set PREFIX=%CONDA_PREFIX%
       set PYTHON=python
       call conda-recipe\bld.bat
+      IF %ERRORLEVEL% neq 0 EXIT /b %ERRORLEVEL%
       set DALROOT=%CONDA_PREFIX%
       python setup_sklearnex.py install --single-version-externally-managed --record=record_sklearnex.txt
     displayName: 'Build daal4py/sklearnex'

--- a/onedal/common/dispatch_utils.hpp
+++ b/onedal/common/dispatch_utils.hpp
@@ -50,7 +50,7 @@ struct fptype2t {
         ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(fptype);
     }
 
-    Ops ops;
+    Ops ops
 };
 
 template <typename Policy, typename Input, typename Ops>

--- a/onedal/common/dispatch_utils.hpp
+++ b/onedal/common/dispatch_utils.hpp
@@ -50,7 +50,7 @@ struct fptype2t {
         ONEDAL_PARAM_DISPATCH_THROW_INVALID_VALUE(fptype);
     }
 
-    Ops ops
+    Ops ops;
 };
 
 template <typename Policy, typename Input, typename Ops>


### PR DESCRIPTION
### Description 
Adds an error level check to properly fail the azure pipelines step when building daal4py/onedal fails. Includes an error so that onedal won't properly build.


