### PR TITLE
Fix on preview ridge tests having too little error tolerance for coefficients assertions

### DIFF
--- a/sklearnex/preview/linear_model/tests/test_ridge.py
+++ b/sklearnex/preview/linear_model/tests/test_ridge.py
@@ -65,7 +65,7 @@ def test_ridge_coefficients(dataframe, queue, sample_size, feature_size, alpha):
     xt_y = numpy.dot(X.T, y)
     coefficients_manual = numpy.dot(inverse_term, xt_y)
 
-    assert_allclose(ridge_reg.coef_, coefficients_manual)
+    assert_allclose(ridge_reg.coef_, coefficients_manual, rtol=1e-5, atol=1e-5)
 
 
 if daal_check_version((2024, "P", 600)):

--- a/sklearnex/preview/linear_model/tests/test_ridge.py
+++ b/sklearnex/preview/linear_model/tests/test_ridge.py
@@ -65,7 +65,7 @@ def test_ridge_coefficients(dataframe, queue, sample_size, feature_size, alpha):
     xt_y = numpy.dot(X.T, y)
     coefficients_manual = numpy.dot(inverse_term, xt_y)
 
-    assert_allclose(ridge_reg.coef_, coefficients_manual, rtol=1e-5, atol=1e-5)
+    assert_allclose(ridge_reg.coef_, coefficients_manual, rtol=1e-6, atol=1e-6)
 
 
 if daal_check_version((2024, "P", 600)):


### PR DESCRIPTION
### Description 
This pr introduces fix for on-gpu preview ridge tests with too strict equality assertions.

This [ci step](http://intel-ci.intel.com/ef4610c3-18d4-f198-99ec-a4bf010d0e2e) fails sporadically with only 1 out of 50 coefficients having following accuracy missing:
Max absolute difference among violations: 3.46780698e-15
Max relative difference among violations: 1.5232134e-07

Fixes # - _issue number(s) if exists_

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

