### PR TITLE
[CI, testing] add SVM C and nu parameter check prevents seg fault sklearn < 1.2

### DIFF
--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -83,6 +83,8 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
+        elif self.nu <= 0 or self.nu > 1:
+            raise ValueError("nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -84,6 +84,15 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
+            # else if added to correct issues with 
+            # sklearn tests:
+            # svm/tests/test_sparse.py::test_error
+            # svm/tests/test_svm.py::test_bad_input
+            # for sklearn versions < 1.2 (i.e. without
+            # validate_params parameter checking)
+            # Without this, a segmentation fault with
+            # Windows fatal exception: access violation
+            # occurs
             raise ValueError("nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -84,7 +84,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
-            raise ValueError("Margin error upper bound outside range: nu <= 0 or nu > 1")
+            raise ValueError("nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -84,7 +84,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
-            # else if added to correct issues with 
+            # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
             # svm/tests/test_svm.py::test_bad_input

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -84,7 +84,7 @@ class NuSVC(sklearn_NuSVC, BaseSVC):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
-            raise ValueError("nu <= 0 or nu > 1")
+            raise ValueError("Margin error upper bound outside range: nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -67,7 +67,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
             raise ValueError("nu <= 0 or nu > 1")
-            # else if added to correct issues with 
+            # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
             # svm/tests/test_svm.py::test_bad_input

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -66,7 +66,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
-            raise ValueError("Margin error upper bound outside range: nu <= 0 or nu > 1")
+            raise ValueError("nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -66,7 +66,6 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
-            raise ValueError("nu <= 0 or nu > 1")
             # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
@@ -76,6 +75,7 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             # Without this, a segmentation fault with
             # Windows fatal exception: access violation
             # occurs
+            raise ValueError("nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -67,6 +67,15 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
             self._validate_params()
         elif self.nu <= 0 or self.nu > 1:
             raise ValueError("nu <= 0 or nu > 1")
+            # else if added to correct issues with 
+            # sklearn tests:
+            # svm/tests/test_sparse.py::test_error
+            # svm/tests/test_svm.py::test_bad_input
+            # for sklearn versions < 1.2 (i.e. without
+            # validate_params parameter checking)
+            # Without this, a segmentation fault with
+            # Windows fatal exception: access violation
+            # occurs
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -65,6 +65,8 @@ class NuSVR(sklearn_NuSVR, BaseSVR):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
+        elif self.nu <= 0 or self.nu > 1:
+            raise ValueError("Margin error upper bound outside range: nu <= 0 or nu > 1")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -87,7 +87,6 @@ class SVC(sklearn_SVC, BaseSVC):
             self._validate_params()
         elif self.C < 0:
             raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
-            
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -85,6 +85,9 @@ class SVC(sklearn_SVC, BaseSVC):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
+        elif self.C < 0:
+            raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
+            
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -87,6 +87,15 @@ class SVC(sklearn_SVC, BaseSVC):
             self._validate_params()
         elif self.C <= 0:
             raise ValueError("C <= 0")
+            # else if added to correct issues with 
+            # sklearn tests:
+            # svm/tests/test_sparse.py::test_error
+            # svm/tests/test_svm.py::test_bad_input
+            # for sklearn versions < 1.2 (i.e. without
+            # validate_params parameter checking)
+            # Without this, a segmentation fault with
+            # Windows fatal exception: access violation
+            # occurs
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -85,8 +85,8 @@ class SVC(sklearn_SVC, BaseSVC):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
-        elif self.C < 0:
-            raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
+        elif self.C <= 0:
+            raise ValueError("C <= 0")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -86,7 +86,6 @@ class SVC(sklearn_SVC, BaseSVC):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.C <= 0:
-            raise ValueError("C <= 0")
             # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
@@ -96,6 +95,7 @@ class SVC(sklearn_SVC, BaseSVC):
             # Without this, a segmentation fault with
             # Windows fatal exception: access violation
             # occurs
+            raise ValueError("C <= 0")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -87,7 +87,7 @@ class SVC(sklearn_SVC, BaseSVC):
             self._validate_params()
         elif self.C <= 0:
             raise ValueError("C <= 0")
-            # else if added to correct issues with 
+            # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
             # svm/tests/test_svm.py::test_bad_input

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -65,6 +65,8 @@ class SVR(sklearn_SVR, BaseSVR):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
+        elif self.C < 0:
+            raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -65,8 +65,8 @@ class SVR(sklearn_SVR, BaseSVR):
     def fit(self, X, y, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
-        elif self.C < 0:
-            raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
+        elif self.C <= 0:
+            raise ValueError("C <= 0")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)
         dispatch(

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -66,6 +66,15 @@ class SVR(sklearn_SVR, BaseSVR):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.C <= 0:
+            # else if added to correct issues with 
+            # sklearn tests:
+            # svm/tests/test_sparse.py::test_error
+            # svm/tests/test_svm.py::test_bad_input
+            # for sklearn versions < 1.2 (i.e. without
+            # validate_params parameter checking)
+            # Without this, a segmentation fault with
+            # Windows fatal exception: access violation
+            # occurs
             raise ValueError("C <= 0")
         if sklearn_check_version("1.0"):
             self._check_feature_names(X, reset=True)

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -66,7 +66,7 @@ class SVR(sklearn_SVR, BaseSVR):
         if sklearn_check_version("1.2"):
             self._validate_params()
         elif self.C <= 0:
-            # else if added to correct issues with 
+            # else if added to correct issues with
             # sklearn tests:
             # svm/tests/test_sparse.py::test_error
             # svm/tests/test_svm.py::test_bad_input


### PR DESCRIPTION
### Description 
This adds the necessary checks to prevent seg faults caused by C and Nu out of bounds which are handled on libsvm/oneDAL side.  In sklearn >=1.2 there are checks on parameter constraints which prevent this check from occuring on sklearn side.

Upon request of @Vika-F to convert this to a true PR.

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

