### PR TITLE
Fix _check_X_y method

### DIFF
--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -194,9 +194,13 @@ def _check_X_y(
 
     if not accept_2d_y:
         y = _column_or_1d(y, warn=True)
+    else:
+        y = np.ascontiguousarray(y)
+
     if y_numeric and y.dtype.kind == "O":
         y = y.astype(np.float64)
-    _assert_all_finite(y)
+    if force_all_finite:
+        _assert_all_finite(y)
 
     lengths = [X.shape[0], y.shape[0]]
     uniques = np.unique(lengths)


### PR DESCRIPTION
### Description

* Finiteness checker for y is called now only if force_all_finite=True
* Returned y is always contiguous now

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
