### PR TITLE
fix int overflow in FTI model convertor

### DIFF
--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -253,6 +253,15 @@ class TreeList(list):
         Note: We cannot type-hint the xgb.Booster without loading xgb as dependency in pyx code,
               therefore not type hint is added.
         """
+        # dump_format="json" is affected by the integer-overflow error,
+        # since XGBoost doesn't control numeric limits of integer features.
+        # For correct conversion we manulally replace feature types from 'int'->'float;
+        feature_types = booster.feature_types
+        for i in range(len(feature_types)):
+            if feature_types[i] == "int":
+                feature_types[i] = "float"
+        booster.feature_types = feature_types
+
         tl = TreeList()
         dump = booster.get_dump(dump_format="json", with_stats=True)
         for tree_id, raw_tree in enumerate(dump):

--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -256,12 +256,13 @@ class TreeList(list):
         # dump_format="json" is affected by the integer-overflow error,
         # since XGBoost doesn't control numeric limits of integer features.
         # For correct conversion we manulally replace feature types from 'int'->'float;
-        feature_types = booster.feature_types
-        if feature_types:
-            for i in range(len(feature_types)):
-                if feature_types[i] == "int":
-                    feature_types[i] = "float"
-            booster.feature_types = feature_types
+        if hasattr(booster, "feature_types"):
+            feature_types = booster.feature_types
+            if feature_types:
+                for i in range(len(feature_types)):
+                    if feature_types[i] == "int":
+                        feature_types[i] = "float"
+                booster.feature_types = feature_types
 
         tl = TreeList()
         dump = booster.get_dump(dump_format="json", with_stats=True)

--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -257,10 +257,11 @@ class TreeList(list):
         # since XGBoost doesn't control numeric limits of integer features.
         # For correct conversion we manulally replace feature types from 'int'->'float;
         feature_types = booster.feature_types
-        for i in range(len(feature_types)):
-            if feature_types[i] == "int":
-                feature_types[i] = "float"
-        booster.feature_types = feature_types
+        if feature_types:
+            for i in range(len(feature_types)):
+                if feature_types[i] == "int":
+                    feature_types[i] = "float"
+            booster.feature_types = feature_types
 
         tl = TreeList()
         dump = booster.get_dump(dump_format="json", with_stats=True)


### PR DESCRIPTION
### Description

FTI model convertor for xgboost suffers from integer overflow error, since xgboost doesn't control numeric limits for integer valued features. In this PR we manually replace the feature type from `int` to `float `to avoid this problem.

Should fix https://github.com/intel/scikit-learn-intelex/issues/2016

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
