### PR TITLE
CI: deselect failing NuSVC tests

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -153,6 +153,8 @@ deselected_tests:
   # scikit-learn expects an exception for sparse matrices with 64-bit integer indices,
   # scikit-learn-intelex works correctly with 64-bit integer indices
   - tests/test_common.py::test_estimators[NuSVC()-check_estimator_sparse_data]
+  - tests/test_common.py::test_estimators[NuSVC()-check_estimator_sparse_array]
+  - tests/test_common.py::test_estimators[NuSVC()-check_estimator_sparse_matrix]
   - utils/tests/test_estimator_checks.py::test_xfail_ignored_in_check_estimator
 
   # SVC._dual_coef_ is changing after fitting, but the result of prediction is still the same


### PR DESCRIPTION
### Description 
TBD on root cause but could be linked to public CI seg faults, or existing deselection.

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

