### PR TITLE
[testing] sklearn 1.5 conformance update

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -380,6 +380,12 @@ deselected_tests:
   # There are not enough data to run onedal backend
   - tests/test_common.py::test_estimators[IncrementalLinearRegression()-check_fit2d_1sample]
 
+  # Deselection of LogisticRegression tests over accuracy comparisons with sample_weights
+  # and without.  Because scikit-learn-intelex does not support sample_weights, it's doing
+  # a fallback to scikit-learn in one case and not in the other, and needs to be investigated.
+  - model_selection/tests/test_classification_threshold.py::test_fit_and_score_over_thresholds_sample_weight >=1.5
+  - model_selection/tests/test_classification_threshold.py::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence >= 1.5
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:
@@ -568,6 +574,7 @@ gpu:
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_estimators_nan_inf]
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_estimators_overwrite_params]
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_estimators_pickle(readonly_memmap=True)]
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_methods_sample_order_invariance]
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_methods_subset_invariance]
   - tests/test_common.py::test_estimators[BayesianGaussianMixture()-check_fit2d_1feature]
@@ -587,6 +594,7 @@ gpu:
   - tests/test_common.py::test_estimators[GaussianMixture()-check_estimators_nan_inf]
   - tests/test_common.py::test_estimators[GaussianMixture()-check_estimators_overwrite_params]
   - tests/test_common.py::test_estimators[GaussianMixture()-check_estimators_pickle]
+  - tests/test_common.py::test_estimators[GaussianMixture()-check_estimators_pickle(readonly_memmap=True)]
   - tests/test_common.py::test_estimators[GaussianMixture()-check_methods_sample_order_invariance]
   - tests/test_common.py::test_estimators[GaussianMixture()-check_methods_subset_invariance]
   - tests/test_common.py::test_estimators[GaussianMixture()-check_fit2d_1feature]

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -384,7 +384,7 @@ deselected_tests:
   # and without.  Because scikit-learn-intelex does not support sample_weights, it's doing
   # a fallback to scikit-learn in one case and not in the other, and needs to be investigated.
   - model_selection/tests/test_classification_threshold.py::test_fit_and_score_over_thresholds_sample_weight >=1.5
-  - model_selection/tests/test_classification_threshold.py::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence >= 1.5
+  - model_selection/tests/test_classification_threshold.py::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence >=1.5
 
   # --------------------------------------------------------
   # No need to test daal4py patching

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -196,7 +196,11 @@ if daal_check_version((2024, "P", 1)):
                 f"sklearn.linear_model.{class_name}.fit"
             )
 
