### PR TITLE
Update oneDAL DPC interface detection

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,6 +166,7 @@ The build-process (using setup.py) happens in 4 stages:
 * ``DALROOT``: sets the oneAPI Data Analytics Library path
 * ``NO_DIST``: set to '1', 'yes' or alike to build without support for distributed mode
 * ``NO_STREAM``: set to '1', 'yes' or alike to build without support for streaming mode
+* ``NO_DPC``: set to '1', 'yes' or alike to build without support of oneDAL DPC++ interfaces
 * ``OFF_ONEDAL_IFACE``: set to '1' to build without the support of oneDAL interfaces
 
 ### Build Intel(R) Extension for Scikit-learn

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -16,6 +16,7 @@
 # ===============================================================================
 
 import re
+from ctypes.util import find_library
 from os.path import isfile
 from os.path import join as jp
 from sys import platform
@@ -68,3 +69,26 @@ def get_onedal_version(dal_root, version_type="release"):
                 version["__INTEL_DAAL_MINOR_BINARY__"]
             )
     return version
+
+
+def get_onedal_shared_libs(dal_root):
+    """Function to find which oneDAL shared libraries are available in the system"""
+    lib_names = [
+        "onedal",
+        "onedal_core",
+        "onedal_thread",
+        "onedal_dpc",
+        "onedal_parameters",
+    ]
+    major_bin_version, _ = get_onedal_version(dal_root, "binary")
+    found_libraries = []
+    for lib_name in lib_names:
+        possible_aliases = [
+            lib_name,
+            f"lib{lib_name}.so.{major_bin_version}",
+            f"lib{lib_name}.{major_bin_version}.dylib"
+            f"{lib_name}.{major_bin_version}.dll",
+        ]
+        if any(find_library(alias) for alias in possible_aliases):
+            found_libraries.append(lib_name)
+    return found_libraries

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -19,7 +19,6 @@ import re
 from ctypes.util import find_library
 from os.path import isfile
 from os.path import join as jp
-from sys import platform
 
 
 def find_defines(defines: list, file_obj):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import shutil
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from ctypes.util import find_library
 from os.path import join as jp
 from sysconfig import get_config_vars
 
@@ -38,12 +39,7 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 import scripts.build_backend as build_backend
 from scripts.package_helpers import get_packages_with_tests
-from scripts.version import get_onedal_version
-
-try:
-    from ctypes.utils import find_library
-except ImportError:
-    from ctypes.util import find_library
+from scripts.version import get_onedal_shared_libs, get_onedal_version
 
 IS_WIN = False
 IS_MAC = False
@@ -91,7 +87,12 @@ no_dist = True if "NO_DIST" in os.environ and os.environ["NO_DIST"] in trues els
 no_stream = "NO_STREAM" in os.environ and os.environ["NO_STREAM"] in trues
 debug_build = os.getenv("DEBUG_BUILD") == "1"
 mpi_root = None if no_dist else os.environ["MPIROOT"]
-dpcpp = shutil.which("icpx") is not None and not (IS_WIN and debug_build)
+dpcpp = (
+    shutil.which("icpx") is not None
+    and "onedal_dpc" in get_onedal_shared_libs(dal_root)
+    and os.environ.get("NO_DPC", None) is None
+    and not (IS_WIN and debug_build)
+)
 
 use_parameters_lib = (not IS_WIN) and (ONEDAL_VERSION >= 20240000)
 


### PR DESCRIPTION
### Description

Update the way how sklearnex building script decides to enable DPC part:
- Check for existence of `onedal_dpc` shared library
- Check if `NO_DPC` env variable is not set

Solves https://github.com/intel/scikit-learn-intelex/issues/1981

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
