### PR TITLE
[fix] lock 'isort' and 'black' matching versions for pre-commit-config.yaml and CI check

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -52,7 +52,7 @@ jobs:
       echo "##vso[task.setvariable variable=ISORT_VERSION]$(grep -zoP '(?<=isort\n    rev: ).*' .pre-commit-config.yaml)"
       echo "##vso[task.setvariable variable=BLACK_VERSION]$(grep -zoP '(?<=black\n    rev: ).*' .pre-commit-config.yaml)"
       echo "##vso[task.setvariable variable=PYTHON_LINT_VERSION]'$(grep -oP -m 1 '(?<=python).*' .pre-commit-config.yaml)'"
-  displayName: 'Collect lint versions'
+    displayName: 'Collect lint versions'
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(PYTHON_LINT_VERSION)

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -57,7 +57,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools
       pip install isort==${ISORT_VERSION} black[jupyter]==${BLACK_VERSION}
-      if !(grep -q ./.pre-commit-config.yaml "${ISORT_VERSION}") || !(grep -q ./.pre-commit-config.yaml "${BLACK_VERSION}"); then exit 1; fi
+      if !(grep -q "${ISORT_VERSION}" ./.pre-commit-config.yaml) || !(grep -q "${BLACK_VERSION}" ./.pre-commit-config.yaml); then exit 1; fi
       isort --profile black --check . && black --check .
     displayName: 'Linting'
 - job: LinuxCondaEnv

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -42,8 +42,9 @@ variables:
   PYTHON: 'python'
   ARGS: '1'
   SHELLOPTS: 'errexit:pipefail'
-  ISORT_VERSION: 5.13.2
+  ISORT_VERSION: 5.13.1
   BLACK_VERSION: 24.1.1
+  PYTHON_LINT_VERSION: '3.10'
 
 jobs:
 - job: Lint
@@ -52,12 +53,14 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.10'
+      versionSpec: ${PYTHON_LINT_VERSION}
       addToPath: true
   - script: |
