### PR TITLE
[CI] deselect win32 svm tests causing segmentation faults

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -391,6 +391,7 @@ deselected_tests:
 
   # Remove windows seg fault for out of bounds parameters in SVM
   - svm/tests/test_sparse.py::test_error <1.2 win32
+  - svm/tests/test_svm.py::test_bad_input <1.2 win32
 
   # --------------------------------------------------------
   # No need to test daal4py patching

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -389,6 +389,9 @@ deselected_tests:
   - model_selection/tests/test_classification_threshold.py::test_fit_and_score_over_thresholds_sample_weight >=1.5
   - model_selection/tests/test_classification_threshold.py::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence >=1.5
 
+  # Remove windows seg fault for out of bounds parameters in SVM
+  - svm/tests/test_sparse.py::test_error
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -390,7 +390,7 @@ deselected_tests:
   - model_selection/tests/test_classification_threshold.py::test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence >=1.5
 
   # Remove windows seg fault for out of bounds parameters in SVM
-  - svm/tests/test_sparse.py::test_error
+  - svm/tests/test_sparse.py::test_error <1.2 win32
 
   # --------------------------------------------------------
   # No need to test daal4py patching


### PR DESCRIPTION
### Description 
Remove SVM seg faulting test on windows public CI

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

