### PR TITLE
[bug] fix issues with sklearn conformance for preview Ridge for 2024.6

### DIFF
--- a/daal4py/sklearn/linear_model/_ridge.py
+++ b/daal4py/sklearn/linear_model/_ridge.py
@@ -179,7 +179,7 @@ def _fit_ridge(self, _X, _y, sample_weight=None):
     if not _dal_ready:
         if hasattr(self, "daal_model_"):
             del self.daal_model_
-        return super(Ridge, self).fit(_X, _y, sample_weight=sample_weight)
+        return Ridge_original.fit(self, _X, _y, sample_weight=sample_weight)
     self.n_iter_ = None
     res = _daal4py_fit(self, X, y)
     if res is None:
@@ -188,7 +188,7 @@ def _fit_ridge(self, _X, _y, sample_weight=None):
         )
         if hasattr(self, "daal_model_"):
             del self.daal_model_
-        return super(Ridge, self).fit(_X, _y, sample_weight=sample_weight)
+        return Ridge_original.fit(self, _X, _y, sample_weight=sample_weight)
     return res
 
 

--- a/sklearnex/preview/linear_model/ridge.py
+++ b/sklearnex/preview/linear_model/ridge.py
@@ -31,6 +31,9 @@ if daal_check_version((2024, "P", 600)):
 
     if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
         from sklearn.linear_model._base import _deprecate_normalize
+    if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
+        from sklearn.utils import check_scalar
+
 
     from onedal.linear_model import Ridge as onedal_Ridge
     from onedal.utils import _num_features, _num_samples
@@ -274,6 +277,23 @@ if daal_check_version((2024, "P", 600)):
             # `Sample weight` is not supported. Expected to be None value.
             assert sample_weight is None
 
+            if sklearn_check_version("1.2"):
+                self._validate_params()
+            elif sklearn_check_version("1.1"):
+                if self.max_iter is not None:
+                    self.max_iter = check_scalar(
+                        self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1
+                    )
+                self.tol = check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
+                if self.alpha is not None and not isinstance(self.alpha, (np.ndarray, tuple)):
+                    self.alpha = check_scalar(
+                        self.alpha,
+                        "alpha",
+                        target_type=numbers.Real,
+                        min_val=0.0,
+                        include_boundaries="left",
+                    )
+
             check_params = {
                 "X": X,
                 "y": y,
@@ -284,7 +304,6 @@ if daal_check_version((2024, "P", 600)):
             }
             if sklearn_check_version("1.2"):
                 X, y = self._validate_data(**check_params)
-                self._validate_params()
             else:
                 X, y = check_X_y(**check_params)
 

--- a/sklearnex/preview/linear_model/ridge.py
+++ b/sklearnex/preview/linear_model/ridge.py
@@ -80,16 +80,16 @@ if daal_check_version((2024, "P", 600)):
                     random_state=random_state,
                 )
 
-        else:
+        elif sklearn_check_version("1.0"):
 
             def __init__(
                 self,
                 alpha=1.0,
                 fit_intercept=True,
-                normalize="deprecated" if sklearn_check_version("1.0") else False,
+                normalize="deprecated",
                 copy_X=True,
                 max_iter=None,
-                tol=1e-4,
+                tol=1e-3,
                 solver="auto",
                 positive=False,
                 random_state=None,
@@ -103,6 +103,30 @@ if daal_check_version((2024, "P", 600)):
                     solver=solver,
                     tol=tol,
                     positive=positive,
+                    random_state=random_state,
+                )
+
+        else:
+
+            def __init__(
+                self,
+                alpha=1.0,
+                fit_intercept=True,
+                normalize=False,
+                copy_X=True,
+                max_iter=None,
+                tol=1e-3,
+                solver="auto",
+                random_state=None,
+            ):
+                super().__init__(
+                    alpha=alpha,
+                    fit_intercept=fit_intercept,
+                    normalize=normalize,
+                    copy_X=copy_X,
+                    max_iter=max_iter,
+                    tol=tol,
+                    solver=solver,
                     random_state=random_state,
                 )
 

--- a/sklearnex/preview/linear_model/ridge.py
+++ b/sklearnex/preview/linear_model/ridge.py
@@ -305,7 +305,7 @@ if daal_check_version((2024, "P", 600)):
                 "y_numeric": True,
                 "multi_output": True,
             }
-            if sklearn_check_version("1.2"):
+            if sklearn_check_version("1.0"):
                 X, y = self._validate_data(**check_params)
             else:
                 X, y = check_X_y(**check_params)

--- a/sklearnex/preview/linear_model/ridge.py
+++ b/sklearnex/preview/linear_model/ridge.py
@@ -34,7 +34,6 @@ if daal_check_version((2024, "P", 600)):
     if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
         from sklearn.utils import check_scalar
 
-
     from onedal.linear_model import Ridge as onedal_Ridge
     from onedal.utils import _num_features, _num_samples
 
@@ -284,8 +283,12 @@ if daal_check_version((2024, "P", 600)):
                     self.max_iter = check_scalar(
                         self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1
                     )
-                self.tol = check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
-                if self.alpha is not None and not isinstance(self.alpha, (np.ndarray, tuple)):
+                self.tol = check_scalar(
+                    self.tol, "tol", target_type=numbers.Real, min_val=0.0
+                )
+                if self.alpha is not None and not isinstance(
+                    self.alpha, (np.ndarray, tuple)
+                ):
                     self.alpha = check_scalar(
                         self.alpha,
                         "alpha",


### PR DESCRIPTION
### Description 

Preview Ridge is currently guarded by a daal_check_version which does not activate the new implementation in public CI.  Public CI checks sklearn conformance for 1.0-1.5 for preview.  When the 2024.6 drop occurs, the new Ridge implementation will be used, and will fail for sklearn conformance for preview. This solves the errors observed for falling back to sklearn after running onedal due to inheritance issues in the daal4py version of Ridge for array-like or tuple alpha values, and some incorrect checking and default parameters for sklearn < 1.2. 

Fixes # - _issue number(s) if exists_

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.
- [x] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

