### PR TITLE
CI: broaden kmeans 2025.0 deselections

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -382,8 +382,7 @@ deselected_tests:
 
   # Deselections for 2025.0
   - ensemble/tests/test_forest.py::test_importances[ExtraTreesRegressor-squared_error-float64]
-
-  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-1e-100-sparse_array-normal]
+  - cluster/tests/test_k_means.py::test_kmeans_elkan_results
 
   # --------------------------------------------------------
   # No need to test daal4py patching


### PR DESCRIPTION
## Description

Full list of conformance tests that have failed in nightly:
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-1e-100-sparse_array-normal]
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-0-sparse_array-normal]
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-0-sparse-normal]
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-0.01-sparse_array-normal]
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[1e-08-sparse-normal]
  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-1e-08-sparse_matrix-normal]

 Planning to just deselect the entire suite unless specific deselection is desired.

_Add a comprehensive description of proposed changes_

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

_Benchmarks PR (if needed): https://github.com/IntelPython/scikit-learn_bench/pull/155 (for example)_

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
