### PR TITLE
[enhancement] ban runtime use of Python's ```property``` in sklearnex

### DIFF
--- a/onedal/cluster/kmeans.py
+++ b/onedal/cluster/kmeans.py
@@ -349,7 +349,8 @@ class _BaseKMeans(onedal_BaseEstimator, TransformerMixin, ClusterMixin, ABC):
 
         return self
 
-    def _get_cluster_centers(self):
+    @property
+    def cluster_centers_(self):
         if not hasattr(self, "_cluster_centers_"):
             if hasattr(self, "model_"):
                 centroids = self.model_.centroids
@@ -358,7 +359,8 @@ class _BaseKMeans(onedal_BaseEstimator, TransformerMixin, ClusterMixin, ABC):
                 raise NameError("This model have not been trained")
         return self._cluster_centers_
 
-    def _set_cluster_centers(self, cluster_centers):
+    @cluster_centers_.setter
+    def cluster_centers_(self, cluster_centers):
         self._cluster_centers_ = np.asarray(cluster_centers)
 
         self.n_iter_ = 0
@@ -371,7 +373,9 @@ class _BaseKMeans(onedal_BaseEstimator, TransformerMixin, ClusterMixin, ABC):
 
         return self
 
-    cluster_centers_ = property(_get_cluster_centers, _set_cluster_centers)
+    @cluster_centers_.deleter
+    def cluster_centers_(self):
+        del self._cluster_centers_
 
     def _predict(self, X, module, queue=None, result_options=None):
         is_csr = _is_csr(X)

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -298,7 +298,7 @@ class LinearRegression(_sklearn_LinearRegression):
         return self._intercept_
 
     @intercept_.setter
-    def set_intercept_(self, value):
+    def intercept_(self, value):
         self._intercept_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.intercept_ = value

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -289,6 +289,10 @@ class LinearRegression(_sklearn_LinearRegression):
             self._onedal_estimator.coef_ = value
             del self._onedal_estimator._onedal_model
 
+    @coef_.deleter
+    def coef_(self):
+        del self._coef_
+
     @property
     def intercept_(self):
         return self._intercept_
@@ -299,6 +303,10 @@ class LinearRegression(_sklearn_LinearRegression):
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.intercept_ = value
             del self._onedal_estimator._onedal_model
+
+    @intercept_.deleter
+    def intercept_(self):
+        del self._intercept_
 
     def _save_attributes(self):
         self.n_features_in_ = self._onedal_estimator.n_features_in_

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -278,31 +278,33 @@ class LinearRegression(_sklearn_LinearRegression):
             y, self._onedal_predict(X, queue=queue), sample_weight=sample_weight
         )
 
-    def get_coef_(self):
-        return self.coef_
+    @property
+    def coef_(self):
+        return self._coef_
 
-    def set_coef_(self, value):
-        self.__dict__["coef_"] = value
+    @coef_.setter
+    def coef_(self, value):
+        self._coef_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.coef_ = value
             del self._onedal_estimator._onedal_model
 
-    def get_intercept_(self):
-        return self.intercept_
+    @property
+    def intercept_(self):
+        return self._intercept_
 
+    @intercept_.setter
     def set_intercept_(self, value):
-        self.__dict__["intercept_"] = value
+        self._intercept_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.intercept_ = value
             del self._onedal_estimator._onedal_model
 
     def _save_attributes(self):
-        self.coef_ = property(self.get_coef_, self.set_coef_)
-        self.intercept_ = property(self.get_intercept_, self.set_intercept_)
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self._sparse = False
-        self.__dict__["coef_"] = self._onedal_estimator.coef_
-        self.__dict__["intercept_"] = self._onedal_estimator.intercept_
+        self._coef_ = self._onedal_estimator.coef_
+        self._intercept_ = self._onedal_estimator.intercept_
 
     fit.__doc__ = _sklearn_LinearRegression.fit.__doc__
     predict.__doc__ = _sklearn_LinearRegression.predict.__doc__

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -51,6 +51,10 @@ class BaseSVM(BaseEstimator, ABC):
             if not self._is_in_fit:
                 del self._onedal_estimator._onedal_model
 
+    @dual_coef_.deleter
+    def dual_coef_(self):
+        del self._dual_coef_
+
     @property
     def intercept_(self):
         return self._intercept_
