### PR TITLE
Update oneapi-gpu.rst with Conda install instructions

### DIFF
--- a/doc/sources/oneapi-gpu.rst
+++ b/doc/sources/oneapi-gpu.rst
@@ -38,9 +38,9 @@ DPC++ compiler runtime can be installed either from PyPI or Anaconda:
 
      pip install dpcpp-cpp-rt
 
-- Install from Anaconda::
+- Install using Conda via the Intel repository::
 
-     conda install dpcpp_cpp_rt -c intel
+     conda install dpcpp_cpp_rt -c https://software.repos.intel.com/python/conda/
 
 Device offloading
 -----------------


### PR DESCRIPTION
Anaconda license is no longer supported. The package has been moved to an Intel repository. Rodriguo Bernal Castro verified that 'intel' as a package should be changed to https://software.repos.intel.com/python/conda/

### Description

_Add a comprehensive description of proposed changes_

_List issue number(s) if exist(s): #6 (for example)_

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x ] I have reviewed my changes thoroughly before submitting this pull request.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.  
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
