### PR TITLE
TEST: Run all tests through `pytest`

### DIFF
--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -21,6 +21,10 @@ import sys
 
 import pytest
 
+# This is a workaround for older versions of Python on Windows
+# which didn't have it as part of the built-in 'os' module.
+EX_OK = os.EX_OK if hasattr(os, "EX_OK") else 0
+
 # Note: from the structure of this file, one might thing of adding a test
 # along the lines of 'test_patching_all_from_command_line'. There is however
 # an issue in that, after the first time a scikit-learn module is imported,
@@ -36,14 +40,14 @@ def patch_svc_from_command_line():
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "patch_sklearn", "-a", "svc"]
     )
-    assert err_code == os.EX_OK
+    assert err_code == EX_OK
 
     yield
 
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn", "-a", "svc"]
     )
-    assert err_code == os.EX_OK
+    assert err_code == EX_OK
 
 
 def test_patching_svc_from_command_line(patch_svc_from_command_line):
@@ -59,7 +63,7 @@ def test_unpatching_svc_from_command_line(patch_svc_from_command_line):
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
     )
-    assert err_code == os.EX_OK
+    assert err_code == EX_OK
     from sklearnex import unpatch_sklearn
 
     unpatch_sklearn()

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -22,7 +22,7 @@ import pytest
 
 
 @pytest.fixture
-def patch_from_command_line(request):
+def patch_svc_from_command_line(request):
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "patch_sklearn", "-a", "svc"]
     )
@@ -38,7 +38,7 @@ def patch_from_command_line(request):
     return
 
 
-def test_patching_from_command_line(patch_from_command_line):
+def test_patching_svc_from_command_line(patch_from_command_line):
     from sklearn.svm import SVC, SVR
 
     assert SVC.__module__.startswith("daal4py") or SVC.__module__.startswith("sklearnex")
@@ -47,7 +47,7 @@ def test_patching_from_command_line(patch_from_command_line):
     )
 
 
-def test_unpatching_from_command_line(patch_from_command_line):
+def test_unpatching_svc_from_command_line(patch_from_command_line):
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
     )
@@ -66,7 +66,7 @@ def test_unpatching_from_command_line(patch_from_command_line):
 
 
 @pytest.fixture
-def patch_from_function(request):
+def patch_svc_from_function(request):
     from sklearnex import patch_sklearn, unpatch_sklearn
 
     patch_sklearn(name=["svc"], global_patch=True)
@@ -78,7 +78,7 @@ def patch_from_function(request):
     return
 
 
-def test_patching_from_function(patch_from_function):
+def test_patching_svc_from_function(patch_from_function):
     from sklearn.svm import SVC, SVR
 
     assert SVC.__module__.startswith("daal4py") or SVC.__module__.startswith("sklearnex")
@@ -87,7 +87,7 @@ def test_patching_from_function(patch_from_function):
     )
 
 
-def test_unpatching_from_function(patch_from_function):
+def test_unpatching_svc_from_function(patch_from_function):
     from sklearnex import unpatch_sklearn
 
     unpatch_sklearn(global_unpatch=True)

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -21,6 +21,15 @@ import sys
 
 import pytest
 
+# Note: from the structure of this file, one might thing of adding a test
+# along the lines of 'test_patching_all_from_command_line'. There is however
+# an issue in that, after the first time a scikit-learn module is imported,
+# further calls to 'patch_sklearn' with different arguments will have no effect
+# since sklearn is already imported. Reloading it through 'importlib.reload'
+# or deleting it from 'sys.modules' doesn't appear to have the intended effect
+# either. This also makes this first command-line fixture and tests that use
+# it not entirely idempotent, given that they need to import sklearn modules.
+
 
 @pytest.fixture
 def patch_svc_from_command_line():
@@ -62,42 +71,6 @@ def test_unpatching_svc_from_command_line(patch_svc_from_command_line):
     assert not SVR.__module__.startswith("daal4py") and not SVR.__module__.startswith(
         "sklearnex"
     )
