### PR TITLE
Fix for getting of description for PR Checklist job

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -42,8 +42,9 @@ jobs:
           core.setOutput('draft', pr_desc.data.draft)
     - name: Check if all checkboxes are checked
       id: checkboxes
+      env:
+        DESCRIPTION: ${{ steps.pr.outputs.body }}
       run: |
-        DESCRIPTION="${{ steps.pr.outputs.body }}"
         UNCHECKED=$(echo "$DESCRIPTION" | grep -c '\[ \]' || true)
         echo "unchecked=$UNCHECKED" >> $GITHUB_OUTPUT
     - name: Fail if not all checkboxes are checked and PR is not draft


### PR DESCRIPTION
## Description

Fixes setting of DESCRIPTION variable when description of PR contains ` or ``` breaking variable setting in bash.

Blocks of code to test it in current PR:

`print("Hello, world!")`

```print("Hello, world!")```

```python
print("Hello, world!")
```

Import of https://github.com/oneapi-src/oneDAL/pull/2927.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
