### PR TITLE
TEST: clear a few warnings in model builder tests

### DIFF
--- a/tests/test_df_support.py
+++ b/tests/test_df_support.py
@@ -80,7 +80,6 @@ class Test(unittest.TestCase):
         X = np.random.randn(13024 * 3, 16)
         df = pd.DataFrame(X[1::3, 1:])
         ps = pd.Series(X[1::3, 0])
-        print(ps.to_numpy().flags)
         self.verify_on_linear_regression(df, ps)
 
     def test_contiguous_heterogeneous(self):

--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -231,7 +231,7 @@ class XGBoostRegressionModelBuilder_base_score100(XGBoostRegressionModelBuilder)
 
 @unittest.skipUnless(shap_supported, reason=shap_not_supported_str)
 class XGBoostClassificationModelBuilder(unittest.TestCase):
-    def getConversionWarningIsExpected(self):
+    def get_conversion_warning_is_expected(self):
         if (
             self.xgb_model._estimator_type == "classifier"
             and self.xgb_model.objective == "binary:logitraw"
@@ -241,7 +241,7 @@ class XGBoostClassificationModelBuilder(unittest.TestCase):
             return False
 
     @contextlib.contextmanager
-    def conditionalAssertWarns(self, warning):
+    def conditional_assert_warns(self, warning):
         if warning is not None:
             with self.assertWarns(warning) as ctx:
                 try:
@@ -282,8 +282,10 @@ class XGBoostClassificationModelBuilder(unittest.TestCase):
         cls.xgb_model.fit(X, y)
 
     def test_model_conversion(self):
-        expected_warning = UserWarning if self.getConversionWarningIsExpected() else None
-        with self.conditionalAssertWarns(expected_warning):
+        expected_warning = (
+            UserWarning if self.get_conversion_warning_is_expected() else None
+        )
+        with self.conditional_assert_warns(expected_warning):
             m = d4p.mb.convert_model(self.xgb_model.get_booster())
         self.assertEqual(m.model_type, "xgboost")
         self.assertEqual(m.n_classes_, self.n_classes)
@@ -291,8 +293,10 @@ class XGBoostClassificationModelBuilder(unittest.TestCase):
         self.assertFalse(m._is_regression)
 
     def test_model_predict(self):
-        expected_warning = UserWarning if self.getConversionWarningIsExpected() else None
-        with self.conditionalAssertWarns(expected_warning):
+        expected_warning = (
+            UserWarning if self.get_conversion_warning_is_expected() else None
+        )
+        with self.conditional_assert_warns(expected_warning):
             m = d4p.mb.convert_model(self.xgb_model.get_booster())
         d4p_pred = m.predict(self.X_test)
         xgboost_pred = self.xgb_model.predict(self.X_test)
@@ -308,8 +312,10 @@ class XGBoostClassificationModelBuilder(unittest.TestCase):
         np.testing.assert_allclose(d4p_pred, xgboost_pred, rtol=1e-5)
 
     def test_missing_value_support(self):
-        expected_warning = UserWarning if self.getConversionWarningIsExpected() else None
-        with self.conditionalAssertWarns(expected_warning):
+        expected_warning = (
+            UserWarning if self.get_conversion_warning_is_expected() else None
+        )
+        with self.conditional_assert_warns(expected_warning):
             m = d4p.mb.convert_model(self.xgb_model.get_booster())
         d4p_pred = m.predict(self.X_nan)
         xgboost_pred = self.xgb_model.predict(self.X_nan)


### PR DESCRIPTION
### Description

This PR clears a few warnings that are observed when executing unit tests that involve building and converting models from XGBoost and LightGBM, and removes an unnecessary `print` statement that executes in one of the tests.

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