-
-
-@pytest.fixture
-def patch_all_from_command_line():
-    err_code = subprocess.call([sys.executable, "-m", "sklearnex.glob", "patch_sklearn"])
-    assert err_code == os.EX_OK
-
-    yield
-
-    err_code = subprocess.call(
-        [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
-    )
-    assert err_code == os.EX_OK
-
-
-def test_patching_all_from_command_line(patch_all_from_command_line):
-    from sklearn.svm import SVC, SVR
-
-    assert SVC.__module__.startswith("daal4py") or SVC.__module__.startswith("sklearnex")
-    assert SVR.__module__.startswith("daal4py") or SVR.__module__.startswith("sklearnex")
-
-
-def test_unpatching_all_from_command_line(patch_all_from_command_line):
-    err_code = subprocess.call(
-        [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
-    )
-    assert err_code == os.EX_OK
-    from sklearnex import unpatch_sklearn
-
-    unpatch_sklearn()
-    from sklearn.svm import SVC, SVR
-
-    assert not SVC.__module__.startswith("daal4py")
-    assert not SVC.__module__.startswith("sklearnex")
-    assert not SVR.__module__.startswith("daal4py")
-    assert not SVR.__module__.startswith("sklearnex")
 
 
 @pytest.fixture

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -22,20 +22,18 @@ import pytest
 
 
 @pytest.fixture
-def patch_svc_from_command_line(request):
+def patch_svc_from_command_line():
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "patch_sklearn", "-a", "svc"]
     )
     assert not err_code
 
-    def unpatch_from_cmd():
-        err_code = subprocess.call(
-            [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
-        )
-        assert not err_code
+    yield
 
-    request.addfinalizer(unpatch_from_cmd)
-    return
+    err_code = subprocess.call(
+        [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
+    )
+    assert not err_code
 
 
 def test_patching_svc_from_command_line(patch_svc_from_command_line):
@@ -71,11 +69,9 @@ def patch_svc_from_function(request):
 
     patch_sklearn(name=["svc"], global_patch=True)
 
-    def unpatch_from_fn():
-        unpatch_sklearn(global_unpatch=True)
+    yield
 
-    request.addfinalizer(unpatch_from_fn)
-    return
+    unpatch_sklearn(global_unpatch=True)
 
 
 def test_patching_svc_from_function(patch_svc_from_function):

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -36,18 +36,20 @@ EX_OK = os.EX_OK if hasattr(os, "EX_OK") else 0
 
 
 @pytest.fixture
-def patch_svc_from_command_line():
+def patch_svc_from_command_line(request):
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "patch_sklearn", "-a", "svc"]
     )
     assert err_code == EX_OK
 
