### PR TITLE
ENH: Fix doc link in HTML representation of estimators

### DIFF
--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sys
 import warnings
+from abc import ABC
 
 from daal4py.sklearn._utils import (
     PatchingConditionsChain as daal4py_PatchingConditionsChain,
@@ -113,3 +114,19 @@ def register_hyperparameters(hyperparameters_map):
         return estimator_class
 
     return wrap_class
+
+
+# This abstract class is meant to generate a clickable doc link for classses
+# in sklearnex that are not present in scikit-learn. It should be inherited
+# before inheriting from a scikit-learn estimator, otherwise will get overriden
+# by the estimator's original.
+class NonSKLearnAlgorithm(ABC):
+    @property
+    def _doc_link_module(self) -> str:
+        return "sklearnex"
+
+    @property
+    def _doc_link_template(self) -> str:
+        module_path = ".".join(self.__class__.__module__.split(".")[:-1])
+        class_name = self.__class__.__name__
+        return f"https://intel.github.io/scikit-learn-intelex/latest/non-scikit-algorithms.html#{module_path}.{class_name}"

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -26,7 +26,7 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.basic_statistics import BasicStatistics as onedal_BasicStatistics
 
 from .._device_offload import dispatch
-from .._utils import PatchingConditionsChain
+from .._utils import NonSKLearnAlgorithm, PatchingConditionsChain
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data
@@ -38,7 +38,7 @@ if sklearn_check_version("1.2"):
 
 
 @control_n_jobs(decorated_methods=["fit"])
-class BasicStatistics(BaseEstimator):
+class BasicStatistics(NonSKLearnAlgorithm, BaseEstimator):
     """
     Estimator for basic statistics.
     Allows to compute basic statistics for provided data.

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -26,7 +26,7 @@ from onedal.basic_statistics import (
 )
 
 from .._device_offload import dispatch
-from .._utils import PatchingConditionsChain
+from .._utils import NonSKLearnAlgorithm, PatchingConditionsChain
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
@@ -41,7 +41,8 @@ else:
 
 
 @control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
-class IncrementalBasicStatistics(BaseEstimator):
+# class IncrementalBasicStatistics(NonSKLearnAlgorithm, BaseEstimator):
+class IncrementalBasicStatistics(NonSKLearnAlgorithm, BaseEstimator):
     """
     Calculates basic statistics on the given data, allows for computation when the data are split into
     batches. The user can use ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -33,7 +33,11 @@ from onedal.covariance import (
 from sklearnex import config_context
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import PatchingConditionsChain, register_hyperparameters
+from .._utils import (
+    NonSKLearnAlgorithm,
+    PatchingConditionsChain,
+    register_hyperparameters,
+)
 from ..metrics import pairwise_distances
 from ..utils._array_api import get_namespace
 
@@ -47,7 +51,7 @@ else:
 
 
 @control_n_jobs(decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"])
-class IncrementalEmpiricalCovariance(BaseEstimator):
+class IncrementalEmpiricalCovariance(NonSKLearnAlgorithm, BaseEstimator):
     """
     Maximum likelihood covariance estimator that allows for the estimation when the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -40,7 +40,11 @@ else:
 from onedal.common.hyperparameters import get_hyperparameters
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import PatchingConditionsChain, register_hyperparameters
+from .._utils import (
+    NonSKLearnAlgorithm,
+    PatchingConditionsChain,
+    register_hyperparameters,
+)
 
 
 @register_hyperparameters(
@@ -52,7 +56,9 @@ from .._utils import PatchingConditionsChain, register_hyperparameters
 @control_n_jobs(
     decorated_methods=["fit", "partial_fit", "predict", "score", "_onedal_finalize_fit"]
 )
-class IncrementalLinearRegression(MultiOutputMixin, RegressorMixin, BaseEstimator):
+class IncrementalLinearRegression(
+    NonSKLearnAlgorithm, MultiOutputMixin, RegressorMixin, BaseEstimator
+):
     """
     Trains a linear regression model, allows for computation if the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide


### PR DESCRIPTION
## Description

This PR fixes the interactive HTML representation of sklearnex estimators that don't have a scikit-learn analog to offer a clickable link to their docs, the same way scikit-learn estimators do, which is currently not working.

Before:
![image](https://github.com/user-attachments/assets/a113d4bd-a848-4fd4-92f4-04832dab5599)

After:
![image](https://github.com/user-attachments/assets/854df464-a715-491a-af93-15d596f5c55a)

Note: here I'm using the "latest" tag, as I wasn't sure how to get the link to the actual version of sklearnex that is used at runtime. Currently, this "latest" tag points to a 2023 release, so it won't work as-is until that issue is fixed.

---

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable
