### PR TITLE
FIX: align sklearnex `BasicStatistics._onedal_fit` with other algos

### DIFF
--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -91,7 +91,7 @@ class BasicStatistics(BaseEstimator):
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):
         if sklearn_check_version("1.0"):
-            X = self._validate_data(X, dtype=[np.float64, np.float32])
+            X = self._validate_data(X, dtype=[np.float64, np.float32], ensure_2d=False)
         else:
             X = check_array(X, dtype=[np.float64, np.float32])
 

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -16,8 +16,11 @@
 
 import numpy as np
 from sklearn.base import BaseEstimator
+from sklearn.utils import check_array
+from sklearn.utils.validation import _check_sample_weight
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
+from daal4py.sklearn._utils import sklearn_check_version
 from onedal.basic_statistics import BasicStatistics as onedal_BasicStatistics
 
 from .._device_offload import dispatch
@@ -87,6 +90,14 @@ class BasicStatistics(BaseEstimator):
     _onedal_gpu_supported = _onedal_supported
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):
+        if sklearn_check_version("1.0"):
+            X = self._validate_data(X, dtype=[np.float64, np.float32])
+        else:
+            X = check_array(X, dtype=[np.float64, np.float32])
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
+        
         onedal_params = {
             "result_options": self.options,
         }

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -97,7 +97,7 @@ class BasicStatistics(BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
-        
+
         onedal_params = {
             "result_options": self.options,
         }


### PR DESCRIPTION
### Description 
Follow up to https://github.com/intel/scikit-learn-intelex/pull/1644. Specifically, aligns directly with https://github.com/intel/scikit-learn-intelex/blob/main/sklearnex/basic_statistics/incremental_basic_statistics.py#L178-L184

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

