### PR TITLE
[fix] correct issue in aliased _onedal_cpu_supported and _onedal_gpu_supported in fit_check_before_support_check

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -248,7 +248,7 @@ if daal_check_version((2023, "P", 200)):
             @wrap_output_data
             def predict(self, X):
                 self._validate_params()
-
+                check_is_fitted(self)
                 return dispatch(
                     self,
                     "predict",
@@ -280,7 +280,7 @@ if daal_check_version((2023, "P", 200)):
                             "will be removed in 1.5.",
                             FutureWarning,
                         )
-
+                check_is_fitted(self)
                 return dispatch(
                     self,
                     "predict",
@@ -293,8 +293,6 @@ if daal_check_version((2023, "P", 200)):
                 )
 
         def _onedal_predict(self, X, sample_weight=None, queue=None):
-            check_is_fitted(self)
-
             X = validate_data(
                 self,
                 X,
@@ -334,6 +332,7 @@ if daal_check_version((2023, "P", 200)):
 
         @wrap_output_data
         def score(self, X, y=None, sample_weight=None):
+            check_is_fitted(self)
             return dispatch(
                 self,
                 "score",
@@ -347,8 +346,6 @@ if daal_check_version((2023, "P", 200)):
             )
 
         def _onedal_score(self, X, y=None, sample_weight=None, queue=None):
-            check_is_fitted(self)
-
             X = validate_data(
                 self,
                 X,

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -23,7 +23,7 @@ from sklearn.base import BaseEstimator, clone
 from sklearn.covariance import EmpiricalCovariance as _sklearn_EmpiricalCovariance
 from sklearn.covariance import log_likelihood
 from sklearn.utils import check_array, gen_batches
-from sklearn.utils.validation import _num_features
+from sklearn.utils.validation import _num_features, check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
@@ -226,6 +226,7 @@ class IncrementalEmpiricalCovariance(BaseEstimator):
     def score(self, X_test, y=None):
         xp, _ = get_namespace(X_test)
 
+        check_is_fitted(self)
         location = self.location_
         if sklearn_check_version("1.0"):
             X = validate_data(

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -22,6 +22,7 @@ from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import r2_score
 from sklearn.utils import check_array, gen_batches
+from sklearn.utils.validation import check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
@@ -414,13 +415,7 @@ class IncrementalLinearRegression(MultiOutputMixin, RegressorMixin, BaseEstimato
         C : array, shape (n_samples, n_targets)
             Returns predicted values.
         """
-        if not hasattr(self, "coef_"):
-            msg = (
-                "This %(name)s instance is not fitted yet. Call 'fit' or 'partial_fit' "
-                "with appropriate arguments before using this estimator."
-            )
-            raise NotFittedError(msg % {"name": self.__class__.__name__})
-
+        check_is_fitted(self)
         return dispatch(
             self,
             "predict",
@@ -472,13 +467,7 @@ class IncrementalLinearRegression(MultiOutputMixin, RegressorMixin, BaseEstimato
         regressors (except for
         :class:`~sklearn.multioutput.MultiOutputRegressor`).
         """
-        if not hasattr(self, "coef_"):
-            msg = (
-                "This %(name)s instance is not fitted yet. Call 'fit' or 'partial_fit' "
-                "with appropriate arguments before using this estimator."
-            )
-            raise NotFittedError(msg % {"name": self.__class__.__name__})
-
+        check_is_fitted(self)
         return dispatch(
             self,
             "score",

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -19,7 +19,6 @@ import warnings
 
 import numpy as np
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
-from sklearn.exceptions import NotFittedError
 from sklearn.metrics import r2_score
 from sklearn.utils import check_array, gen_batches
 from sklearn.utils.validation import check_is_fitted

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -18,7 +18,6 @@ import logging
 from abc import ABC
 
 import numpy as np
-from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LinearRegression as _sklearn_LinearRegression
 from sklearn.metrics import r2_score
 from sklearn.utils.validation import check_array
@@ -33,7 +32,7 @@ if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize
 
 from scipy.sparse import issparse
-from sklearn.utils.validation import check_X_y
+from sklearn.utils.validation import check_is_fitted, check_X_y
 
 from onedal.common.hyperparameters import get_hyperparameters
 from onedal.linear_model import LinearRegression as onedal_LinearRegression
@@ -111,14 +110,7 @@ class LinearRegression(_sklearn_LinearRegression):
 
     @wrap_output_data
     def predict(self, X):
-
-        if not hasattr(self, "coef_"):
-            msg = (
-                "This %(name)s instance is not fitted yet. Call 'fit' with "
-                "appropriate arguments before using this estimator."
-            )
-            raise NotFittedError(msg % {"name": self.__class__.__name__})
-
+        check_is_fitted(self)
         return dispatch(
             self,
             "predict",
@@ -131,6 +123,7 @@ class LinearRegression(_sklearn_LinearRegression):
 
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
+        check_is_fitted(self)
         return dispatch(
             self,
             "score",

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -367,14 +367,9 @@ def runtime_property_check(text, estimator, method):
 
 def fit_check_before_support_check(text, estimator, method):
     if "fit" not in method:
-        if "_onedal_cpu_supported" in text["funcs"]:
-            onedal_support = "_onedal_cpu_supported"
-        elif "_onedal_gpu_supported" in text["funcs"]:
-            onedal_support = "_onedal_gpu_supported"
-        else:
+        if "dispatch" not in text["funcs"]:
             pytest.skip(f"onedal dispatching not used in {estimator}.{method}")
-        # get location of _onedal_*_supported
-        idx = len(text["funcs"]) - 1 - text["funcs"][::-1].index(onedal_support)
+        idx = len(text["funcs"]) - 1 - text["funcs"][::-1].index("dispatch")
         validfuncs = text["funcs"][:idx]
         assert (
             "check_is_fitted" in validfuncs


### PR DESCRIPTION
## Description

Some estimators have alias attributes to ```_onedal_cpu_supported``` and ```_onedal_gpu_supported``` which were not being properly analyzed in design testing.  This changes the test slightly to check for ```dispatch``` and then checks before then. This fixes issues introduced in #2110 

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