-    yield
+    def finalizer():
+        err_code = subprocess.call(
+            [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn", "-a", "svc"]
+        )
+        assert err_code == EX_OK
 
-    err_code = subprocess.call(
-        [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn", "-a", "svc"]
-    )
-    assert err_code == EX_OK
+    request.addfinalizer(finalizer)
+    return
 
 
 def test_patching_svc_from_command_line(patch_svc_from_command_line):
@@ -78,14 +80,16 @@ def test_unpatching_svc_from_command_line(patch_svc_from_command_line):
 
 
 @pytest.fixture
-def patch_svc_from_function():
+def patch_svc_from_function(request):
     from sklearnex import patch_sklearn, unpatch_sklearn
 
     patch_sklearn(name=["svc"], global_patch=True)
 
-    yield
+    def finalizer():
+        unpatch_sklearn(name=["svc"], global_unpatch=True)
 
-    unpatch_sklearn(name=["svc"], global_unpatch=True)
+    request.addfinalizer(finalizer)
+    return
 
 
 def test_patching_svc_from_function(patch_svc_from_function):
@@ -110,14 +114,16 @@ def test_unpatching_svc_from_function(patch_svc_from_function):
 
 
 @pytest.fixture
-def patch_all_from_function():
+def patch_all_from_function(request):
     from sklearnex import patch_sklearn, unpatch_sklearn
 
     patch_sklearn(global_patch=True)
 
-    yield
+    def finalizer():
+        unpatch_sklearn(global_unpatch=True)
 
-    unpatch_sklearn(global_unpatch=True)
+    request.addfinalizer(finalizer)
+    return
 
 
 def test_patching_svc_from_function(patch_all_from_function):

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -101,7 +101,7 @@ def test_unpatching_all_from_command_line(patch_all_from_command_line):
 
 
 @pytest.fixture
-def patch_svc_from_function(request):
+def patch_svc_from_function():
     from sklearnex import patch_sklearn, unpatch_sklearn
 
     patch_sklearn(name=["svc"], global_patch=True)
@@ -133,7 +133,7 @@ def test_unpatching_svc_from_function(patch_svc_from_function):
 
 
 @pytest.fixture
-def patch_all_from_function(request):
+def patch_all_from_function():
     from sklearnex import patch_sklearn, unpatch_sklearn
 
     patch_sklearn(global_patch=True)

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -38,7 +38,7 @@ def patch_svc_from_command_line(request):
     return
 
 
-def test_patching_svc_from_command_line(patch_from_command_line):
+def test_patching_svc_from_command_line(patch_svc_from_command_line):
     from sklearn.svm import SVC, SVR
 
     assert SVC.__module__.startswith("daal4py") or SVC.__module__.startswith("sklearnex")
@@ -47,7 +47,7 @@ def test_patching_svc_from_command_line(patch_from_command_line):
     )
 
 
-def test_unpatching_svc_from_command_line(patch_from_command_line):
+def test_unpatching_svc_from_command_line(patch_svc_from_command_line):
     err_code = subprocess.call(
         [sys.executable, "-m", "sklearnex.glob", "unpatch_sklearn"]
     )
@@ -78,7 +78,7 @@ def patch_svc_from_function(request):
     return
 
 
-def test_patching_svc_from_function(patch_from_function):
+def test_patching_svc_from_function(patch_svc_from_function):
     from sklearn.svm import SVC, SVR
 
     assert SVC.__module__.startswith("daal4py") or SVC.__module__.startswith("sklearnex")
@@ -87,7 +87,7 @@ def test_patching_svc_from_function(patch_from_function):
     )
 
 
-def test_unpatching_svc_from_function(patch_from_function):
+def test_unpatching_svc_from_function(patch_svc_from_function):
     from sklearnex import unpatch_sklearn
 
     unpatch_sklearn(global_unpatch=True)

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -34,6 +34,10 @@ EX_OK = os.EX_OK if hasattr(os, "EX_OK") else 0
 # either. This also makes this first command-line fixture and tests that use
 # it not entirely idempotent, given that they need to import sklearn modules.
 
+# Note 2: don't try to change these into 'yield' fixtures, because otherwise
+# some test runners on windows which use multi-processing will throw errors
+# about the fixtures not being serializable.
+
 
 @pytest.fixture
 def patch_svc_from_command_line(request):

--- a/.ci/scripts/test_global_patch.py
+++ b/.ci/scripts/test_global_patch.py
@@ -25,7 +25,8 @@ import pytest
 # which didn't have it as part of the built-in 'os' module.
 EX_OK = os.EX_OK if hasattr(os, "EX_OK") else 0
 
-# Note: from the structure of this file, one might thing of adding a test
+# Note: from the structure of this file, one might think of adding a test
+
 # along the lines of 'test_patching_all_from_command_line'. There is however
 # an issue in that, after the first time a scikit-learn module is imported,
 # further calls to 'patch_sklearn' with different arguments will have no effect

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -76,9 +76,10 @@ test:
         - daal4py/sklearn
     commands:
         - python -c "import daal4py"