+      if !(grep -q "rev: ${ISORT_VERSION}" ./.pre-commit-config.yaml) then echo "##vso[task.logissue type=error]isort version mismatch"; fi
+      if !(grep -q "rev: ${BLACK_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]black version mismatch"; fi
+      if !(grep -q "python${PYTHON_LINT_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]python lint version mismatch"; fi
       python -m pip install --upgrade pip setuptools
       pip install isort==${ISORT_VERSION} black[jupyter]==${BLACK_VERSION}
-      if !(grep -q "${ISORT_VERSION}" ./.pre-commit-config.yaml) || !(grep -q "${BLACK_VERSION}" ./.pre-commit-config.yaml); then exit 1; fi
       isort --profile black --check . && black --check .
     displayName: 'Linting'
 - job: LinuxCondaEnv

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -53,7 +53,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: ${PYTHON_LINT_VERSION}
+      versionSpec: $(PYTHON_LINT_VERSION)
       addToPath: true
   - script: |
       if !(grep -q "rev: ${ISORT_VERSION}" ./.pre-commit-config.yaml) then echo "##vso[task.logissue type=error]isort version mismatch"; fi

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -42,23 +42,21 @@ variables:
   PYTHON: 'python'
   ARGS: '1'
   SHELLOPTS: 'errexit:pipefail'
-  ISORT_VERSION: 5.13.2
-  BLACK_VERSION: 24.1.1
-  PYTHON_LINT_VERSION: '3.10'
 
 jobs:
 - job: Lint
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
+  - bash: |
+      echo "##vso[task.setvariable variable=ISORT_VERSION]$(grep -zoP '(?<=isort\n    rev: ).*' .pre-commit-config.yaml)"
+      echo "##vso[task.setvariable variable=BLACK_VERSION]$(grep -zoP '(?<=black\n    rev: ).*' .pre-commit-config.yaml)"
+      echo "##vso[task.setvariable variable=PYTHON_LINT_VERSION]'$(grep -oP -m 1 '(?<=python).*' .pre-commit-config.yaml)'"
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(PYTHON_LINT_VERSION)
       addToPath: true
   - script: |
-      if !(grep -q "rev: ${ISORT_VERSION}" ./.pre-commit-config.yaml) then echo "##vso[task.logissue type=error]isort mismatch" && exit 1; fi
-      if !(grep -q "rev: ${BLACK_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]black mismatch" && exit 1; fi
-      if !(grep -q "python${PYTHON_LINT_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]python lint mismatch" && exit 1; fi
       python -m pip install --upgrade pip setuptools
       pip install isort==${ISORT_VERSION} black[jupyter]==${BLACK_VERSION}
       isort --profile black --check . && black --check .

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -51,7 +51,7 @@ jobs:
   - script: |
       echo "##vso[task.setvariable variable=ISORT_VERSION]$(grep -zoP '(?<=isort\n    rev: ).*' .pre-commit-config.yaml)"
       echo "##vso[task.setvariable variable=BLACK_VERSION]$(grep -zoP '(?<=black\n    rev: ).*' .pre-commit-config.yaml)"
-      echo "##vso[task.setvariable variable=PYTHON_LINT_VERSION]'$(grep -oP -m 1 '(?<=python).*' .pre-commit-config.yaml)'"
+      echo "##vso[task.setvariable variable=PYTHON_LINT_VERSION]$(grep -oP -m 1 '(?<=python).*' .pre-commit-config.yaml)"
     displayName: 'Collect lint versions'
   - task: UsePythonVersion@0
     inputs:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -42,7 +42,7 @@ variables:
   PYTHON: 'python'
   ARGS: '1'
   SHELLOPTS: 'errexit:pipefail'
-  ISORT_VERSION: 5.13.1
+  ISORT_VERSION: 5.13.2
   BLACK_VERSION: 24.1.1
   PYTHON_LINT_VERSION: '3.10'
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -54,7 +54,7 @@ jobs:
       addToPath: true
   - script: |
       python -m pip install --upgrade pip setuptools
-      pip install isort black[jupyter]==24.1.1
+      pip install isort==5.13.2 black[jupyter]==24.1.1
       isort --profile black --check . && black --check .
     displayName: 'Linting'
 - job: LinuxCondaEnv

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -48,10 +48,11 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
-  - bash: |
+  - script: |
       echo "##vso[task.setvariable variable=ISORT_VERSION]$(grep -zoP '(?<=isort\n    rev: ).*' .pre-commit-config.yaml)"
       echo "##vso[task.setvariable variable=BLACK_VERSION]$(grep -zoP '(?<=black\n    rev: ).*' .pre-commit-config.yaml)"
       echo "##vso[task.setvariable variable=PYTHON_LINT_VERSION]'$(grep -oP -m 1 '(?<=python).*' .pre-commit-config.yaml)'"
+  displayName: 'Collect lint versions'
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(PYTHON_LINT_VERSION)

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -56,9 +56,9 @@ jobs:
       versionSpec: $(PYTHON_LINT_VERSION)
       addToPath: true
   - script: |
-      if !(grep -q "rev: ${ISORT_VERSION}" ./.pre-commit-config.yaml) then echo "##vso[task.logissue type=error]isort version mismatch"; fi
-      if !(grep -q "rev: ${BLACK_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]black version mismatch"; fi
-      if !(grep -q "python${PYTHON_LINT_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]python lint version mismatch"; fi
+      if !(grep -q "rev: ${ISORT_VERSION}" ./.pre-commit-config.yaml) then echo "##vso[task.logissue type=error]isort mismatch" && exit 1; fi
+      if !(grep -q "rev: ${BLACK_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]black mismatch" && exit 1; fi
+      if !(grep -q "python${PYTHON_LINT_VERSION}" ./.pre-commit-config.yaml); then echo "##vso[task.logissue type=error]python lint mismatch" && exit 1; fi
       python -m pip install --upgrade pip setuptools
       pip install isort==${ISORT_VERSION} black[jupyter]==${BLACK_VERSION}
       isort --profile black --check . && black --check .

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -42,6 +42,8 @@ variables:
   PYTHON: 'python'
   ARGS: '1'
   SHELLOPTS: 'errexit:pipefail'
+  ISORT_VERSION: 5.13.2
+  BLACK_VERSION: 24.1.1
 
 jobs:
 - job: Lint
@@ -50,11 +52,12 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.9'
+      versionSpec: '3.10'
       addToPath: true
   - script: |
       python -m pip install --upgrade pip setuptools
-      pip install isort==5.13.2 black[jupyter]==24.1.1
+      pip install isort==${ISORT_VERSION} black[jupyter]==${BLACK_VERSION}
+      if !(grep -q ./.pre-commit-config.yaml "${ISORT_VERSION}") || !(grep -q ./.pre-commit-config.yaml "${BLACK_VERSION}"); then exit 1; fi
       isort --profile black --check . && black --check .
     displayName: 'Linting'
 - job: LinuxCondaEnv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3.10
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         language_version: python3.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Continuous Integration (CI) testing is enabled for the repository. Your pull req
 
 ## Code Style
 
-We use [black](https://black.readthedocs.io/en/stable/) and [isort](https://pycqa.github.io/isort/) formatters for Python* code. The line length is 90 characters; use default options otherwise. You can find the linter configuration in [.pyproject.toml](https://github.com/intel/scikit-learn-intelex/blob/main/pyproject.toml).
+We use [black](https://black.readthedocs.io/en/stable/) version 24.1.1 and [isort](https://pycqa.github.io/isort/) version 5.13.2 formatters for Python* code. The line length is 90 characters; use default options otherwise. You can find the linter configuration in [.pyproject.toml](https://github.com/intel/scikit-learn-intelex/blob/main/pyproject.toml).
 
 A GitHub* Action verifies if your changes comply with the output of the auto-formatting tools.
 


### PR DESCRIPTION
## Description

Fix isort and black versions to simply development processes with git and precommits.

Pin isort to the most recent publicly-available version (no impact on the repository currently).

Pin python version to match between the two (Python3.10).

All are now defined and decided by what is in ```.pre-commit-config.yaml```

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
