### PR TITLE
Use `__repr__` method for `daal4py` algorithm results in order to be printable in jupyter sessions

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -374,7 +374,7 @@ cdef class {{flatname}}:
     def __init__(self, int64_t ptr=0):
         self.c_ptr = <{{class_type|flat}}>ptr
 
-    def __str__(self):
+    def __repr__(self):
         return _str(self, [{% for m in enum_gets+named_gets %}'{{m[1]}}',{% endfor %}])
 {% for m in enum_gets+named_gets %}
 {% set rtype = m[2]|d2cy(False) if m in enum_gets else m[0]|d2cy(False) %}

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1,0 +1,32 @@
+# ==============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import re
+import unittest
+
+import numpy as np
+
+import daal4py
+
+
+class Test(unittest.TestCase):
+    def test_printing(self):
+        rng = np.random.default_rng(seed=123)
+        X = rng.standard_normal(size=(10, 5))
+        qr_algorithm = daal4py.qr()
+        qr_result = qr_algorithm.compute(X)
+        assert "matrixQ" in qr_result.__str__()
+        assert "matrixQ" in qr_result.__repr__()

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -28,5 +28,8 @@ class Test(unittest.TestCase):
         X = rng.standard_normal(size=(10, 5))
         qr_algorithm = daal4py.qr()
         qr_result = qr_algorithm.compute(X)
-        assert "matrixQ" in qr_result.__str__()
-        assert "matrixQ" in qr_result.__repr__()
+        qr_result_str, qr_result_repr = qr_result.__str__(), qr_result.__repr__()
+        assert "matrixQ" in qr_result_str
+        assert "matrixR" in qr_result_str
+        assert "matrixQ" in qr_result_repr 
+        assert "matrixR" in qr_result_repr 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -31,5 +31,5 @@ class Test(unittest.TestCase):
         qr_result_str, qr_result_repr = qr_result.__str__(), qr_result.__repr__()
         assert "matrixQ" in qr_result_str
         assert "matrixR" in qr_result_str
-        assert "matrixQ" in qr_result_repr 
-        assert "matrixR" in qr_result_repr 
+        assert "matrixQ" in qr_result_repr
+        assert "matrixR" in qr_result_repr

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -23,7 +23,7 @@ import daal4py
 
 
 class Test(unittest.TestCase):
-    def test_printing(self):
+    def test_qr_printing(self):
         rng = np.random.default_rng(seed=123)
         X = rng.standard_normal(size=(10, 5))
         qr_algorithm = daal4py.qr()


### PR DESCRIPTION
### Description

This PR switches the `__str__` method in result classes to `__repr__`.

In the absence of a `__str__` implementation, `__repr__` is called instead, so behavior does not change for calls to `__str__`.

What this changes however is how objects get printed when shown in interactive sessions, such as through jupyter's `display` which calls `__repr__` instead of `__str__`, and is likely to be encountered in IDEs and interactive sessions.

* Before:
![image](https://github.com/user-attachments/assets/7fd57031-b537-42d1-9649-226de860cf86)


* After:
![image](https://github.com/user-attachments/assets/909c47ad-21f3-4d0d-bed6-7f4f8983e748)


---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
