### PR TITLE
[fix] register pytest.mark.mpi to solve ```PytestUnknownMarkWarning```

### DIFF
--- a/sklearnex/conftest.py
+++ b/sklearnex/conftest.py
@@ -31,6 +31,7 @@ def pytest_configure(config):
         "markers", "mpi: mark test to require MPI for distributed testing"
     )
 
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     # setup logger to check for sklearn fallback

--- a/sklearnex/conftest.py
+++ b/sklearnex/conftest.py
@@ -27,7 +27,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "allow_sklearn_fallback: mark test to not check for sklearnex usage"
     )
-
+    config.addinivalue_line(
+        "markers", "mpi: mark test to require MPI for distributed testing"
+    )
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):


### PR DESCRIPTION
### Description

Warnings are raised when running sklearnex testing with a MPI-enabled build that the mpi marker has not been registered. This registers the mark via the ```conftest.py``` in ```sklearnex```.  Note, this marker will only impact the ```sklearnex``` package, and not the ```onedal``` package.

This warning is raised in main on MPI enabled builds (see [azure pipelines linux public CI sklearnex testing on main](https://dev.azure.com/daal/daal4py/_build/results?buildId=37841&view=logs&jobId=cf2d4777-8a0c-5226-662a-531d169dcfd1&j=cf2d4777-8a0c-5226-662a-531d169dcfd1&t=0f0920fb-b2f2-52eb-1255-bc379073312f))

An alternative (as given by the warning) is to register it in the pyproject.toml: https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks

I will leave that up to the reviewers. No impact on performance

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
