### PR TITLE
FIX: update functional support fallback logic for a DPNP/DPCTL ndarray inputs

### DIFF
--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -140,7 +140,7 @@ def _transfer_to_host(queue, *data):
             raise RuntimeError("Input data shall be located on single target device")
 
         host_data.append(item)
-    return queue, host_data
+    return has_usm_data, queue, host_data
 
 
 def _get_global_queue():
@@ -157,8 +157,8 @@ def _get_global_queue():
 
 def _get_host_inputs(*args, **kwargs):
     q = _get_global_queue()
-    q, hostargs = _transfer_to_host(q, *args)
-    q, hostvalues = _transfer_to_host(q, *kwargs.values())
+    _, q, hostargs = _transfer_to_host(q, *args)
+    _, q, hostvalues = _transfer_to_host(q, *kwargs.values())
     hostkwargs = dict(zip(kwargs.keys(), hostvalues))
     return q, hostargs, hostkwargs
 

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -70,7 +70,9 @@ def dispatch(obj, method_name, branches, *args, **kwargs):
     backend, q, patching_status = _get_backend(obj, q, method_name, *hostargs)
     has_usm_data = has_usm_data_for_args or has_usm_data_for_kwargs
     if backend == "onedal":
-        patching_status.write_log(queue=q)
+        # Host args only used before onedal backend call.
+        # Device will be offloaded when onedal backend will be called.
+        patching_status.write_log(queue=q, transferred_to_host=False)
         return branches[backend](obj, *hostargs, **hostkwargs, queue=q)
     if backend == "sklearn":
         if (
@@ -88,7 +90,7 @@ def dispatch(obj, method_name, branches, *args, **kwargs):
             # of the fallback cases.
             # If `array_api_dispatch` enabled and array api is supported for the stock scikit-learn,
             # then raw inputs are used for the fallback.
-            patching_status.write_log()
+            patching_status.write_log(transferred_to_host=False)
             return branches[backend](obj, *args, **kwargs)
         else:
             patching_status.write_log()

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -80,6 +80,12 @@ def dispatch(obj, method_name, branches, *args, **kwargs):
             and obj._get_tags()["array_api_support"]
             and not has_usm_data
         ):
+            # USM ndarrays are also excluded for the fallback Array API. Currently, DPNP.ndarray is
+            # not compliant with the Array API standard, and DPCTL usm_ndarray Array API is compliant,
+            # except for the linalg module. There is no guarantee that stock scikit-learn will
+            # work with such input data. The condition will be updated after DPNP.ndarray and
+            # DPCTL usm_ndarray enabling for conformance testing and these arrays supportance
+            # of the fallback cases.
             # If `array_api_dispatch` enabled and array api is supported for the stock scikit-learn,
             # then raw inputs are used for the fallback.
             patching_status.write_log()

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -29,10 +29,10 @@ class PatchingConditionsChain(daal4py_PatchingConditionsChain):
     def get_status(self):
         return self.patching_is_enabled
 
-    def write_log(self, queue=None):
+    def write_log(self, queue=None, transferred_to_host=True):
         if self.patching_is_enabled:
             self.logger.info(
-                f"{self.scope_name}: {get_patch_message('onedal', queue=queue)}"
+                f"{self.scope_name}: {get_patch_message('onedal', queue=queue, transferred_to_host=transferred_to_host)}"
             )
         else:
             self.logger.debug(
@@ -43,7 +43,9 @@ class PatchingConditionsChain(daal4py_PatchingConditionsChain):
                 self.logger.debug(
                     f"{self.scope_name}: patching failed with cause - {message}"
                 )
-            self.logger.info(f"{self.scope_name}: {get_patch_message('sklearn')}")
+            self.logger.info(
+                f"{self.scope_name}: {get_patch_message('sklearn', transferred_to_host=transferred_to_host)}"
+            )
 
 
 def set_sklearn_ex_verbose():
@@ -66,7 +68,7 @@ def set_sklearn_ex_verbose():
         )
 
 
-def get_patch_message(s, queue=None):
+def get_patch_message(s, queue=None, transferred_to_host=True):
     if s == "onedal":
         message = "running accelerated version on "
         if queue is not None:
@@ -87,11 +89,18 @@ def get_patch_message(s, queue=None):
             f"Invalid input - expected one of 'onedal','sklearn',"
             f" 'sklearn_after_onedal', got {s}"
         )
+    if transferred_to_host:
+        message += (
+            ". All input data transferred to host for further backend computations."
+        )
     return message
 
 
-def get_sklearnex_version(rule):
-    return daal_check_version(rule)
+def get_usm_data_message(is_copied=False):
+    message = ""
+    if is_copied:
+        message = ". All USM inputs are being copied to HOST for further computations."
+    return message
 
 
 def register_hyperparameters(hyperparameters_map):

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -96,6 +96,10 @@ def get_patch_message(s, queue=None, transferred_to_host=True):
     return message
 
 
+def get_sklearnex_version(rule):
+    return daal_check_version(rule)
+
+
 def register_hyperparameters(hyperparameters_map):
     """Decorator for hyperparameters support in estimator class.
     Adds `get_hyperparameters` method to class.

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -96,13 +96,6 @@ def get_patch_message(s, queue=None, transferred_to_host=True):
     return message
 
 
-def get_usm_data_message(is_copied=False):
-    message = ""
-    if is_copied:
-        message = ". All USM inputs are being copied to HOST for further computations."
-    return message
-
-
 def register_hyperparameters(hyperparameters_map):
     """Decorator for hyperparameters support in estimator class.
     Adds `get_hyperparameters` method to class.


### PR DESCRIPTION
## Description

Stock scikit-learn only support such Array API inputs as `cupy.array_api, array-api-strict, cupy, and PyTorch` [[scikit-learn's Array API support](https://scikit-learn.org/1.5/modules/array_api.html)]. Host numpy copies of the input data will be used for the fallback cases, since stock scikit-learn doesn't support DPCTL usm_ndarray and DPNP ndarray

Aligning with [Documentation PR](https://github.com/intel/scikit-learn-intelex/pull/1918)

### Proposed changes
* update the logic for scikit-learn fallback condition
* Logger enhanced for patch message when data transferred to host


---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
