### PR TITLE
Allow usage of Version from distutils when packaging is not available

### DIFF
--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -22,7 +22,12 @@ import sys
 import warnings
 
 import sklearn
-from packaging.version import Version
+
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
+
 from sklearn import __version__ as sklearn_version
 from yaml import FullLoader
 from yaml import load as yaml_load

--- a/daal4py/sklearn/_utils.py
+++ b/daal4py/sklearn/_utils.py
@@ -30,7 +30,10 @@ DaalVersionTuple = Tuple[int, str, int]
 
 import logging
 
-from packaging.version import Version
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
 
 try:
     from pandas import DataFrame


### PR DESCRIPTION
### Description

distutils have been removed earlier because of discontinuation starting at python 3.12. However, removal of distutils completely created a dependency of "packaging". This is a quick fix and return to previous behavior just for the cases where we use "Version". Other part of the removal had no issue. Need to have discussion about adding "packaging" as dependency or a suitable alternative.

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.  
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