@@ -62,6 +66,10 @@ class BaseSVM(BaseEstimator, ABC):
             self._onedal_estimator.intercept_ = value
             if not self._is_in_fit:
                 del self._onedal_estimator._onedal_model
+
+    @intercept_.deleter
+    def intercept_(self):
+        del self._intercept_
 
     def _onedal_gpu_supported(self, method_name, *data):
         patching_status = PatchingConditionsChain(f"sklearn.{method_name}")

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -41,11 +41,11 @@ class BaseSVM(BaseEstimator, ABC):
 
     @property
     def _dual_coef_(self):
-        return self._dualcoef_
+        return self.dual_coef_
 
     @_dual_coef_.setter
     def _dual_coef_(self, value):
-        self._dualcoef_ = value
+        self.dual_coef_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.dual_coef_ = value
             if hasattr(self._onedal_estimator, "_onedal_model"):
@@ -53,7 +53,7 @@ class BaseSVM(BaseEstimator, ABC):
 
     @_dual_coef_.deleter
     def _dual_coef_(self):
-        del self._dualcoef_
+        del self.dual_coef_
 
     @property
     def intercept_(self):
@@ -305,8 +305,6 @@ class BaseSVC(BaseSVM):
             self._probA = np.empty(0)
             self._probB = np.empty(0)
 
-        self._dualcoef_ = self.dual_coef_
-
         if sklearn_check_version("1.1"):
             length = int(len(self.classes_) * (len(self.classes_) - 1) / 2)
             self.n_iter_ = np.full((length,), self._onedal_estimator.n_iter_)
@@ -327,8 +325,6 @@ class BaseSVR(BaseSVM):
         self._gamma = self._onedal_estimator._gamma
         self._probA = None
         self._probB = None
-
-        self._dualcoef_ = self.dual_coef_
 
         if sklearn_check_version("1.1"):
             self.n_iter_ = self._onedal_estimator.n_iter_

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -40,20 +40,20 @@ else:
 class BaseSVM(BaseEstimator, ABC):
 
     @property
-    def dual_coef_(self):
-        return self._dual_coef_
+    def _dual_coef_(self):
+        return self._dualcoef_
 
-    @dual_coef_.setter
-    def dual_coef_(self, value):
-        self._dual_coef_ = value
+    @_dual_coef_.setter
+    def _dual_coef_(self, value):
+        self._dualcoef_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.dual_coef_ = value
             if not self._is_in_fit:
                 del self._onedal_estimator._onedal_model
 
-    @dual_coef_.deleter
-    def dual_coef_(self):
-        del self._dual_coef_
+    @_dual_coef_.deleter
+    def _dual_coef_(self):
+        del self._dualcoef_
 
     @property
     def intercept_(self):
@@ -286,7 +286,7 @@ class BaseSVC(BaseSVM):
         self.support_vectors_ = self._onedal_estimator.support_vectors_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.fit_status_ = 0
-        self._dual_coef_ = self._onedal_estimator.dual_coef_
+        self.dual_coef_ = self._onedal_estimator.dual_coef_
         self.shape_fit_ = self._onedal_estimator.class_weight_
         self.classes_ = self._onedal_estimator.classes_
         if isinstance(self, ClassifierMixin) or not sklearn_check_version("1.2"):
@@ -305,6 +305,7 @@ class BaseSVC(BaseSVM):
             self._probA = np.empty(0)
             self._probB = np.empty(0)
 
+        self._dualcoef_ = self.dual_coef_
         self._is_in_fit = False
 
         if sklearn_check_version("1.1"):
@@ -317,7 +318,7 @@ class BaseSVR(BaseSVM):
         self.support_vectors_ = self._onedal_estimator.support_vectors_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.fit_status_ = 0
-        self._dual_coef_ = self._onedal_estimator.dual_coef_
+        self.dual_coef_ = self._onedal_estimator.dual_coef_
         self.shape_fit_ = self._onedal_estimator.shape_fit_
         self.support_ = self._onedal_estimator.support_
 
@@ -328,9 +329,7 @@ class BaseSVR(BaseSVM):
         self._probA = None
         self._probB = None
 
