### PR TITLE
[fix] Add forgotten _check_array to IncrementalBasicStatistics.partial_fit

### DIFF
--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -97,10 +97,15 @@ class IncrementalBasicStatistics(BaseBasicStatistics):
         policy = self._get_policy(queue, X)
         X, weights = _convert_to_supported(policy, X, weights)
 
-        X = _check_array(X, dtype=[np.float64, np.float32], ensure_2d=False)
+        X = _check_array(
+            X, dtype=[np.float64, np.float32], ensure_2d=False, force_all_finite=False
+        )
         if weights is not None:
             weights = _check_array(
-                weights, dtype=[np.float64, np.float32], ensure_2d=False
+                weights,
+                dtype=[np.float64, np.float32],
+                ensure_2d=False,
+                force_all_finite=False,
             )
 
         if not hasattr(self, "_onedal_params"):

--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -19,6 +19,7 @@ import numpy as np
 from daal4py.sklearn._utils import get_dtype
 
 from ..datatypes import _convert_to_supported, from_table, to_table
+from ..utils import _check_array
 from .basic_statistics import BaseBasicStatistics
 
 
@@ -95,6 +96,12 @@ class IncrementalBasicStatistics(BaseBasicStatistics):
         self._queue = queue
         policy = self._get_policy(queue, X)
         X, weights = _convert_to_supported(policy, X, weights)
+
+        X = _check_array(X, dtype=[np.float64, np.float32], ensure_2d=False)
+        if weights is not None:
+            weights = _check_array(
+                weights, dtype=[np.float64, np.float32], ensure_2d=False
+            )
 
         if not hasattr(self, "_onedal_params"):
             dtype = get_dtype(X)


### PR DESCRIPTION
### Description

* `_check_array` is used now in `IncrementalBasicStatistics.partial_fit`. It prevents failure in case if non-contiguous numpy array has been provided as argument. 

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
