### PR TITLE
FIX: Remove exit code check from tests/test_examples_sklearnex.py to get meaningful logs

### DIFF
--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -46,12 +46,16 @@ def test_generator(file):
             ["python", os.path.join(examples_path, file)],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=True,
+            check=False,
         )  # nosec
         exit_code = process.returncode
 
         # Assert that the exit code is 0
-        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            exit_code,
+            0,
+            msg=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",
+        )
 
     setattr(TestsklearnexExamples, "test_" + os.path.splitext(file)[0], testit)
     print("Generating tests for " + os.path.splitext(file)[0])


### PR DESCRIPTION
### Description 
* Set check parameter to True and updated error message. Now the test doesn't fail on `subprocess.run` command and proceeds to exit code checking and printing subprocess output in case of failure. It gives more informative logs.


- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary.
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [x] I have added a respective label(s) to PR if I have a permission for that.  

