### PR TITLE
DOC: replace "-c intel" in doc files

### DIFF
--- a/doc/daal4py/index.rst
+++ b/doc/daal4py/index.rst
@@ -102,7 +102,7 @@ Last but not least, daal4py allows :ref:`getting input data from streams <stream
 
 oneAPI and GPU support in daal4py
 ---------------------------------
-daal4py oneAPI and GPU support is deprecated. Use `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/latest/oneapi-gpu.html#>`_ 
+daal4py oneAPI and GPU support is deprecated. Use `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/latest/oneapi-gpu.html#>`_
 instead.
 
 
@@ -148,8 +148,8 @@ and in `Intel channel <https://anaconda.org/intel/daal4py>`_.
 Sources and build instructions are available in
 `daal4py repository <https://github.com/intel/scikit-learn-intelex/tree/main/daal4py>`_.
 
-The daal4py package is available via same distribution channels and platforms as scikit-learn-intelex. 
-See  
+The daal4py package is available via same distribution channels and platforms as scikit-learn-intelex.
+See
 `scikit-learn-intelex requirements <https://intel.github.io/scikit-learn-intelex/latest/system-requirements.html>` _
 
 - Install from PyPI::
@@ -160,12 +160,12 @@ See
 
      сonda install daal4py -c conda-forge
 
-- Install from Anaconda Cloud: Intel channel::
+- Install using conda from the Intel repository::
 
-    conda install daal4py -c intel
+    conda install daal4py -c https://software.repos.intel.com/python/conda/
 
 We recommend to use **PyPi**. If you are using Intel® Distribution for Python,
-we recommend using **Anaconda Cloud: Intel channel**.
+we recommend using **conda from the Intel Repository**.
 In other cases, use **Anaconda Cloud: conda-forge channel**.
 
 
@@ -193,7 +193,7 @@ daal4py will work on the entire file content.
 Scikit-Learn API and patching
 -----------------------------
 .. tip::
-    We recommend using 
+    We recommend using
     the 'scikit-learn-intelex package patching <https://intel.github.io/scikit-learn-intelex/latest/what-is-patching.html>' _ for the scikit-learn patching.
 daal4py exposes some oneDAL solvers using a scikit-learn compatible API.
 


### PR DESCRIPTION
Change references to Anaconda to now point to the Intel repository.

### Description 
Anaconda license is no longer supported. The package has been moved to an Intel repository. Rodriguo Bernal Castro verified that 'intel' as a package should be changed to **https://software.repos.intel.com/python/conda/**

Fixes # - _issue number(s) if exists_

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

