### PR TITLE
[enh] add random_state warning to SVM probability estimates

### DIFF
--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -236,8 +236,11 @@ class BaseSVC(BaseSVM):
         # CalibratedClassifierCV with "prefit" does not use an RNG nor a seed. This may
         # impact users without their knowledge, so display a warning.
         if self.random_seed is not None:
-            warnings.warn("Random seed does not influence oneDAL SVM results", warnings.RuntimeWarning)
-        
+            warnings.warn(
+                "Random seed does not influence oneDAL SVM results",
+                warnings.RuntimeWarning,
+            )
+
         params = self.get_params()
         params["probability"] = False
         params["decision_function_shape"] = "ovr"

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -235,9 +235,9 @@ class BaseSVC(BaseSVM):
         # LibSVM uses the random seed to control cross-validation for probability generation
         # CalibratedClassifierCV with "prefit" does not use an RNG nor a seed. This may
         # impact users without their knowledge, so display a warning.
-        if self.random_seed is not None:
+        if self.random_state is not None:
             warnings.warn(
-                "Random seed does not influence oneDAL SVM results",
+                "random_state does not influence oneDAL SVM results",
                 warnings.RuntimeWarning,
             )
 

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -238,7 +238,7 @@ class BaseSVC(BaseSVM):
         if self.random_state is not None:
             warnings.warn(
                 "random_state does not influence oneDAL SVM results",
-                warnings.RuntimeWarning,
+                RuntimeWarning,
             )
 
         params = self.get_params()

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -16,6 +16,7 @@
 
 from abc import ABC
 from numbers import Number, Real
+import warnings
 
 import numpy as np
 from scipy import sparse as sp
@@ -230,6 +231,13 @@ class BaseSVC(BaseSVM):
 
     def _fit_proba(self, X, y, sample_weight=None, queue=None):
         # TODO: rewrite this method when probabilities output is implemented in oneDAL
+
+        # LibSVM uses the random seed to control cross-validation for probability generation
+        # CalibratedClassifierCV with "prefit" does not use an RNG nor a seed. This may
+        # impact users without their knowledge, so display a warning.
+        if self.random_seed is not None:
+            warnings.warn("Random seed does not influence oneDAL SVM results", warnings.RuntimeWarning)
+        
         params = self.get_params()
         params["probability"] = False
         params["decision_function_shape"] = "ovr"

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 # ==============================================================================
 
+import warnings
 from abc import ABC
 from numbers import Number, Real
-import warnings
 
 import numpy as np
 from scipy import sparse as sp


### PR DESCRIPTION
### Description 
Sklearn's SVM implementation depends on libsvm (https://github.com/cjlin1/libsvm) which uses an RNG only for cross-validation in the probability estimates.  The seed for the RNG is controlled as a parameter for sklearn, and is made available for sklearnex. As we use a CalibratedClassifierCV for generating the probability estimates, the ability to set the RNG seed is lost.  This loss of functionality should be made known to the user, as changing the seed will have no effect.  This adds a warning to the _fit_proba method if random_seed is not None (i.e. when the user tries to force a value).  This will only show for attributes of SVM which are influenced by the cross-validation (probabilities).

If/when probability estimates are implemented in oneDAL, then a RNG seed will likely need control, and this warning can be removed.

Fixes # - _issue number(s) if exists_

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes, if necessary (updated in # - _add PR number_)
- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.
- [ ] I have resolved any merge conflicts that might occur with the base branch.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_
- [ ] I have added a respective label(s) to PR if I have a permission for that.  

