### PR TITLE
[fix] remove `_test_type_and_finiteness` method from `LinearRegression` and `LogisticRegression`

### DIFF
--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -27,7 +27,6 @@ from daal4py.sklearn._utils import sklearn_check_version
 
 from .._device_offload import dispatch, wrap_output_data
 from .._utils import PatchingConditionsChain, get_patch_message, register_hyperparameters
-from ..utils.validation import _assert_all_finite
 
 if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -182,7 +182,7 @@ class LinearRegression(sklearn_LinearRegression):
         if not dal_ready:
             return patching_status
 
-        patching_status.and_condition(
+        patching_status.and_conditions(
             [
                 (not np.iscomplexobj(X), "Input X is not supported."),
                 (not np.iscomplexobj(y), "Input y is not supported."),

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -213,7 +213,7 @@ class LinearRegression(sklearn_LinearRegression):
             return patching_status
 
         patching_status.and_condition(
-            self._test_type_and_finiteness(data[0]), "Input X is not supported."
+            not np.iscomplexobj(data[0]), "Input X is not supported."
         )
 
         return patching_status
@@ -242,7 +242,6 @@ class LinearRegression(sklearn_LinearRegression):
             "accept_sparse": ["csr", "csc", "coo"],
             "y_numeric": True,
             "multi_output": True,
-            "force_all_finite": False,
         }
         if sklearn_check_version("1.2"):
             X, y = self._validate_data(**check_params)

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -160,7 +160,7 @@ class LinearRegression(sklearn_LinearRegression):
         # Check if equations are well defined
         is_underdetermined = n_samples < (n_features + int(self.fit_intercept))
 
-        dal_ready = patching_status.and_conditions(
+        patching_status.and_conditions(
             [
                 (sample_weight is None, "Sample weight is not supported."),
                 (
@@ -177,15 +177,6 @@ class LinearRegression(sklearn_LinearRegression):
                     "The shape of X (fitting) does not satisfy oneDAL requirements:"
                     "Number of features + 1 >= number of samples.",
                 ),
-            ]
-        )
-        if not dal_ready:
-            return patching_status
-
-        patching_status.and_conditions(
-            [
-                (not np.iscomplexobj(X), "Input X is not supported."),
-                (not np.iscomplexobj(y), "Input y is not supported."),
             ]
         )
 

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -138,19 +138,6 @@ class LinearRegression(sklearn_LinearRegression):
             sample_weight=sample_weight,
         )
 
-    def _test_type_and_finiteness(self, X_in):
-        X = X_in if isinstance(X_in, np.ndarray) else np.asarray(X_in)
-
-        dtype = X.dtype
-        if "complex" in str(type(dtype)):
-            return False
-
-        try:
-            _assert_all_finite(X)
-        except BaseException:
-            return False
-        return True
-
     def _onedal_fit_supported(self, method_name, *data):
         assert method_name == "fit"
         assert len(data) == 3
@@ -196,13 +183,11 @@ class LinearRegression(sklearn_LinearRegression):
         if not dal_ready:
             return patching_status
 
-        if not patching_status.and_condition(
-            self._test_type_and_finiteness(X), "Input X is not supported."
-        ):
-            return patching_status
-
         patching_status.and_condition(
-            self._test_type_and_finiteness(y), "Input y is not supported."
+            [
+                (not np.iscomplexobj(X), "Input X is not supported."),
+                (not np.iscomplexobj(y), "Input y is not supported."),
+            ]
         )
 
         return patching_status

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -192,18 +192,12 @@ class LinearRegression(sklearn_LinearRegression):
         model_is_sparse = issparse(self.coef_) or (
             self.fit_intercept and issparse(self.intercept_)
         )
-        dal_ready = patching_status.and_conditions(
+        patching_status.and_conditions(
             [
                 (n_samples > 0, "Number of samples is less than 1."),
                 (not issparse(data[0]), "Sparse input is not supported."),
                 (not model_is_sparse, "Sparse coefficients are not supported."),
             ]
-        )
-        if not dal_ready:
-            return patching_status
-
-        patching_status.and_condition(
-            not np.iscomplexobj(data[0]), "Input X is not supported."
         )
 
         return patching_status

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -263,7 +263,7 @@ if daal_check_version((2024, "P", 1)):
                 return patching_status
 
             patching_status.and_condition(
-                self._test_type_and_finiteness(*data), "Input X is not supported."
+                not np.iscomplexobj(*data), "Input X is not supported."
             )
 
             return patching_status

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -215,16 +215,6 @@ if daal_check_version((2024, "P", 1)):
                 ]
             )
 
-            if not dal_ready:
-                return patching_status
-
-            patching_status.and_conditions(
-                [
-                    (not np.iscomplexobj(X), "Input X is not supported."),
-                    (not np.iscomplexobj(y), "Input y is not supported."),
-                ]
-            )
-
             return patching_status
 
         def _onedal_gpu_predict_supported(self, method_name, *data):
@@ -257,12 +247,6 @@ if daal_check_version((2024, "P", 1)):
                         "oneDAL model was not trained.",
                     ),
                 ]