-            target = type_of_target(y, input_name="y") if sklearn_check_version("1.1") else type_of_target(y)
+            target = (
+                type_of_target(y, input_name="y")
+                if sklearn_check_version("1.1")
+                else type_of_target(y)
+            )
             dal_ready = patching_status.and_conditions(
                 [
                     (self.penalty == "l2", "Only l2 penalty is supported."),

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -198,7 +198,7 @@ if daal_check_version((2024, "P", 1)):
                 f"sklearn.linear_model.{class_name}.fit"
             )
 
-            target = (
+            target_type = (
                 type_of_target(y, input_name="y")
                 if sklearn_check_version("1.1")
                 else type_of_target(y)
@@ -221,7 +221,7 @@ if daal_check_version((2024, "P", 1)):
                     (self.l1_ratio is None, "l1 ratio is not supported."),
                     (sample_weight is None, "Sample weight is not supported."),
                     (
-                        target == "binary",
+                        target_type == "binary",
                         "Only binary classification is supported",
                     ),
                 ]

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -188,7 +188,7 @@ if daal_check_version((2024, "P", 1)):
 
         def _onedal_gpu_fit_supported(self, method_name, *data):
             assert method_name == "fit"
-            X, y, sample_weight = data if len(data) == 3 else data[0], data[1], None
+            X, y, sample_weight = data if len(data) == 3 else (*data, None)
 
             class_name = self.__class__.__name__
             patching_status = PatchingConditionsChain(

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -116,7 +116,7 @@ if daal_check_version((2024, "P", 1)):
                 },
                 X,
                 y,
-                sample_weight=sample_weight,
+                sample_weight,
             )
             return self
 
@@ -188,7 +188,8 @@ if daal_check_version((2024, "P", 1)):
 
         def _onedal_gpu_fit_supported(self, method_name, *data):
             assert method_name == "fit"
-            X, y, sample_weight = data if len(data) == 3 else (*data, None)
+            assert len(data) == 3
+            X, y, sample_weight = data
 
             class_name = self.__class__.__name__
             patching_status = PatchingConditionsChain(

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -196,6 +196,7 @@ if daal_check_version((2024, "P", 1)):
                 f"sklearn.linear_model.{class_name}.fit"
             )
 
+            target = type_of_target(y, input_name="y") if sklearn_check_version("1.1") else type_of_target(y)
             dal_ready = patching_status.and_conditions(
                 [
                     (self.penalty == "l2", "Only l2 penalty is supported."),
@@ -214,7 +215,7 @@ if daal_check_version((2024, "P", 1)):
                     (self.l1_ratio is None, "l1 ratio is not supported."),
                     (sample_weight is None, "Sample weight is not supported."),
                     (
-                        type_of_target(y) == "binary",
+                        target == "binary",
                         "Only binary classification is supported",
                     ),
                 ]

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -107,6 +107,8 @@ if daal_check_version((2024, "P", 1)):
         _onedal_cpu_fit = daal4py_fit
 
         def fit(self, X, y, sample_weight=None):
+            if sklearn_check_version("1.2"):
+                self._validate_params()
             dispatch(
                 self,
                 "fit",
@@ -316,9 +318,6 @@ if daal_check_version((2024, "P", 1)):
                 X, y = self._validate_data(X, y, dtype=[np.float64, np.float32])
             else:
                 X, y = check_X_y(X, y, dtype=[np.float64, np.float32])
-
-            if sklearn_check_version("1.2"):
-                self._validate_params()
 
             self._initialize_onedal_estimator()
             try:

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -120,7 +120,7 @@ if daal_check_version((2024, "P", 1)):
                 },
                 X,
                 y,
-                sample_weight,
+                sample_weight=sample_weight,
             )
             return self
 
@@ -313,24 +313,16 @@ if daal_check_version((2024, "P", 1)):
             }
             self._onedal_estimator = onedal_LogisticRegression(**onedal_params)
 
-        def _onedal_fit(self, X, y, sample_weight, queue=None):
+        def _onedal_fit(self, X, y, sample_weight=None, queue=None):
             if queue is None or queue.sycl_device.is_cpu:
                 return self._onedal_cpu_fit(X, y, sample_weight)
 
             assert sample_weight is None
 
-            check_params = {
-                "X": X,
-                "y": y,
-                "dtype": [np.float64, np.float32],
-                "accept_sparse": False,
-                "multi_output": False,
-                "force_all_finite": True,
-            }
             if sklearn_check_version("1.2"):
-                X, y = self._validate_data(**check_params)
+                X, y = self._validate_data(X, y, dtype=[np.float64, np.float32])
             else:
-                X, y = check_X_y(**check_params)
+                X, y = check_X_y(X, y, dtype=[np.float64, np.float32])
             self._initialize_onedal_estimator()
             try:
                 self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -188,7 +188,7 @@ if daal_check_version((2024, "P", 1)):
 
         def _onedal_gpu_fit_supported(self, method_name, *data):
             assert method_name == "fit"
-            X, y = data[0], data[1]
+            X, y, sample_weight = data if len(data) == 3 else data[0], data[1], None
 
             class_name = self.__class__.__name__
             patching_status = PatchingConditionsChain(


### PR DESCRIPTION
Deselections for sklearn 1.5, and GPU related tests for sklearn 1.3. LogisticRegression does not return the proper error when checking type_of_target, where a new test was introduced in sklearn 1.3 - tests/test_common.py::test_estimators[Pipeline(steps=[('scaler',StandardScaler()),('final_estimator',LogisticRegression())])-check_supervised_y_no_nan]  This PR contains fixes for this test.