-        - mpirun -n 4 python -m unittest discover -v -s tests -p test*spmd*.py # [not win]
-        - mpiexec -localonly -n 4 python -m unittest discover -v -s tests -p test*spmd*.py # [win]
-        - python -m unittest discover -v -s tests -p test*.py
+        - PYTHONPATH="tests:${PYTHONPATH}" mpirun -n 4 python -m pytest --verbose -s tests/test*spmd*.py # [not win]
+        - set PYTHONPATH=tests;%PYTHONPATH% && mpiexec -localonly -n 4 python -m pytest --verbose -s tests/test*spmd*.py # [win]
+        - PYTHONPATH="tests:${PYTHONPATH}" python -m pytest --verbose -s tests # [not win]
+        - set PYTHONPATH=tests;%PYTHONPATH% && python -m pytest --verbose -s tests # [win]
         - pytest --pyargs daal4py/sklearn/
         - python tests/run_examples.py
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -76,8 +76,8 @@ test:
         - daal4py/sklearn
     commands:
         - python -c "import daal4py"
-        - mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
-        - mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
+        - mpirun -n 4 pytest --verbose -s tests/test*spmd*.py # [not win]
+        - mpiexec -localonly -n 4 pytest --verbose -s tests/test*spmd*.py # [win]
         - pytest --pyargs --verbose -s tests
         - pytest --pyargs daal4py/sklearn/
         - python tests/run_examples.py

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -76,10 +76,9 @@ test:
         - daal4py/sklearn
     commands:
         - python -c "import daal4py"
-        - PYTHONPATH="${PYTHONPATH}:tests" mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
-        - set PYTHONPATH=%PYTHONPATH%;tests && mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
-        - PYTHONPATH="${PYTHONPATH}:tests" pytest --pyargs --verbose -s tests # [not win]
-        - set PYTHONPATH=%PYTHONPATH%;tests && python -m pytest --verbose -s tests # [win]
+        - mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
+        - mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
+        - pytest --pyargs --verbose -s tests
         - pytest --pyargs daal4py/sklearn/
         - python tests/run_examples.py
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -76,9 +76,9 @@ test:
         - daal4py/sklearn
     commands:
         - python -c "import daal4py"
-        - PYTHONPATH="tests:${PYTHONPATH}" mpirun -n 4 python -m pytest --verbose -s tests/test*spmd*.py # [not win]
-        - set PYTHONPATH=tests;%PYTHONPATH% && mpiexec -localonly -n 4 python -m pytest --verbose -s tests/test*spmd*.py # [win]
-        - PYTHONPATH="tests:${PYTHONPATH}" python -m pytest --verbose -s tests # [not win]
+        - PYTHONPATH="tests:${PYTHONPATH}" mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
+        - set PYTHONPATH=tests;%PYTHONPATH% && mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
+        - PYTHONPATH="tests:${PYTHONPATH}" pytest --pyargs --verbose -s tests # [not win]
         - set PYTHONPATH=tests;%PYTHONPATH% && python -m pytest --verbose -s tests # [win]
         - pytest --pyargs daal4py/sklearn/
         - python tests/run_examples.py

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -76,10 +76,10 @@ test:
         - daal4py/sklearn
     commands:
         - python -c "import daal4py"
-        - PYTHONPATH="tests:${PYTHONPATH}" mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
-        - set PYTHONPATH=tests;%PYTHONPATH% && mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
-        - PYTHONPATH="tests:${PYTHONPATH}" pytest --pyargs --verbose -s tests # [not win]
-        - set PYTHONPATH=tests;%PYTHONPATH% && python -m pytest --verbose -s tests # [win]
+        - PYTHONPATH="${PYTHONPATH}:tests" mpirun -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [not win]
+        - set PYTHONPATH=%PYTHONPATH%;tests && mpiexec -localonly -n 4 pytest --pyargs --verbose -s tests/test*spmd*.py # [win]
+        - PYTHONPATH="${PYTHONPATH}:tests" pytest --pyargs --verbose -s tests # [not win]
+        - set PYTHONPATH=%PYTHONPATH%;tests && python -m pytest --verbose -s tests # [win]
         - pytest --pyargs daal4py/sklearn/
         - python tests/run_examples.py
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -39,7 +39,8 @@ IF DEFINED TBBROOT (
     call "%TBBROOT%\env\vars.bat" || set exitcode=1
 )
 
