### PR TITLE
DOC: Fix docs related to `n_jobs`

### DIFF
--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -154,11 +154,6 @@ def control_n_jobs(decorated_methods: list = []):
     decorated_methods: list
         A list of method names to be executed with 'n_jobs'.
 
-    non_sklearn_class: bool
-        Indicator telling whether this is a class that exists in stock scikit-learn
-        or not, used in order to determine whether to place an internal or external
-        link to their glossary.
-
     Example
     -------
         @control_n_jobs(decorated_methods=['fit', 'predict'])

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -213,7 +213,7 @@ def control_n_jobs(decorated_methods: list = []):
             and "n_jobs : int" not in original_class.__doc__
         ):
             parameters_doc_tail = "\n    Attributes"
-            n_jobs_doc = f"""
+            n_jobs_doc = """
     n_jobs : int, default=None
         The number of jobs to use in parallel for the computation.
         ``None`` means using all physical cores

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -135,7 +135,7 @@ def _run_with_n_jobs(method):
     return n_jobs_wrapper
 
 
-def control_n_jobs(decorated_methods: list = []):
+def control_n_jobs(decorated_methods: list = [], non_sklearn_class: bool = False):
     """
     Decorator for controlling the 'n_jobs' parameter in an estimator class.
 
@@ -151,7 +151,13 @@ def control_n_jobs(decorated_methods: list = []):
 
     Parameters
     ----------
-        decorated_methods (list): A list of method names to be executed with 'n_jobs'.
+    decorated_methods: list
+        A list of method names to be executed with 'n_jobs'.
+
+    non_sklearn_class: bool
+        Indicator telling whether this is a class that exists in stock scikit-learn
+        or not, used in order to determine whether to place an internal or external
+        link to their glossary.
 
     Example
     -------
@@ -212,13 +218,17 @@ def control_n_jobs(decorated_methods: list = []):
             and "n_jobs : int" not in original_class.__doc__
         ):
             parameters_doc_tail = "\n    Attributes"
-            n_jobs_doc = """
+            if non_sklearn_class:
+                n_jobs_link = "`Glossary <https://scikit-learn.org/stable/glossary.html#term-n_jobs>`__"
+            else:
+                n_jobs_link = ":term:`Glossary <n_jobs>`"
+            n_jobs_doc = f"""
     n_jobs : int, default=None
         The number of jobs to use in parallel for the computation.
         ``None`` means using all physical cores
         unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all logical cores.
-        See :term:`Glossary <n_jobs>` for more details.
+        See {n_jobs_link} for more details.
 """
             original_class.__doc__ = original_class.__doc__.replace(
                 parameters_doc_tail, n_jobs_doc + parameters_doc_tail

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -135,7 +135,7 @@ def _run_with_n_jobs(method):
     return n_jobs_wrapper
 
 
-def control_n_jobs(decorated_methods: list = [], non_sklearn_class: bool = False):
+def control_n_jobs(decorated_methods: list = []):
     """
     Decorator for controlling the 'n_jobs' parameter in an estimator class.
 
@@ -218,17 +218,13 @@ def control_n_jobs(decorated_methods: list = [], non_sklearn_class: bool = False
             and "n_jobs : int" not in original_class.__doc__
         ):
             parameters_doc_tail = "\n    Attributes"
-            if non_sklearn_class:
-                n_jobs_link = "`Glossary <https://scikit-learn.org/stable/glossary.html#term-n_jobs>`__"
-            else:
-                n_jobs_link = ":term:`Glossary <n_jobs>`"
             n_jobs_doc = f"""
     n_jobs : int, default=None
         The number of jobs to use in parallel for the computation.
         ``None`` means using all physical cores
         unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all logical cores.
-        See {n_jobs_link} for more details.
+        See :term:`Glossary <n_jobs>` for more details.
 """
             original_class.__doc__ = original_class.__doc__.replace(
                 parameters_doc_tail, n_jobs_doc + parameters_doc_tail

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -68,7 +68,22 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
 ]
+
+intersphinx_mapping = {
+    "sklearn": ("https://scikit-learn.org/stable/", None),
+    # from scikit-learn, in case some object in sklearnex points to them:
+    # https://github.com/scikit-learn/scikit-learn/blob/main/doc/conf.py
+    "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "matplotlib": ("https://matplotlib.org/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
+    "seaborn": ("https://seaborn.pydata.org/", None),
+    "skops": ("https://skops.readthedocs.io/en/stable/", None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -37,7 +37,7 @@ if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import StrOptions
 
 
-@control_n_jobs(decorated_methods=["fit"])
+@control_n_jobs(decorated_methods=["fit"], non_sklearn_class=True)
 class BasicStatistics(BaseEstimator):
     """
     Estimator for basic statistics.
@@ -80,7 +80,7 @@ class BasicStatistics(BaseEstimator):
 
     Note
     ----
-    Attributes' names without the trailing underscore are
+    Names of attributes without the trailing underscore are
     supported currently but deprecated in 2025.1 and will be removed in 2026.0
 
     Note

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -37,7 +37,7 @@ if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import StrOptions
 
 
-@control_n_jobs(decorated_methods=["fit"], non_sklearn_class=True)
+@control_n_jobs(decorated_methods=["fit"])
 class BasicStatistics(BaseEstimator):
     """
     Estimator for basic statistics.

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -40,7 +40,9 @@ else:
     validate_data = BaseEstimator._validate_data
 
 
-@control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
+@control_n_jobs(
+    decorated_methods=["partial_fit", "_onedal_finalize_fit"], non_sklearn_class=True
+)
 class IncrementalBasicStatistics(BaseEstimator):
     """
     Calculates basic statistics on the given data, allows for computation when the data are split into
@@ -105,7 +107,7 @@ class IncrementalBasicStatistics(BaseEstimator):
 
     Note
     ----
-    Attributes' names without the trailing underscore are
+    Names of attributes without the trailing underscore are
     supported currently but deprecated in 2025.1 and will be removed in 2026.0
 
     Examples

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -40,9 +40,7 @@ else:
     validate_data = BaseEstimator._validate_data
 
 
-@control_n_jobs(
-    decorated_methods=["partial_fit", "_onedal_finalize_fit"], non_sklearn_class=True
-)
+@control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
 class IncrementalBasicStatistics(BaseEstimator):
     """
     Calculates basic statistics on the given data, allows for computation when the data are split into

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -46,10 +46,7 @@ else:
     validate_data = BaseEstimator._validate_data
 
 
-@control_n_jobs(
-    decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"],
-    non_sklearn_class=True,
-)
+@control_n_jobs(decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"])
 class IncrementalEmpiricalCovariance(BaseEstimator):
     """
     Maximum likelihood covariance estimator that allows for the estimation when the data are split into

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -46,7 +46,10 @@ else:
     validate_data = BaseEstimator._validate_data
 
 
-@control_n_jobs(decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"])
+@control_n_jobs(
+    decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"],
+    non_sklearn_class=True,
+)
 class IncrementalEmpiricalCovariance(BaseEstimator):
     """
     Maximum likelihood covariance estimator that allows for the estimation when the data are split into


### PR DESCRIPTION
## Description

This PR fixes an issue in which the docs for classes that are not part of original scikit-learn were not setting the docs for `n_jobs` correctly and showing warnings about them, due to to three reasons:
* Using internal "glossary" link, which is from original scikit-learn but not present in sklearnex.
* Referencing objects from joblib without linking to them the way scikit-learn does.
* The decorator adding the parameter more than once to the docstrings if the keyword "Attributes" appeared more than once.

Before:
![image](https://github.com/user-attachments/assets/72fe7583-99d0-4a6c-899b-efe95ed02b3c)
(note that glossary and backend are not clickable)

After:
![image](https://github.com/user-attachments/assets/9ac0bd7c-0001-4182-a38c-a1af9d6c3fc8)


---


Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