-        self._is_in_fit = True
-        self._dual_coef_ = self.dual_coef_
-        self.intercept_ = self._intercept_
+        self._dualcoef_ = self.dual_coef_
         self._is_in_fit = False
 
         if sklearn_check_version("1.1"):

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -36,6 +36,7 @@ if sklearn_check_version("1.6"):
 else:
     validate_data = BaseEstimator._validate_data
 
+
 class BaseSVM(BaseEstimator, ABC):
 
     @property
@@ -308,7 +309,7 @@ class BaseSVR(BaseSVM):
         self.support_vectors_ = self._onedal_estimator.support_vectors_
         self.n_features_in_ = self._onedal_estimator.n_features_in_
         self.fit_status_ = 0
-        self.dual_coef_ = self._onedal_estimator.dual_coef_
+        self._dual_coef_ = self._onedal_estimator.dual_coef_
         self.shape_fit_ = self._onedal_estimator.shape_fit_
         self.support_ = self._onedal_estimator.support_
 
@@ -318,9 +319,6 @@ class BaseSVR(BaseSVM):
         self._gamma = self._onedal_estimator._gamma
         self._probA = None
         self._probB = None
-
-        self._dual_coef_ = property(get_dual_coef, set_dual_coef)
-        self.intercept_ = property(get_intercept, set_intercept)
 
         self._is_in_fit = True
         self._dual_coef_ = self.dual_coef_

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -48,7 +48,7 @@ class BaseSVM(BaseEstimator, ABC):
         self._dualcoef_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.dual_coef_ = value
-            if not self._is_in_fit:
+            if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
 
     @_dual_coef_.deleter
@@ -64,7 +64,7 @@ class BaseSVM(BaseEstimator, ABC):
         self._intercept_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.intercept_ = value
-            if not self._is_in_fit:
+            if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
 
     @intercept_.deleter
@@ -306,7 +306,6 @@ class BaseSVC(BaseSVM):
             self._probB = np.empty(0)
 
         self._dualcoef_ = self.dual_coef_
-        self._is_in_fit = False
 
         if sklearn_check_version("1.1"):
             length = int(len(self.classes_) * (len(self.classes_) - 1) / 2)
@@ -330,7 +329,6 @@ class BaseSVR(BaseSVM):
         self._probB = None
 
         self._dualcoef_ = self.dual_coef_
-        self._is_in_fit = False
 
         if sklearn_check_version("1.1"):
             self.n_iter_ = self._onedal_estimator.n_iter_

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -51,6 +51,10 @@ class BaseSVM(BaseEstimator, ABC):
             if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
 
+    @_dual_coef.deleter
+    def _dual_coef_(self):
+        del self._dualcoef_
+
     @property
     def intercept_(self):
         return self._icept_
@@ -62,6 +66,10 @@ class BaseSVM(BaseEstimator, ABC):
             self._onedal_estimator.intercept_ = value
             if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
+
+    @intercept_.deleter
+    def intercept_(self):
+        del self._icept_
 
     def _onedal_gpu_supported(self, method_name, *data):
         patching_status = PatchingConditionsChain(f"sklearn.{method_name}")

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -41,11 +41,11 @@ class BaseSVM(BaseEstimator, ABC):
 
     @property
     def _dual_coef_(self):
-        return self.dual_coef_
+        return self._dualcoef_
 
     @_dual_coef_.setter
     def _dual_coef_(self, value):
-        self.dual_coef_ = value
+        self._dualcoef_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.dual_coef_ = value
             if hasattr(self._onedal_estimator, "_onedal_model"):
@@ -53,11 +53,11 @@ class BaseSVM(BaseEstimator, ABC):
 
     @property
     def intercept_(self):
-        return self._intercept_
+        return self._icept_
 
     @intercept_.setter
     def intercept_(self, value):
-        self._intercept_ = value
+        self._icept_ = value
         if hasattr(self, "_onedal_estimator"):
             self._onedal_estimator.intercept_ = value
             if hasattr(self._onedal_estimator, "_onedal_model"):
@@ -285,7 +285,7 @@ class BaseSVC(BaseSVM):
             self.class_weight_ = self._onedal_estimator.class_weight_
         self.support_ = self._onedal_estimator.support_
 
-        self._intercept_ = self._onedal_estimator.intercept_
+        self._icept_ = self._onedal_estimator.intercept_
         self._n_support = self._onedal_estimator._n_support
         self._sparse = False
         self._gamma = self._onedal_estimator._gamma
