### PR TITLE
Sample weight checks removal from Kmeans predict

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -20,6 +20,7 @@ from daal4py.sklearn._utils import daal_check_version
 
 if daal_check_version((2023, "P", 200)):
 
+    import numbers
     import warnings
 
     import numpy as np
@@ -108,6 +109,10 @@ if daal_check_version((2023, "P", 200)):
                 _is_csr(X) and daal_check_version((2024, "P", 700))
             ) or not issparse(X)
 
+            _acceptable_sample_weights = sample_weight is None or isinstance(
+                sample_weight, numbers.Number
+            )
+
             patching_status.and_conditions(
                 [
                     (
@@ -116,8 +121,8 @@ if daal_check_version((2023, "P", 200)):
                     ),
                     (correct_count, "n_clusters is smaller than number of samples"),
                     (
-                        sample_weight is None,
-                        "oneDAL doesn't support sample_weight.",
+                        _acceptable_sample_weights,
+                        "oneDAL doesn't support sample_weight, None or equal weights are accepted.",
                     ),
                     (
                         is_data_supported,


### PR DESCRIPTION
### Description

check_sample_weights or np_allclose is pretty expensive and have performance impact even if the branch is not taken. Since sklearn dropped support for sample weights in KMeans Predict from 1.5, we can ignore all these expensive checks. Fit continues to support sample_weight though.

_List issue number(s) if exist(s): #6 (for example)_

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.  
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
