### PR TITLE
FIX: prevent `support_usm_ndarray` from changing queue if explicitly provided.

### DIFF
--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -178,11 +178,23 @@ if dpnp_available:
 
 
 def support_usm_ndarray(freefunc=False, queue_param=True):
+    """
+    Handles USMArray input. Puts SYCLQueue from data to method arguments.
+
+    Parameters
+    ----------
+    freefunc (bool) : Set to True if decorates free function.
+    queue_param (bool) : Set to True if queue from data should be provided to the method args.
+                         Queue will not be changed if provided explicitly.
+    """
+
     def decorator(func):
         def wrapper_impl(obj, *args, **kwargs):
             usm_iface = _extract_usm_iface(*args, **kwargs)
             data_queue, hostargs, hostkwargs = _get_host_inputs(*args, **kwargs)
-            if queue_param:
+            if queue_param and not (
+                "queue" in hostkwargs and hostkwargs["queue"] is not None
+            ):
                 hostkwargs["queue"] = data_queue
             result = _run_on_device(func, obj, *hostargs, **hostkwargs)
             if usm_iface is not None and hasattr(result, "__array_interface__"):

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -179,12 +179,13 @@ if dpnp_available:
 
 def support_usm_ndarray(freefunc=False, queue_param=True):
     """
-    Handles USMArray input. Puts SYCLQueue from data to method arguments.
+    Handles USMArray input. Puts SYCLQueue from data to decorated function arguments.
+    Converts output of decorated function to dpnp.ndarray if input was of this type.
 
     Parameters
     ----------
     freefunc (bool) : Set to True if decorates free function.
-    queue_param (bool) : Set to True if queue from data should be provided to the method args.
+    queue_param (bool) : Set to True if queue from data should be provided to the decorated function args.
                          Queue will not be changed if provided explicitly.
     """
 

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -180,13 +180,16 @@ if dpnp_available:
 def support_usm_ndarray(freefunc=False, queue_param=True):
     """
     Handles USMArray input. Puts SYCLQueue from data to decorated function arguments.
-    Converts output of decorated function to dpnp.ndarray if input was of this type.
+    Converts output of decorated function to dpctl.tensor/dpnp.ndarray if input was of this type.
 
     Parameters
     ----------
     freefunc (bool) : Set to True if decorates free function.
-    queue_param (bool) : Set to True if queue from data should be provided to the decorated function args.
-                         Queue will not be changed if provided explicitly.
+    queue_param (bool) : Set to False if the decorated function has no `queue` parameter
+
+    Notes
+    -----
+    Queue will not be changed if provided explicitly.
     """
 
     def decorator(func):


### PR DESCRIPTION
### Description 

* Changed logic of `support_usm_ndarray`. Now it does not change the queue if it was explicitly provided to args. Previous logic does not allow to use `np.array` + `SyclQueue` interface with decorated method.
* `queue_param` is removed from `support_usm_ndarray` since the check can be done via kwargs checking.
* Docstring is added to `support_usm_ndarray` with highlighting the change

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

