### PR TITLE
[fix] automatically cancel older github action PR CI runs on new commit to branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   TBB_VERSION: 2021.13
   DPCPP_VERSION: 2024.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# build artefacts test
+# build artefacts
 *.so
 *.egg
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# build artefacts
+# build artefacts test
 *.so
 *.egg
 *.pyc


### PR DESCRIPTION
### Description

New commits on PRs with currently running CI jobs will not cancel those jobs/runs.  This will lead to a lock up of Github Actions runners if there are too many commits at the same time. This update will enable the same style of cancellation as is observed in Azure Pipelines.

Note this will not stop the github Actions CI checks on merges to main, only on PRs.

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.  
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