-%PYTHON% -m unittest discover -v -s %1\tests -p test*.py || set exitcode=1
+set PYTHONPATH=%1\tests;%PYTHONPATH%
+%PYTHON% -m pytest --verbose -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1
 pytest --verbose --pyargs sklearnex || set exitcode=1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -39,10 +39,10 @@ IF DEFINED TBBROOT (
     call "%TBBROOT%\env\vars.bat" || set exitcode=1
 )
 
-pytest --verbose --pyargs -s %1\tests || set exitcode=1
+%PYTHON% -m pytest --verbose --pyargs -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1
 pytest --verbose --pyargs sklearnex || set exitcode=1
 pytest --verbose --pyargs %1\onedal --deselect="onedal/common/tests/test_policy.py" || set exitcode=1
-python %1\.ci\scripts\test_global_patch.py || set exitcode=1
+pytest --verbose --pyargs %1\.ci\scripts\test_global_patch.py || set exitcode=1
 EXIT /B %exitcode%

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -39,10 +39,10 @@ IF DEFINED TBBROOT (
     call "%TBBROOT%\env\vars.bat" || set exitcode=1
 )
 
-%PYTHON% -m pytest --verbose --pyargs -s %1\tests || set exitcode=1
+%PYTHON% -m pytest --verbose -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1
 pytest --verbose --pyargs sklearnex || set exitcode=1
 pytest --verbose --pyargs %1\onedal --deselect="onedal/common/tests/test_policy.py" || set exitcode=1
-pytest --verbose --pyargs %1\.ci\scripts\test_global_patch.py || set exitcode=1
+pytest --verbose %1\.ci\scripts\test_global_patch.py || set exitcode=1
 EXIT /B %exitcode%

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -40,7 +40,7 @@ IF DEFINED TBBROOT (
 )
 
 set PYTHONPATH=%1\tests;%PYTHONPATH%
-%PYTHON% -m pytest --verbose -s %1\tests || set exitcode=1
+%PYTHON% -m pytest --verbose --pyargs -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1
 pytest --verbose --pyargs sklearnex || set exitcode=1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -39,7 +39,7 @@ IF DEFINED TBBROOT (
     call "%TBBROOT%\env\vars.bat" || set exitcode=1
 )
 
-set PYTHONPATH=%1\tests;%PYTHONPATH%
+set PYTHONPATH=%PYTHONPATH%;%1\tests
 %PYTHON% -m pytest --verbose --pyargs -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -39,8 +39,7 @@ IF DEFINED TBBROOT (
     call "%TBBROOT%\env\vars.bat" || set exitcode=1
 )
 
-set PYTHONPATH=%PYTHONPATH%;%1\tests
-%PYTHON% -m pytest --verbose --pyargs -s %1\tests || set exitcode=1
+pytest --verbose --pyargs -s %1\tests || set exitcode=1
 
 pytest --verbose --pyargs %1\daal4py\sklearn || set exitcode=1
 pytest --verbose --pyargs sklearnex || set exitcode=1

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -39,14 +39,14 @@ return_code=$(($return_code + $?))
 
 echo "Pytest run of legacy unittest ..."
 echo ${daal4py_dir}
-pytest --verbose --pyargs -s ${daal4py_dir}/tests
+pytest --verbose -s ${daal4py_dir}/tests
 return_code=$(($return_code + $?))
 
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
+    mpirun -n 4 pytest --verbose -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 
@@ -63,7 +63,7 @@ pytest --verbose --pyargs ${daal4py_dir}/onedal
 return_code=$(($return_code + $?))
 
 echo "Global patching test running ..."
