### PR TITLE
Fix for Logistic Regression loss scaling

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -424,6 +424,10 @@ def __logistic_regression_path(
                 (classes.size, n_features + int(fit_intercept)), order="F", dtype=X.dtype
             )
 
+    # Adoption of https://github.com/scikit-learn/scikit-learn/pull/26721
+    if solver in ["lbfgs", "newton-cg", "newton-cholesky"]:
+        sw_sum = len(X) if sample_weight is None else np.sum(sample_weight)
+
     if coef is not None:
         # it must work both giving the bias term and not
         if multi_class == "ovr":
@@ -590,7 +594,7 @@ def __logistic_regression_path(
                     X,
                     target,
                     0.0,
-                    1.0 / (2 * C * C_daal_multiplier),
+                    1.0 / (2 * C * C_daal_multiplier * sw_sum),
                     fit_intercept,
                     value=True,
                     gradient=True,
@@ -598,10 +602,10 @@ def __logistic_regression_path(
                 )
             else:
                 if sklearn_check_version("1.1"):
-                    l2_reg_strength = 1.0 / C
+                    l2_reg_strength = 1.0 / (C * sw_sum)
                     extra_args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
-                    extra_args = (X, target, 1.0 / C, sample_weight)
+                    extra_args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 
             iprint = [-1, 50, 1, 100, 101][
                 np.searchsorted(np.array([0, 1, 2, 3]), verbose)
@@ -612,7 +616,13 @@ def __logistic_regression_path(
                 method="L-BFGS-B",
                 jac=True,
                 args=extra_args,
-                options={"iprint": iprint, "gtol": tol, "maxiter": max_iter},
+                options={
+                    "maxiter": max_iter,
+                    "maxls": 50,
+                    "iprint": iprint,
+                    "gtol": tol,
+                    "ftol": 64 * np.finfo(float).eps,
+                },
             )
             n_iter_i = _check_optimize_result(
                 solver,
@@ -627,7 +637,7 @@ def __logistic_regression_path(
             if _dal_ready:
 
                 def make_ncg_funcs(f, value=False, gradient=False, hessian=False):
-                    daal_penaltyL2 = 1.0 / (2 * C * C_daal_multiplier)
+                    daal_penaltyL2 = 1.0 / (2 * C * C_daal_multiplier * sw_sum)
                     _obj_, X_, y_, n_samples = daal_extra_args_func(
                         classes.size,
                         w0,
@@ -660,10 +670,10 @@ def __logistic_regression_path(
                 )
             else:
                 if sklearn_check_version("1.1"):
-                    l2_reg_strength = 1.0 / C
+                    l2_reg_strength = 1.0 / (C * sw_sum)
                     args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
-                    args = (X, target, 1.0 / C, sample_weight)
+                    args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 
                 w0, n_iter_i = _newton_cg(
                     hess, func, grad, w0, args=args, maxiter=max_iter, tol=tol

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -190,6 +190,13 @@ deselected_tests:
   # margin above the test threshold, see https://github.com/scikit-learn/scikit-learn/pull/13645
   - linear_model/tests/test_logistic.py::test_dtype_match
 
+  # Logistic Regression coeffs change due to fix for loss scaling
+  # (https://github.com/scikit-learn/scikit-learn/pull/26721)
+  - feature_selection/tests/test_from_model.py::test_importance_getter[estimator0-named_steps.logisticregression.coef_]
+  - inspection/_plot/tests/test_boundary_decision_display.py::test_class_of_interest_binary[predict_proba]
+  - linear_model/tests/test_sag.py::test_sag_pobj_matches_logistic_regression[csr_matrix]
+  - linear_model/tests/test_sag.py::test_sag_pobj_matches_logistic_regression[csr_array]
+
   # This fails on certain platforms. While weighted data does not go through DAAL,
   # unweighted does. Since convergence does not occur (comment in the test
   # suggests that) and because coefficients are slightly different,

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -194,8 +194,7 @@ deselected_tests:
   # (https://github.com/scikit-learn/scikit-learn/pull/26721)
   - feature_selection/tests/test_from_model.py::test_importance_getter[estimator0-named_steps.logisticregression.coef_]
   - inspection/_plot/tests/test_boundary_decision_display.py::test_class_of_interest_binary[predict_proba]
-  - linear_model/tests/test_sag.py::test_sag_pobj_matches_logistic_regression[csr_matrix]
-  - linear_model/tests/test_sag.py::test_sag_pobj_matches_logistic_regression[csr_array]
+  - linear_model/tests/test_sag.py::test_sag_pobj_matches_logistic_regression
 
   # This fails on certain platforms. While weighted data does not go through DAAL,
   # unweighted does. Since convergence does not occur (comment in the test


### PR DESCRIPTION
### Description 

Solves https://github.com/autogluon/autogluon/issues/4280.

LogReg loss scaling was changed from 1.3 to 1.4 sklearn version in https://github.com/scikit-learn/scikit-learn/pull/26721 resulting in worse convergence of sklearnex LogReg compared to stock sklearn and appearing in mentioned AutoGluon issue.
Sklearnex LogReg coefficient became different due to change of convergence way, so few deselections of tests are needed because of that.

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

