### PR TITLE
Enable serialization in `daal4py` algorithm classes

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -1019,9 +1019,13 @@ cdef class {{algo}}{{'('+iface[0]|lower+'__iface__)' if iface[0] else ''}}:
         self.c_ptr = mk_{{algo}}(
             {{params_all|fmt('{}', 'arg_cyext', sep=',\n')|indent(25+(algo|length))}}
         )
+        current_locals = locals()
+        ordered_input_args = '''
+            {{params_all|fmt('{}', 'name', sep=' ')|indent(0)}}
+        '''.strip().split()
         self._params = tuple(
-            v for k, v in locals().items()
-            if k != "self"
+            current_locals[arg]
+            for arg in ordered_input_args
         )
 
     def __reduce__(self):

--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -1003,6 +1003,8 @@ cdef extern from "daal4py_cpp.h":
 
 # this is our actual algorithm class for Python
 cdef class {{algo}}{{'('+iface[0]|lower+'__iface__)' if iface[0] else ''}}:
+    cdef tuple _params
+
     '''
     {{algo}}
     {{params_all|fmt('{}', 'sphinx', sep='\n')|indent(4)}}
@@ -1017,6 +1019,13 @@ cdef class {{algo}}{{'('+iface[0]|lower+'__iface__)' if iface[0] else ''}}:
         self.c_ptr = mk_{{algo}}(
             {{params_all|fmt('{}', 'arg_cyext', sep=',\n')|indent(25+(algo|length))}}
         )
+        self._params = tuple(
+            v for k, v in locals().items()
+            if k != "self"
+        )
+
+    def __reduce__(self):
+        return (self.__class__, self._params)
 
 {% if not iface[0] %}
     # the C++ manager__iface__ (de-templatized)

--- a/tests/test_daal4py_serialization.py
+++ b/tests/test_daal4py_serialization.py
@@ -23,7 +23,7 @@ import daal4py
 
 
 class Test(unittest.TestCase):
-    def test_serialization_of_algorithms(self):
+    def test_serialization_of_qr(self):
         obj_original = daal4py.qr(fptype="float")
         obj_deserialized = pickle.loads(pickle.dumps(obj_original))
 
@@ -34,3 +34,15 @@ class Test(unittest.TestCase):
         Q_deserialized = obj_deserialized.compute(X).matrixQ
         np.testing.assert_almost_equal(Q_orig, Q_deserialized)
         assert Q_orig.dtype == Q_deserialized.dtype
+
+    def test_serialization_of_kmeans(self):
+        obj_original = daal4py.kmeans_init(nClusters=4)
+        obj_deserialized = pickle.loads(pickle.dumps(obj_original))
+
+        rng = np.random.default_rng(seed=123)
+        X = rng.standard_normal(size=(100, 20))
+
+        np.testing.assert_almost_equal(
+            obj_original.compute(X).centroids,
+            obj_deserialized.compute(X).centroids,
+        )

--- a/tests/test_daal4py_serialization.py
+++ b/tests/test_daal4py_serialization.py
@@ -1,0 +1,36 @@
+# ==============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import pickle
+import unittest
+
+import numpy as np
+
+import daal4py
+
+
+class Test(unittest.TestCase):
+    def test_serialization_of_algorithms(self):
+        obj_original = daal4py.qr(fptype="float")
+        obj_deserialized = pickle.loads(pickle.dumps(obj_original))
+
+        rng = np.random.default_rng(seed=123)
+        X = rng.standard_normal(size=(10, 5))
+
+        Q_orig = obj_original.compute(X).matrixQ
+        Q_deserialized = obj_deserialized.compute(X).matrixQ
+        np.testing.assert_almost_equal(Q_orig, Q_deserialized)
+        assert Q_orig.dtype == Q_deserialized.dtype


### PR DESCRIPTION
### Description

fixes https://github.com/intel/scikit-learn-intelex/issues/425

This PR adds support for serialization of the algorithm classes in `daal4py`.

Since they do not store data nor results, the logic is simply to store the init parameters that were passed, and call the initializer again with those same parameters.

I wasn't sure where to add a unit test for this so I created a new test file.

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
