### PR TITLE
MAINT: increase tests timeout to `170`

### DIFF
--- a/tests/test_daal4py_examples.py
+++ b/tests/test_daal4py_examples.py
@@ -73,7 +73,7 @@ class Config:
     result_attribute: Union[str, Callable[..., Any]] = ""
     required_version: Optional[Tuple[Any, ...]] = None
     req_libs: List[str] = field(default_factory=list)
-    timeout_cpu_seconds: int = 120
+    timeout_cpu_seconds: int = 170
     suspended_on: Optional[Tuple[int, int, int]] = None
     suspended_for_n_days: int = 30
 


### PR DESCRIPTION
## Description

In this PR, the timeout for tests was increased due to longer execution times after transitioning to oneMKL.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