-pytest --verbose --pyargs -s ${daal4py_dir}/.ci/scripts/test_global_patch.py
+pytest --verbose -s ${daal4py_dir}/.ci/scripts/test_global_patch.py
 return_code=$(($return_code + $?))
 
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -41,15 +41,14 @@ echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    PYTHONPATH="${PYTHONPATH}:${daal4py_dir}/tests" mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
+    PYTHONPATH=mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 
 echo "Pytest run of legacy unittest ..."
 echo ${daal4py_dir}
-PYTHONPATH="${PYTHONPATH}:${daal4py_dir}/tests" pytest --verbose --pyargs -s ${daal4py_dir}/tests
+pytest --verbose --pyargs -s ${daal4py_dir}/tests
 return_code=$(($return_code + $?))
-exit 1
 
 echo "Pytest of daal4py running ..."
 pytest --verbose --pyargs ${daal4py_dir}/daal4py/sklearn

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -63,7 +63,7 @@ pytest --verbose --pyargs ${daal4py_dir}/onedal
 return_code=$(($return_code + $?))
 
 echo "Global patching test running ..."
-python ${daal4py_dir}/.ci/scripts/test_global_patch.py
+pytest --verbose --pyargs -s ${daal4py_dir}/.ci/scripts/test_global_patch.py
 return_code=$(($return_code + $?))
 
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -37,6 +37,11 @@ return_code=0
 python -c "import daal4py"
 return_code=$(($return_code + $?))
 
+echo "Pytest run of legacy unittest ..."
+echo ${daal4py_dir}
+pytest --verbose --pyargs -s ${daal4py_dir}/tests
+return_code=$(($return_code + $?))
+
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
@@ -44,11 +49,6 @@ if [[ ! $NO_DIST ]]; then
     mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
-
-echo "Pytest run of legacy unittest ..."
-echo ${daal4py_dir}
-pytest --verbose --pyargs -s ${daal4py_dir}/tests
-return_code=$(($return_code + $?))
 
 echo "Pytest of daal4py running ..."
 pytest --verbose --pyargs ${daal4py_dir}/daal4py/sklearn

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -41,14 +41,15 @@ echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
+    PYTHONPATH="${PYTHONPATH}:${daal4py_dir}/tests" mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 
 echo "Pytest run of legacy unittest ..."
 echo ${daal4py_dir}
-PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" pytest --verbose --pyargs -s ${daal4py_dir}/tests
+PYTHONPATH="${PYTHONPATH}:${daal4py_dir}/tests" pytest --verbose --pyargs -s ${daal4py_dir}/tests
 return_code=$(($return_code + $?))
+exit 1
 
 echo "Pytest of daal4py running ..."
 pytest --verbose --pyargs ${daal4py_dir}/daal4py/sklearn

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -39,14 +39,15 @@ return_code=$(($return_code + $?))
 
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
-    echo "MPI unittest discover testing ..."
+    echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    mpirun -n 4 python -m unittest discover -v -s ${daal4py_dir}/tests -p test*spmd*.py
+    PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" mpirun -n 4 python -m pytest --verbose -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 
-echo "Unittest discover testing ..."
-python -m unittest discover -v -s ${daal4py_dir}/tests -p test*.py
+echo "Pytest run of legacy unittest ..."
+echo ${daal4py_dir}
+PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" python -m pytest --verbose -s ${daal4py_dir}/tests
 return_code=$(($return_code + $?))
 
 echo "Pytest of daal4py running ..."

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -41,13 +41,13 @@ echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" mpirun -n 4 python -m pytest --verbose -s ${daal4py_dir}/tests/test*spmd*.py
+    PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 
 echo "Pytest run of legacy unittest ..."
 echo ${daal4py_dir}
-PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" python -m pytest --verbose -s ${daal4py_dir}/tests
+PYTHONPATH="${daal4py_dir}/tests:${PYTHONPATH}" pytest --verbose --pyargs -s ${daal4py_dir}/tests
 return_code=$(($return_code + $?))
 
 echo "Pytest of daal4py running ..."

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -41,7 +41,7 @@ echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     echo "MPI pytest run of legacy unittest ..."
     mpirun --version
