### PR TITLE
FIX: minor follow up to #1936 and #2045

### DIFF
--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -36,7 +36,7 @@ from onedal.tests.utils._dataframes_support import (
 )
 from onedal.tests.utils._device_selection import get_queues, is_dpctl_device_available
 from onedal.utils._array_api import _get_sycl_namespace
-from onedal.utils._dpep_helpers import dpctl_available, dpnp_available, is_dpctl_available
+from onedal.utils._dpep_helpers import dpctl_available, dpnp_available
 from sklearnex import config_context
 from sklearnex.tests.utils import PATCHED_FUNCTIONS, PATCHED_MODELS, SPECIAL_INSTANCES
 from sklearnex.utils._array_api import get_namespace
@@ -365,7 +365,7 @@ def test_table_conversions_memory_leaks(dataframe, queue, order, data_shape, dty
     func = ORDER_DICT[order]
 
     if queue.sycl_device.is_gpu and (
-        os.getenv("ZES_ENABLE_SYSMAN") is None or not is_dpctl_available("gpu")
+        os.getenv("ZES_ENABLE_SYSMAN") is None or not is_dpctl_device_available("gpu")
     ):
         pytest.skip("SYCL device memory leak check requires the level zero sysman")
 


### PR DESCRIPTION
## Description

#1936 was merged while #2045 was in progress and then #2045 did not incorporate changes made by #1936

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [X] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