@@ -296,6 +296,8 @@ class BaseSVC(BaseSVM):
         else:
             self._probA = np.empty(0)
             self._probB = np.empty(0)
+
+        self._dualcoef_ = self.dual_coef_
 
         if sklearn_check_version("1.1"):
             length = int(len(self.classes_) * (len(self.classes_) - 1) / 2)
@@ -311,7 +313,7 @@ class BaseSVR(BaseSVM):
         self.shape_fit_ = self._onedal_estimator.shape_fit_
         self.support_ = self._onedal_estimator.support_
 
-        self._intercept_ = self._onedal_estimator.intercept_
+        self._icept_ = self._onedal_estimator.intercept_
         self._n_support = [self.support_vectors_.shape[0]]
         self._sparse = False
         self._gamma = self._onedal_estimator._gamma
@@ -320,6 +322,8 @@ class BaseSVR(BaseSVM):
 
         if sklearn_check_version("1.1"):
             self.n_iter_ = self._onedal_estimator.n_iter_
+
+        self._dualcoef_ = self.dual_coef_
 
     def _onedal_score(self, X, y, sample_weight=None, queue=None):
         return r2_score(

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -51,7 +51,7 @@ class BaseSVM(BaseEstimator, ABC):
             if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
 
-    @_dual_coef.deleter
+    @_dual_coef_.deleter
     def _dual_coef_(self):
         del self._dualcoef_
 

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -51,10 +51,6 @@ class BaseSVM(BaseEstimator, ABC):
             if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
 
-    @_dual_coef_.deleter
-    def _dual_coef_(self):
-        del self.dual_coef_
-
     @property
     def intercept_(self):
         return self._intercept_
@@ -66,10 +62,6 @@ class BaseSVM(BaseEstimator, ABC):
             self._onedal_estimator.intercept_ = value
             if hasattr(self._onedal_estimator, "_onedal_model"):
                 del self._onedal_estimator._onedal_model
-
-    @intercept_.deleter
-    def intercept_(self):
-        del self._intercept_
 
     def _onedal_gpu_supported(self, method_name, *data):
         patching_status = PatchingConditionsChain(f"sklearn.{method_name}")

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -342,7 +342,9 @@ def n_jobs_check(text, estimator, method):
 def runtime_property_check(text, estimator, method):
     """use of Python's 'property' should not be used at runtime, only at class instantiation"""
     # remove the _get_backend function from sklearnex from considered _get_backend
-    assert len(re.findall("property(", text[1])) == 0
+    assert (
+        len(re.findall("property(", text[1])) == 0
+    ), f"{estimator}.{method} should only use 'property' at instantiation"
 
 
 DESIGN_RULES = [n_jobs_check, runtime_property_check]

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -341,7 +341,6 @@ def n_jobs_check(text, estimator, method):
 
 def runtime_property_check(text, estimator, method):
     """use of Python's 'property' should not be used at runtime, only at class instantiation"""
-    # remove the _get_backend function from sklearnex from considered _get_backend
     assert (
         len(re.findall("property(", text[1])) == 0
     ), f"{estimator}.{method} should only use 'property' at instantiation"

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -339,7 +339,13 @@ def n_jobs_check(text, estimator, method):
     ), f"verify if {method} should be in control_n_jobs' decorated_methods for {estimator}"
 
 
-DESIGN_RULES = [n_jobs_check]
+def runtime_property_check(text, estimator, method):
+    """use of Python's 'property' should not be used at runtime, only at class instantiation"""
+    # remove the _get_backend function from sklearnex from considered _get_backend
+    assert len(re.findall("property(", text[1])) == 0
+
+
+DESIGN_RULES = [n_jobs_check, runtime_property_check]
 
 
 if sklearn_check_version("1.0"):


### PR DESCRIPTION
## Description

using ```property``` at runtime is un-pythonic and confusing.  This bans the practice (will require some refactoring of ```LinearRegression```-derived classes).

Notable changes:
- Make SVM ```intercept_``` and ```_dual_coef_``` more robust by proper use of ```property```
- Fix IncrementalLinearRegression's use of ```property``` for ```coef_``` and ```intercept_```
- Fix LinearRegression's use of ```property``` for ``coef_``` and ```intercept_```
- Add design rule check when regexes for 'property('
---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