-    PYTHONPATH=mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
+    mpirun -n 4 pytest --verbose --pyargs -s ${daal4py_dir}/tests/test*spmd*.py
     return_code=$(($return_code + $?))
 fi
 

--- a/tests/test_daal4py_spmd_examples.py
+++ b/tests/test_daal4py_spmd_examples.py
@@ -19,7 +19,10 @@ import unittest
 from pathlib import Path
 
 import numpy as np
-from test_daal4py_examples import (
+
+import daal4py as d4p
+
+from .test_daal4py_examples import (
     Base,
     Config,
     batch_data_path,
@@ -29,8 +32,6 @@ from test_daal4py_examples import (
     low_order_moms_getter,
     readcsv,
 )
-
-import daal4py as d4p
 
 # the examples are supposed to be executed in parallel with mpirun
 try:

--- a/tests/test_daal4py_spmd_examples.py
+++ b/tests/test_daal4py_spmd_examples.py
@@ -19,10 +19,7 @@ import unittest
 from pathlib import Path
 
 import numpy as np
-
-import daal4py as d4p
-
-from .test_daal4py_examples import (
+from test_daal4py_examples import (
     Base,
     Config,
     batch_data_path,
@@ -32,6 +29,8 @@ from .test_daal4py_examples import (
     low_order_moms_getter,
     readcsv,
 )
+
+import daal4py as d4p
 
 # the examples are supposed to be executed in parallel with mpirun
 try:

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -17,7 +17,6 @@
 import os
 import subprocess
 import sys
-import unittest
 
 import pytest
 

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -24,6 +24,10 @@ test_path = os.path.abspath(os.path.dirname(__file__))
 unittest_data_path = os.path.join(test_path, "unittest_data")
 examples_path = os.path.join(os.path.dirname(test_path), "examples", "sklearnex")
 
+# This is a workaround for older versions of Python on Windows
+# which didn't have it as part of the built-in 'os' module.
+EX_OK = os.EX_OK if hasattr(os, "EX_OK") else 0
+
 
 @pytest.mark.parametrize(
     "file",
@@ -43,7 +47,7 @@ def test_sklearn_example(file):
     )  # nosec
     exit_code = process.returncode
 
-    if exit_code != os.EX_OK:
+    if exit_code != EX_OK:
         pytest.fail(
             pytrace=False,
             reason=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -43,8 +43,7 @@ def test_sklearn_example(file):
     )  # nosec
     exit_code = process.returncode
 
-    # Assert that the exit code is 0
-    if exit_code:
+    if exit_code != os.EX_OK:
         pytest.fail(
             pytrace=False,
             reason=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -21,48 +21,32 @@ import unittest
 
 import pytest
 
-from daal4py.sklearn._utils import get_daal_version
-
 test_path = os.path.abspath(os.path.dirname(__file__))
 unittest_data_path = os.path.join(test_path, "unittest_data")
 examples_path = os.path.join(os.path.dirname(test_path), "examples", "sklearnex")
 
-print("Testing examples_sklearnex")
-# First item is major version - 2021,
-# second is minor+patch - 0110,
-# third item is status - B
-sklearnex_version = get_daal_version()
-print("oneDAL version:", sklearnex_version)
 
+@pytest.mark.parametrize(
+    "file",
+    [
+        f
+        for f in os.listdir(examples_path)
+        if f.endswith(".py") and "spmd" not in f and "dpnp" not in f and "dpctl" not in f
+    ],
+)
+def test_generator(file):
+    # Run the script and capture its exit code
+    process = subprocess.run(
+        [sys.executable, os.path.join(examples_path, file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )  # nosec
+    exit_code = process.returncode
 
-class TestsklearnexExamples(unittest.TestCase):
-    """Class for testing sklernex examples"""
-
-    @pytest.mark.parametrize(
-        "file",
-        [
-            f
-            for f in os.listdir(examples_path)
-            if f.endswith(".py")
-            and "spmd" not in f
-            and "dpnp" not in f
-            and "dpctl" not in f
-        ],
-    )
-    def test_generator(file):
-        def testit(self):
-            # Run the script and capture its exit code
-            process = subprocess.run(
-                [sys.executable, os.path.join(examples_path, file)],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-            )  # nosec
-            exit_code = process.returncode
-
-            # Assert that the exit code is 0
-            self.assertEqual(
-                exit_code,
-                0,
-                msg=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",
-            )
+    # Assert that the exit code is 0
+    if exit_code:
+        pytest.fail(
+            pytrace=False,
+            reason=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",
+        )

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -33,7 +33,7 @@ examples_path = os.path.join(os.path.dirname(test_path), "examples", "sklearnex"
         if f.endswith(".py") and "spmd" not in f and "dpnp" not in f and "dpctl" not in f
     ],
 )
-def test_generator(file):
+def test_sklearn_example(file):
     # Run the script and capture its exit code
     process = subprocess.run(
         [sys.executable, os.path.join(examples_path, file)],

--- a/tests/test_examples_sklearnex.py
+++ b/tests/test_examples_sklearnex.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 import unittest
 
+import pytest
+
 from daal4py.sklearn._utils import get_daal_version
 
 test_path = os.path.abspath(os.path.dirname(__file__))
@@ -36,40 +38,31 @@ print("oneDAL version:", sklearnex_version)
 class TestsklearnexExamples(unittest.TestCase):
     """Class for testing sklernex examples"""
 
-    # Get a list of all Python files in the examples directory
-    pass
+    @pytest.mark.parametrize(
+        "file",
+        [
+            f
+            for f in os.listdir(examples_path)
+            if f.endswith(".py")
+            and "spmd" not in f
+            and "dpnp" not in f
+            and "dpctl" not in f
+        ],
+    )
+    def test_generator(file):
+        def testit(self):
+            # Run the script and capture its exit code
+            process = subprocess.run(
+                [sys.executable, os.path.join(examples_path, file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )  # nosec
+            exit_code = process.returncode
 
-
-def test_generator(file):
-    def testit(self):
-        # Run the script and capture its exit code
-        process = subprocess.run(
-            [sys.executable, os.path.join(examples_path, file)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )  # nosec
-        exit_code = process.returncode
-
-        # Assert that the exit code is 0
-        self.assertEqual(
-            exit_code,
-            0,
-            msg=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",
-        )
-
-    setattr(TestsklearnexExamples, "test_" + os.path.splitext(file)[0], testit)
-    print("Generating tests for " + os.path.splitext(file)[0])
-
-
-files = [
-    f
-    for f in os.listdir(examples_path)
-    if f.endswith(".py") and "spmd" not in f and "dpnp" not in f and "dpctl" not in f
-]
-
-for file in files:
-    test_generator(file)
-
-if __name__ == "__main__":
-    unittest.main()
+            # Assert that the exit code is 0
+            self.assertEqual(
+                exit_code,
+                0,
+                msg=f"Example has failed, the example's output:\n{process.stdout.decode()}\n{process.stderr.decode()}",
+            )


### PR DESCRIPTION
## Description

Currently, unit tests execute through a mixture of built-in `unittest` and `pytest`.

From the commit history, it looks like initial tests were added using python's built-in `unittest` framework, and then subsequent tests were introduced using `pytest`.

Compared to `unittest`, `pytest` has a much nicer output format, offers many options for how to execute tests and how to see their outputs, and has plugins that allow it do extra things which the built-in cannot when desired (e.g. JSON outputs, test coverage reports, etc.).

This PR switches the automated scripts to execute all of the tests using `pytest`. This doesn't change what tests were executed - just uses `pytest` as the runner.

One challenge here is how each of these interprets the path from where modules are imported - here I'm trying to control these with the `PYTHONPATH` variable when `pytest` is called within shell scripts, but don't know if this will work out for all the variants under which tests are executed.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
