### PR TITLE
[bug] fix KMeans preview patching

### DIFF
--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -64,7 +64,7 @@ def get_patch_map_core(preview=False):
             sklearn_obj = mapping["kmeans"][0][1]
             mapping.pop("kmeans")
             mapping["kmeans"] = [
-                [(cluster_module, "kmeans", KMeans_sklearnex), sklearn_obj]
+                [(cluster_module, "KMeans", KMeans_sklearnex), sklearn_obj]
             ]
 
             # Covariance


### PR DESCRIPTION
### Description 
I introduced a bug in #1678 which improperly patched KMeans in preview. The sklearn.cluster namespace doesn't have "kmeans" but instead "KMeans". Found by @DDJHB 
