### PR TITLE
oneMKL migration: Fix for DLL loading issue on Windows

### DIFF
--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -31,10 +31,17 @@ if "Windows" in platform.system():
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
-            dal_root_redist = os.path.join(os.environ["DALROOT"], "redist", arch_dir)
+            dal_root = os.environ["DALROOT"]
+            dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
             if os.path.exists(dal_root_redist):
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
+        if "TBBROOT" in os.environ:
+            tbb_root = os.environ["TBBROOT"]
+            tbb_root_redist = os.path.join(tbb_root, "bin")
+            if os.path.exists(tbb_root_redist):
+                os.add_dll_directory(tbb_root_redist)
+                os.environ["PATH"] = tbb_root_redist + os.pathsep + os.environ["PATH"]
 
         try:
             os.add_dll_directory(path_to_libs)


### PR DESCRIPTION
`__init__.py` file in `daal4py` module was modified to add paths to TBB DLLs into the process environment in case `TBBROOT` environment variable is available.

This work is related to [oneDAL PR #2756](https://github.com/oneapi-src/oneDAL/pull/2756).

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [ ] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