-            )
-            if not dal_ready:
-                return patching_status
-
-            patching_status.and_condition(
-                not np.iscomplexobj(*data), "Input X is not supported."
             )
 
             return patching_status

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -38,7 +38,6 @@ if daal_check_version((2024, "P", 1)):
 
     from .._device_offload import dispatch, wrap_output_data
     from .._utils import PatchingConditionsChain, get_patch_message
-    from ..utils.validation import _assert_all_finite
 
     class BaseLogisticRegression(ABC):
         def _save_attributes(self):

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -191,7 +191,7 @@ if daal_check_version((2024, "P", 1)):
                 if sklearn_check_version("1.1")
                 else type_of_target(y)
             )
-            dal_ready = patching_status.and_conditions(
+            patching_status.and_conditions(
                 [
                     (self.penalty == "l2", "Only l2 penalty is supported."),
                     (self.dual == False, "dual=True is not supported."),

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -218,7 +218,7 @@ if daal_check_version((2024, "P", 1)):
             if not dal_ready:
                 return patching_status
 
-            patching_status.and_condition(
+            patching_status.and_conditions(
                 [
                     (not np.iscomplexobj(X), "Input X is not supported."),
                     (not np.iscomplexobj(y), "Input y is not supported."),

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -177,17 +177,6 @@ if daal_check_version((2024, "P", 1)):
                 y, self._onedal_predict(X, queue=queue), sample_weight=sample_weight
             )
 
-        def _test_type_and_finiteness(self, X_in):
-            X = np.asarray(X_in)
-
-            if np.iscomplexobj(X):
-                return False
-            try:
-                _assert_all_finite(X)
-            except BaseException:
-                return False
-            return True
-
         def _onedal_gpu_fit_supported(self, method_name, *data):
             assert method_name == "fit"
             assert len(data) == 3
@@ -230,13 +219,11 @@ if daal_check_version((2024, "P", 1)):
             if not dal_ready:
                 return patching_status
 
-            if not patching_status.and_condition(
-                self._test_type_and_finiteness(X), "Input X is not supported."
-            ):
-                return patching_status
-
             patching_status.and_condition(
-                self._test_type_and_finiteness(y), "Input y is not supported."
+                [
+                    (not np.iscomplexobj(X), "Input X is not supported."),
+                    (not np.iscomplexobj(y), "Input y is not supported."),
+                ]
             )
 
             return patching_status


### PR DESCRIPTION
### Description 
This PR removes the _type_and_finiteness method from LinearRegression and LogisticRegression. This checks for finiteness and if it is a complex valued object.  The finite check was duplicated for the predict method in these estimators, and in cases that sklearnex fell back to sklearn for evaluation. In both of these estimators (in sklearn) require finiteness to operate, and is not necessary for the onedal_support check. The estimator should fail just as is the case for sklearn.

Complex numbers are not supported in sklearn or sklearnex, so it should just fail at a standard check_array or validate_data call.  This call can also be removed (not sure why it was included in the first place).

Therefore the entire check can be removed from both estimators.

This was first found and discussed in #1843.

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

