### PR TITLE
[fix] fully check y array data in ensemble classifiers

### DIFF
--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -70,7 +70,7 @@ class BaseForest(ABC):
         X, y = self._validate_data(
             X,
             y,
-            multi_output=False,
+            multi_output=True,
             accept_sparse=False,
             dtype=[np.float64, np.float32],
             force_all_finite=False,


### PR DESCRIPTION
### Description 
_Add a comprehensive description of proposed changes_

For sklearn's check_X_y and BaseEnsembles's _validate_data, when multi_output is set to False, check_array is not run on the y input. This will cause issues in converting pandas DataFrames and Series to array-like formats, and will prevent the conversion to supported data types (float64 and float32).  This impacts the results of RandomForestClassifier.fit and ExtraTreesClassifier.fit, which will be unable to discern the type of target for classification.  Will fix https://github.com/intel/scikit-learn-intelex/issues/1229

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

