### PR TITLE
TEST: Fix json report for MPI

### DIFF
--- a/conda-recipe/helper_mpi_tests.py
+++ b/conda-recipe/helper_mpi_tests.py
@@ -1,0 +1,25 @@
+# The purpose of this helper script is to be able to execute
+# different shell commands according to whether the process
+# is the first MPI rank or not. It works by passing it two
+# arguments:
+# - First argument is what gets executed by ranks other than '0'.
+# - Second argument is what gets executed by rank 0.
+# Note that the arguments might be multi-word comments, so it
+# uses os.system instead of subprocess or similar.
+
+import os
+import sys
+
+try:
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    is_rank_zero = rank == 0
+except ImportError:
+    is_rank_zero = True
+
+if is_rank_zero:
+    os.system(sys.argv[-1])
+else:
+    os.system(sys.argv[-2])

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -74,7 +74,7 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% -m pytest -k spmd --with-mpi --verbose --pyargs sklearnex || set exitcode=1
-        %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
+        %PYTHON% -m pytest --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -32,22 +32,30 @@ if "%~2"=="--json-report" (
     del /q .pytest_reports\*.json
 )
 
+setlocal enabledelayedexpansion
 if "%with_json_report%"=="1" (
-    %PYTHON% -m pytest --verbose -s %1tests --json-report --json-report-file=.pytest_reports\legacy_report.json || set exitcode=1
+    pytest --verbose -s "%1tests" --json-report --json-report-file=.pytest_reports\legacy_report.json || set exitcode=1
     pytest --verbose --pyargs daal4py --json-report --json-report-file=.pytest_reports\daal4py_report.json || set exitcode=1
     pytest --verbose --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_report.json || set exitcode=1
     pytest --verbose --pyargs onedal --json-report --json-report-file=.pytest_reports\onedal_report.json || set exitcode=1
-    pytest --verbose %1.ci\scripts\test_global_patch.py --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
+    pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
+    %PYTHON% "%~p0\helper_mpi_tests.py"^
+        "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
+        "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
+    if !errorlevel! NEQ 0 (
+        set exitcode=1
+    )
     if NOT EXIST .pytest_reports\legacy_report.json (
         echo "Error: JSON report files failed to be produced."
         set exitcode=1
     )
 ) else (
-    %PYTHON% -m pytest --verbose -s %1tests || set exitcode=1
+    pytest --verbose -s "%1tests" || set exitcode=1
     pytest --verbose --pyargs daal4py || set exitcode=1
     pytest --verbose --pyargs sklearnex || set exitcode=1
     pytest --verbose --pyargs onedal || set exitcode=1
-    pytest --verbose %1.ci\scripts\test_global_patch.py || set exitcode=1
+    pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
+    %PYTHON% -m pytest --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
 )
 
 EXIT /B %exitcode%

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -55,13 +55,12 @@ if "%with_json_report%"=="1" (
         if !errorlevel! NEQ 0 (
             set exitcode=1
         )
-        rem TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
-        rem %PYTHON% "%1tests\helper_mpi_tests.py"^
-        rem     pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py"^
-        rem     --json-report --json-report-file=.pytest_reports\legacy_report.json
-        rem if !errorlevel! NEQ 0 (
-        rem     set exitcode=1
-        rem )
+        %PYTHON% "%1tests\helper_mpi_tests.py"^
+            pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py"^
+            --json-report --json-report-file=.pytest_reports\mpi_legacy.json
+        if !errorlevel! NEQ 0 (
+            set exitcode=1
+        )
     )
     if NOT EXIST .pytest_reports\legacy_report.json (
         echo "Error: JSON report files failed to be produced."
@@ -75,7 +74,7 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% -m pytest -k spmd --with-mpi --verbose --pyargs sklearnex || set exitcode=1
-        rem %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
+        %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -50,15 +50,18 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% "%1tests\helper_mpi_tests.py"^
-            "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex"^
-            "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_spmd.json"
-        rem TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
-        rem %PYTHON% "%1tests\helper_mpi_tests.py"^
-        rem     "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
-        rem     "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
+            pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex^
+            --json-report --json-report-file=.pytest_reports\sklearnex_spmd.json
         if !errorlevel! NEQ 0 (
             set exitcode=1
         )
+        rem TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
+        rem %PYTHON% "%1tests\helper_mpi_tests.py"^
+        rem     pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py"^
+        rem     --json-report --json-report-file=.pytest_reports\legacy_report.json
+        rem if !errorlevel! NEQ 0 (
+        rem     set exitcode=1
+        rem )
     )
     if NOT EXIST .pytest_reports\legacy_report.json (
         echo "Error: JSON report files failed to be produced."

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,4 +1,4 @@
-@echo off
+@echo on
 rem ============================================================================
 rem Copyright 2018 Intel Corporation
 rem
@@ -39,15 +39,16 @@ if "%~2"=="--json-report" (
 )
 
 echo "NO_DIST=%NO_DIST%"
+echo "with_json_report=%with_json_report%"
 setlocal enabledelayedexpansion
-if "%with_json_report%"=="1" (
+if %with_json_report% EQU 1 (
     pytest --verbose -s "%1tests" --json-report --json-report-file=.pytest_reports\legacy_report.json || set exitcode=1
     pytest --verbose --pyargs daal4py --json-report --json-report-file=.pytest_reports\daal4py_report.json || set exitcode=1
     pytest --verbose --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_report.json || set exitcode=1
     pytest --verbose --pyargs onedal --json-report --json-report-file=.pytest_reports\onedal_report.json || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
     if %NO_DIST% NEQ 1 (
-        %PYTHON% "%~p0\helper_mpi_tests.py"^
+        %PYTHON% "%1conda-recipe\helper_mpi_tests.py"^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
         if !errorlevel! NEQ 0 (

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -19,11 +19,12 @@ rem %1 - scikit-learn-intelex repo root (should end with '\', leave empty if it'
 
 set exitcode=0
 
+setlocal enableextensions
 IF NOT DEFINED PYTHON (
     set "PYTHON=python"
     set NO_DIST=1
 )
-if %PYTHON% EQU "python" (
+if "%PYTHON%"=="python" (
     set NO_DIST=1
 )
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -52,9 +52,10 @@ if "%with_json_report%"=="1" (
         %PYTHON% "%1tests\helper_mpi_tests.py"^
             "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex"^
             "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_spmd.json"
-        %PYTHON% "%1tests\helper_mpi_tests.py"^
-            "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
-            "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
+        rem TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
+        rem %PYTHON% "%1tests\helper_mpi_tests.py"^
+        rem     "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
+        rem     "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
         if !errorlevel! NEQ 0 (
             set exitcode=1
         )
@@ -71,7 +72,7 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% -m pytest -k spmd --with-mpi --verbose --pyargs sklearnex || set exitcode=1
-        %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
+        rem %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -50,6 +50,9 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% "%1tests\helper_mpi_tests.py"^
+            "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex"^
+            "pytest -k spmd --with-mpi --verbose -s --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_spmd.json"
+        %PYTHON% "%1tests\helper_mpi_tests.py"^
             "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
             "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
         if !errorlevel! NEQ 0 (
@@ -67,6 +70,7 @@ if "%with_json_report%"=="1" (
     pytest --verbose --pyargs onedal || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
+        %PYTHON% -m pytest -k spmd --with-mpi --verbose --pyargs sklearnex || set exitcode=1
         %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,4 +1,4 @@
-@echo on
+@echo off
 rem ============================================================================
 rem Copyright 2018 Intel Corporation
 rem
@@ -42,14 +42,14 @@ if "%~2"=="--json-report" (
 echo "NO_DIST=%NO_DIST%"
 echo "with_json_report=%with_json_report%"
 setlocal enabledelayedexpansion
-if %with_json_report% EQU 1 (
+if "%with_json_report%"=="1" (
     pytest --verbose -s "%1tests" --json-report --json-report-file=.pytest_reports\legacy_report.json || set exitcode=1
     pytest --verbose --pyargs daal4py --json-report --json-report-file=.pytest_reports\daal4py_report.json || set exitcode=1
     pytest --verbose --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_report.json || set exitcode=1
     pytest --verbose --pyargs onedal --json-report --json-report-file=.pytest_reports\onedal_report.json || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
-        %PYTHON% "%1conda-recipe\helper_mpi_tests.py"^
+        %PYTHON% "%1tests\helper_mpi_tests.py"^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
         if !errorlevel! NEQ 0 (

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,4 +1,4 @@
-@echo off
+@echo on
 rem ============================================================================
 rem Copyright 2018 Intel Corporation
 rem

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -50,8 +50,8 @@ if "%with_json_report%"=="1" (
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
         %PYTHON% "%1tests\helper_mpi_tests.py"^
-            "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
-            "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
+            "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
+            "pytest --with-mpi --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
         if !errorlevel! NEQ 0 (
             set exitcode=1
         )
@@ -67,7 +67,7 @@ if "%with_json_report%"=="1" (
     pytest --verbose --pyargs onedal || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
     if NOT "%NO_DIST%"=="1" (
-        %PYTHON% -m pytest --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
+        %PYTHON% -m pytest --with-mpi --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -48,7 +48,7 @@ if %with_json_report% EQU 1 (
     pytest --verbose --pyargs sklearnex --json-report --json-report-file=.pytest_reports\sklearnex_report.json || set exitcode=1
     pytest --verbose --pyargs onedal --json-report --json-report-file=.pytest_reports\onedal_report.json || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" --json-report --json-report-file=.pytest_reports\global_patching_report.json || set exitcode=1
-    if %NO_DIST% NEQ 1 (
+    if NOT "%NO_DIST%"=="1" (
         %PYTHON% "%1conda-recipe\helper_mpi_tests.py"^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^""^
             "pytest --verbose -s ^"%1tests\test_daal4py_spmd_examples.py^" --json-report --json-report-file=.pytest_reports\legacy_report.json"
@@ -66,7 +66,7 @@ if %with_json_report% EQU 1 (
     pytest --verbose --pyargs sklearnex || set exitcode=1
     pytest --verbose --pyargs onedal || set exitcode=1
     pytest --verbose "%1.ci\scripts\test_global_patch.py" || set exitcode=1
-    if %NO_DIST% NEQ 1 (
+    if NOT "%NO_DIST%"=="1" (
         %PYTHON% -m pytest --verbose -s "%1tests\test_daal4py_spmd_examples.py" || set exitcode=1
     )
 )

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -86,10 +86,9 @@ if [[ ! $NO_DIST ]]; then
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
         pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)
     return_code=$(($return_code + $?))
-    # TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
-    # mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-    #     pytest --with-mpi --verbose -s "${sklex_root}/tests/test_daal4py_spmd_examples.py" $@ $(json_report_name mpi_legacy)
-    # return_code=$(($return_code + $?))
+    mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
+        pytest --with-mpi --verbose -s "${sklex_root}/tests/test_daal4py_spmd_examples.py" $@ $(json_report_name mpi_legacy)
+    return_code=$(($return_code + $?))
 fi
 
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -84,8 +84,8 @@ if [[ ! $NO_DIST ]]; then
         export EXTRA_MPI_ARGS="-n 4"
     fi
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
-        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
+        "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
+        "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))
 fi
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -57,7 +57,7 @@ function json_report_name {
 ${PYTHON} -c "from sklearnex import patch_sklearn; patch_sklearn()"
 return_code=$(($return_code + $?))
 
-pytest --verbose -s ${sklex_root}/tests $@ $(json_report_name legacy)
+pytest --verbose -s "${sklex_root}/tests" $@ $(json_report_name legacy)
 return_code=$(($return_code + $?))
 
 pytest --verbose --pyargs daal4py $@ $(json_report_name daal4py)
@@ -69,13 +69,15 @@ return_code=$(($return_code + $?))
 pytest --verbose --pyargs onedal $@ $(json_report_name onedal)
 return_code=$(($return_code + $?))
 
-pytest --verbose -s ${sklex_root}/.ci/scripts/test_global_patch.py $@ $(json_report_name global_patching)
+pytest --verbose -s "${sklex_root}/.ci/scripts/test_global_patch.py" $@ $(json_report_name global_patching)
 return_code=$(($return_code + $?))
 
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     mpirun --version
-    mpirun -n 4 pytest --verbose -s ${sklex_root}/tests/test*spmd*.py $@ $(json_report_name mpi_legacy)
+    mpirun -n 4 python "$(dirname $0)/helper_mpi_tests.py"  \
+        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
+        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $@ $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))
 fi
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -75,7 +75,7 @@ return_code=$(($return_code + $?))
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     mpirun --version
-    mpirun -n 4 python "$(dirname $0)/helper_mpi_tests.py"  \
+    mpirun -n 4 python "${sklex_root}/conda-recipe/helper_mpi_tests.py" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $@ $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -78,7 +78,7 @@ if [[ ! $NO_DIST ]]; then
     # Note: OpenMPI will not allow running more processes than there
     # are cores in the machine, and Intel's MPI doesn't support the
     # same command line options, hence this line.
-    if [[ ! -z $(mpirun -h | grep "Open MPI") ]]; then
+    if [[ ! -z "$(mpirun -h | grep "Open MPI")" ]]; then
         export EXTRA_MPI_ARGS="-n 2 -oversubscribe"
     else
         export EXTRA_MPI_ARGS="-n 4"

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -77,7 +77,7 @@ if [[ ! $NO_DIST ]]; then
     mpirun --version
     mpirun -n 4 python "${sklex_root}/conda-recipe/helper_mpi_tests.py" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
-        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $@ $(json_report_name mpi_legacy)"
+        "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))
 fi
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -84,13 +84,11 @@ if [[ ! $NO_DIST ]]; then
         export EXTRA_MPI_ARGS="-n 4"
     fi
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-        "pytest -k spmd --with-mpi --verbose --pyargs sklearnex" \
-        "pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)"
+        pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)
     return_code=$(($return_code + $?))
     # TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
     # mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-    #     "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
-    #     "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
+    #     pytest --with-mpi --verbose -s "${sklex_root}/tests/test_daal4py_spmd_examples.py" $@ $(json_report_name mpi_legacy)
     # return_code=$(($return_code + $?))
 fi
 

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -75,7 +75,7 @@ return_code=$(($return_code + $?))
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     mpirun --version
-    mpirun -n 4 python "${sklex_root}/tests/helper_mpi_tests.py" \
+    mpirun -n 2 python "${sklex_root}/tests/helper_mpi_tests.py" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -75,7 +75,7 @@ return_code=$(($return_code + $?))
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     mpirun --version
-    mpirun -n 4 python "${sklex_root}/conda-recipe/helper_mpi_tests.py" \
+    mpirun -n 4 python "${sklex_root}/tests/helper_mpi_tests.py" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -75,7 +75,15 @@ return_code=$(($return_code + $?))
 echo "NO_DIST=$NO_DIST"
 if [[ ! $NO_DIST ]]; then
     mpirun --version
-    mpirun -n 2 python "${sklex_root}/tests/helper_mpi_tests.py" \
+    # Note: OpenMPI will not allow running more processes than there
+    # are cores in the machine, and Intel's MPI doesn't support the
+    # same command line options, hence this line.
+    if [[ ! -z $(mpirun -h | grep "Open MPI") ]]; then
+        export EXTRA_MPI_ARGS="-n 2 -oversubscribe"
+    else
+        export EXTRA_MPI_ARGS="-n 4"
+    fi
+    mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
         "pytest --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -86,10 +86,12 @@ if [[ ! $NO_DIST ]]; then
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
         "pytest -k spmd --with-mpi --verbose --pyargs sklearnex" \
         "pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)"
-    mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-        "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
-        "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))
+    # TODO: this currently doesn't seem to work with pytest+OMPI. Uncomment later if it gets fixed.
+    # mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
+    #     "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
+    #     "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
+    # return_code=$(($return_code + $?))
 fi
 
 exit $return_code

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -84,6 +84,9 @@ if [[ ! $NO_DIST ]]; then
         export EXTRA_MPI_ARGS="-n 4"
     fi
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
+        "pytest -k spmd --with-mpi --verbose --pyargs sklearnex" \
+        "pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)"
+    mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
         "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\"" \
         "pytest --with-mpi --verbose -s \"${sklex_root}/tests/test_daal4py_spmd_examples.py\" $* $(json_report_name mpi_legacy)"
     return_code=$(($return_code + $?))

--- a/conda-recipe/run_test.sh
+++ b/conda-recipe/run_test.sh
@@ -87,7 +87,7 @@ if [[ ! $NO_DIST ]]; then
         pytest -k spmd --with-mpi --verbose --pyargs sklearnex $@ $(json_report_name sklearnex_spmd)
     return_code=$(($return_code + $?))
     mpirun ${EXTRA_MPI_ARGS} python "${sklex_root}/tests/helper_mpi_tests.py" \
-        pytest --with-mpi --verbose -s "${sklex_root}/tests/test_daal4py_spmd_examples.py" $@ $(json_report_name mpi_legacy)
+        pytest --verbose -s "${sklex_root}/tests/test_daal4py_spmd_examples.py" $@ $(json_report_name mpi_legacy)
     return_code=$(($return_code + $?))
 fi
 

--- a/tests/helper_mpi_tests.py
+++ b/tests/helper_mpi_tests.py
@@ -1,3 +1,19 @@
+# ===============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===============================================================================
+
 # The purpose of this helper script is to be able to execute
 # different shell commands according to whether the process
 # is the first MPI rank or not. It works by passing it the

--- a/tests/helper_mpi_tests.py
+++ b/tests/helper_mpi_tests.py
@@ -29,7 +29,6 @@ args_json_report = [
 ]
 
 if is_rank_zero:
-    json_report_plugin = JSONReport()
     pytest.main(args_base + args_json_report)
 else:
     pytest.main(args_base)

--- a/tests/helper_mpi_tests.py
+++ b/tests/helper_mpi_tests.py
@@ -1,14 +1,16 @@
 # The purpose of this helper script is to be able to execute
 # different shell commands according to whether the process
-# is the first MPI rank or not. It works by passing it two
-# arguments:
-# - First argument is what gets executed by ranks other than '0'.
-# - Second argument is what gets executed by rank 0.
-# Note that the arguments might be multi-word commands, so it
-# uses os.system instead of subprocess or similar.
+# is the first MPI rank or not. It works by passing it the
+# arguments to a pytest call with the json report arguments
+# from an mpirun/mpiexec invocation - e.g.
+#     mpirun -n 2 helper_mpi_tests.py pytest <args to pytest>
 
-import os
 import sys
+
+import pytest
+
+print("Info from 'helper_mpi_tests.py'")
+print("sys.argv:", sys.argv)
 
 try:
     from mpi4py import MPI
@@ -19,7 +21,15 @@ try:
 except ImportError:
     is_rank_zero = True
 
+args_base = [
+    arg for arg in sys.argv[1:] if not ("--json-report" in arg) and (arg != "pytest")
+]
+args_json_report = [
+    arg for arg in sys.argv[1:] if ("--json-report" in arg) and (arg != "pytest")
+]
+
 if is_rank_zero:
-    os.system(sys.argv[-1])
+    json_report_plugin = JSONReport()
+    pytest.main(args_base + args_json_report)
 else:
-    os.system(sys.argv[-2])
+    pytest.main(args_base)

--- a/tests/helper_mpi_tests.py
+++ b/tests/helper_mpi_tests.py
@@ -4,7 +4,7 @@
 # arguments:
 # - First argument is what gets executed by ranks other than '0'.
 # - Second argument is what gets executed by rank 0.
-# Note that the arguments might be multi-word comments, so it
+# Note that the arguments might be multi-word commands, so it
 # uses os.system instead of subprocess or similar.
 
 import os


### PR DESCRIPTION
## Description

This PR is an attempt at fixing the JSON report generated by the test script that is ran with MPI.

Currently, the MPI call works in such a way that every process in the MPI call gets passed the argument to produce the JSON report, and each of them tries to write simultaneously to the same file, which results in clashes.

This PR should hopefully fix it by generating the JSON report only in the MPI process that has rank=0.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable
