### PR TITLE
Complete removal of Python 3.8 support

### DIFF
--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -23,7 +23,7 @@ parser.add_argument("--channels", nargs="+", default=["pypi"])
 args = parser.parse_args()
 
 CHANNELS = args.channels
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 SYSTEMS = ["ubuntu-latest", "windows-latest"]
 ACTIVATE = {
     "ubuntu-latest": "conda activate",

--- a/.ci/scripts/setup_sklearn.sh
+++ b/.ci/scripts/setup_sklearn.sh
@@ -25,11 +25,11 @@ sklearn_version=${1:-main}
 
 if [ "$sklearn_version" == "main" ]; then
     # remove sklearn version from test requirements file
-    sed -i.bak -E "s/scikit-learn==[0-9a-zA-Z.]* ;/scikit-learn ;/" requirements-test.txt
+    sed -i.bak -E "s/scikit-learn==[0-9a-zA-Z.]*/scikit-learn/" requirements-test.txt
     # install sklearn build dependencies
     pip install threadpoolctl joblib scipy
     # install sklearn from main branch of git repo
     pip install git+https://github.com/scikit-learn/scikit-learn.git@main
 else
-    sed -i.bak -E "s/scikit-learn==[0-9a-zA-Z.]* ;/scikit-learn==${sklearn_version}.* ;/" requirements-test.txt
+    sed -i.bak -E "s/scikit-learn==[0-9a-zA-Z.]*/scikit-learn==${sklearn_version}.*/" requirements-test.txt
 fi

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,10 +41,10 @@ Check [System](https://intel.github.io/scikit-learn-intelex/latest/system-requir
 
 ## Supported Configurations
 
-| OS / Python version | **Python 3.8** | **Python 3.9** | **Python 3.10** | **Python 3.11** | **Python 3.12** |
-| :------------------ | :------------: | :------------: |  :------------: |  :------------: |  :------------: |
-| **Linux**           |   [CPU, GPU]   |   [CPU, GPU]   |   [CPU, GPU]    |   [CPU, GPU]    |   [CPU, GPU]    |
-| **Windows**         |   [CPU, GPU]   |   [CPU, GPU]   |   [CPU, GPU]    |   [CPU, GPU]    |   [CPU, GPU]    |
+| OS / Python version | **Python 3.9** | **Python 3.10** | **Python 3.11** | **Python 3.12** |
+| :------------------ | :------------: |  :------------: |  :------------: |  :------------: |
+| **Linux**           |   [CPU, GPU]   |   [CPU, GPU]    |   [CPU, GPU]    |   [CPU, GPU]    |
+| **Windows**         |   [CPU, GPU]   |   [CPU, GPU]    |   [CPU, GPU]    |   [CPU, GPU]    |
 
 Applicable for:
 
@@ -148,7 +148,7 @@ The build-process (using setup.py) happens in 4 stages:
 4. Compiling and linking them
 
 ### Prerequisites
-* Python version >= 3.8, <= 3.12
+* Python version >= 3.9, <= 3.12
 * Jinja2
 * Cython
 * Numpy

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/black?icon=github)](https://github.com/intel/scikit-learn-intelex/discussions)
 [![PyPI Version](https://img.shields.io/pypi/v/scikit-learn-intelex)](https://pypi.org/project/scikit-learn-intelex/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scikit-learn-intelex)](https://anaconda.org/conda-forge/scikit-learn-intelex)
-[![python version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
+[![python version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
 [![scikit-learn supported versions](https://img.shields.io/badge/sklearn-1.0%20%7C%201.2%20%7C%201.3%20%7C%201.4-blue)](https://img.shields.io/badge/sklearn-01.0%20%7C%201.2%20%7C%201.3%20%7C%201.4-blue)
 
 ---

--- a/dependencies-dev
+++ b/dependencies-dev
@@ -1,7 +1,6 @@
 Cython==3.0.11
 Jinja2==3.1.4
-numpy==1.19.5 ; python_version < '3.9'
-numpy==2.0.1 ; python_version >= '3.9'
+numpy==2.0.1
 pybind11==2.13.1
 cmake==3.30.2
 setuptools==72.1.0

--- a/doc/sources/quick-start.rst
+++ b/doc/sources/quick-start.rst
@@ -197,7 +197,6 @@ To install |intelex|, run:
    :align: left
 
    * - OS / Python version
-     - Python 3.8
      - Python 3.9
      - Python 3.10
      - Python 3.11
@@ -237,7 +236,6 @@ To prevent version conflicts, we recommend installing `scikit-learn-intelex` int
          :align: left
 
          * - OS / Python version
-           - Python 3.8
            - Python 3.9
            - Python 3.10
            - Python 3.11
@@ -269,7 +267,6 @@ To prevent version conflicts, we recommend installing `scikit-learn-intelex` int
          :align: left
 
          * - OS / Python version
-           - Python 3.8
            - Python 3.9
            - Python 3.10
            - Python 3.11
@@ -300,7 +297,6 @@ To prevent version conflicts, we recommend installing `scikit-learn-intelex` int
          :align: left
 
          * - OS / Python version
-           - Python 3.8
            - Python 3.9
            - Python 3.10
            - Python 3.11

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,14 +4,11 @@ numpy>=1.19.5 ; python_version <= '3.9'
 numpy>=1.21.6 ; python_version == '3.10'
 numpy>=1.23.5 ; python_version == '3.11'
 numpy>=2.0.0 ; python_version >= '3.12'
-scikit-learn==1.2.2 ; python_version == '3.8'
-scikit-learn==1.5.1 ; python_version >= '3.9'
-pandas==2.0.3 ; python_version == '3.8'
-pandas==2.1.3 ; python_version >= '3.9' and python_version < '3.11'
+scikit-learn==1.5.1
+pandas==2.1.3 ; python_version < '3.11'
 pandas==2.2.2 ; python_version >= '3.11'
 xgboost==2.1.1
 lightgbm==4.5.0
 catboost==1.2.5 ; python_version < '3.11' # TODO: Remove 3.11 condition when catboost supports numpy 2.0
-shap==0.44.1 ; python_version == '3.8'
-shap==0.46.0 ; python_version >= '3.9'
-array-api-strict==1.1.1 ; python_version >= '3.9'
+shap==0.46.0
+array-api-strict==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -629,7 +629,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -638,7 +637,7 @@ setup(
         "Topic :: System",
         "Topic :: Software Development",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "scikit-learn>=1.0",
         "numpy>=1.19.5 ; python_version <= '3.9'",


### PR DESCRIPTION
### Description

Remove Python 3.8 dependencies and other parts.

Changes:
- Update `sed` expression to correctly change sklearn version if python version condition is not present
- Change or remove requirements where Python 3.8 is mentioned
- Remove Python 3.8 from docs

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
