### PR TITLE
FIX: Add covariance module to sklearnex init

### DIFF
--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "basic_statistics",
     "cluster",
     "config_context",
+    "covariance",
     "decomposition",
     "ensemble",
     "get_config",


### PR DESCRIPTION
### Description

* Add covariance module to sklearnex `__init__.py` which allows to use `covariance` submodule after `import *`

The following code will work only after this change

```python
from sklearnex import *
c = covariance.IncrementalEmpiricalCovariance()
```

---

Checklist to comply with before moving PR from draft:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.  
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] The unit tests pass successfully.
- [x] I have run it locally and tested the changes extensively.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
