### PR TITLE
ENH: Renamed layout check macro for np.array, changed default layout for oneDAL table

### DIFF
--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -81,7 +81,8 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
         column_count = static_cast<std::int64_t>(array_size(np_data, 1));
     }
     // If both array_is_behaved_C(np_data) and array_is_behaved_F(np_data) are true 
-    // (for example, if the array has only one column), then row-major layout will be chosen.
+    // (for example, if the array has only one column), then row-major layout will be chosen
+    // which is default on oneDAL side.
     const auto layout =
         array_is_behaved_C(np_data) ? dal::data_layout::row_major : dal::data_layout::column_major;
     auto res_table = dal::homogen_table(data_pointer,

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -81,7 +81,7 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
         column_count = static_cast<std::int64_t>(array_size(np_data, 1));
     }
     const auto layout =
-        array_is_behaved_F(np_data) ? dal::data_layout::column_major : dal::data_layout::row_major;
+        array_is_behaved_C(np_data) ? dal::data_layout::row_major : dal::data_layout::column_major;
     auto res_table = dal::homogen_table(data_pointer,
                                         row_count,
                                         column_count,
@@ -152,7 +152,7 @@ dal::table convert_to_table(PyObject *obj) {
     }
     if (is_array(obj)) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
-        if (array_is_behaved(ary) || array_is_behaved_F(ary)) {
+        if (array_is_behaved_C(ary) || array_is_behaved_F(ary)) {
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
             SET_NPY_FEATURE(array_type(ary),
                             array_type_sizeof(ary),

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -80,6 +80,8 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
         // TODO: check safe cast from int to std::int64_t
         column_count = static_cast<std::int64_t>(array_size(np_data, 1));
     }
+    // If both array_is_behaved_C(np_data) and array_is_behaved_F(np_data) are true 
+    // (for example, if the array has only one column), then row-major layout will be chosen.
     const auto layout =
         array_is_behaved_C(np_data) ? dal::data_layout::row_major : dal::data_layout::column_major;
     auto res_table = dal::homogen_table(data_pointer,

--- a/onedal/datatypes/numpy_helpers.hpp
+++ b/onedal/datatypes/numpy_helpers.hpp
@@ -119,7 +119,8 @@
 #define is_array(a)         ((a) && PyArray_Check(a))
 #define array_type(a)       PyArray_TYPE((PyArrayObject *)a)
 #define array_type_sizeof(a) PyArray_ITEMSIZE((PyArrayObject *)a)
-#define array_is_behaved(a) (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
+#define array_is_behaved_C(a) \
+    (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_behaved_F(a) \
     (PyArray_ISFARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_native(a) (PyArray_ISNOTSWAPPED((PyArrayObject *)a))

--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -35,7 +35,7 @@
 
 #define is_array(a)           ((a) && PyArray_Check(a))
 #define array_type(a)         PyArray_TYPE((PyArrayObject *)a)
-#define array_is_behaved(a)   (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
+#define array_is_behaved_C(a)   (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_behaved_F(a) (PyArray_ISFARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_native(a)    (PyArray_ISNOTSWAPPED((PyArrayObject *)a))
 #define array_numdims(a)      PyArray_NDIM((PyArrayObject *)a)
@@ -316,7 +316,7 @@ static daal::data_management::NumericTablePtr _make_hnt(PyObject * nda)
     daal::data_management::NumericTablePtr ptr;
     PyArrayObject * array = reinterpret_cast<PyArrayObject *>(nda);
 
-    assert(is_array(nda) && array_is_behaved(array));
+    assert(is_array(nda) && array_is_behaved_C(array));
 
     if (array_numdims(array) == 2)
     {
@@ -415,7 +415,7 @@ daal::data_management::NumericTablePtr make_nt(PyObject * obj)
         { // we got a numpy array
             PyArrayObject * ary = reinterpret_cast<PyArrayObject *>(obj);
 
-            if (array_is_behaved(ary))
+            if (array_is_behaved_C(ary))
             {
 #define MAKENT_(_T) ptr = _make_hnt<_T>(obj)
                 SET_NPY_FEATURE(PyArray_DESCR(ary)->type, MAKENT_, throw std::invalid_argument("Found unsupported array type"));
@@ -492,7 +492,7 @@ daal::data_management::NumericTablePtr make_nt(PyObject * obj)
                         throw std::runtime_error(std::string("Found wrong dimensionality (") + std::to_string(PyArray_NDIM(ary)) + ") of array in list when constructing SOA table (must be 1d)");
                     }
 
-                    if (!array_is_behaved(ary))
+                    if (!array_is_behaved_C(ary))
                     {
                         throw std::runtime_error(std::string("Cannot operate on column: ") + std::to_string(i) + "  because it is non-contiguous. Please make it contiguous before passing it to daal4py\n");
                     }


### PR DESCRIPTION
### Description 
* Renamed the layout check macro from `array_is_behaved` to `array_is_behaved_C` to be aligned with the opposite macro `array_is_behaved_F`.
* Changed layout choice in the case if source np.array is both C-contagious and F-contagious. Now C-style layout is chosen which is considered as default in our library.

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary.
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

