### PR TITLE
[CI] make GitHub actions more robust by filtering events and using oneDAL build's lnx env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,6 @@ jobs:
     steps:
       - name: Checkout Scikit-learn-intelex
         uses: actions/checkout@v4
-      - name: Checkout oneDAL
-        uses: actions/checkout@v4
-        with:
-          repository: oneapi-src/oneDAL
-          path: oneDAL
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -65,7 +60,7 @@ jobs:
         run: |
           OTHER_REPO="oneapi-src/oneDAL"
           WF_NAME="Nightly-build"
-          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId --status success --jq .[0].databaseId`
+          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event --status success --jq 'map(select(.event == "workflow_dispatch" or .event == "schedule")) | .[0].databaseId'`
           echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:
@@ -78,6 +73,14 @@ jobs:
           repository: oneapi-src/oneDAL
           run-id: ${{ steps.get-run-id.outputs.run-id }}
           path: ./__release_lnx
+      - name: Download oneDAL environment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: oneDAL_env
+          github-token: ${{ github.token }}
+          repository: oneapi-src/oneDAL
+          run-id: ${{ steps.get-run-id.outputs.run-id }}
+          path: .ci/env
       - name: Set Environment Variables
         id: set-env
         run: |
@@ -92,7 +95,7 @@ jobs:
       - name: dpcpp installation
         run: |
           # This CI system yields oneAPI dependencies from the oneDAL repository
-          bash ./oneDAL/.ci/env/apt.sh dpcpp
+          bash .ci/env/apt.sh dpcpp
       - name: describe system
         run: bash .ci/scripts/describe_system.sh
       - name: Install develop requirements
@@ -161,7 +164,7 @@ jobs:
         run: |
           OTHER_REPO="oneapi-src/oneDAL"
           WF_NAME="Nightly-build"
-          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId --status success --jq .[0].databaseId`
+          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event --status success --jq 'map(select(.event == "workflow_dispatch" or .event == "schedule")) | .[0].databaseId'`
           echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Description

Two things are added:

1) Linux will download the ```oneDAL_env``` artifact which describes which external dependencies to download from apt (like MKL, TBB and compiler versions)

2) Filter the list of Nightly-runs for those triggered by 'workflow_dispatch' or 'schedule' which then opens up the possibility on oneDAL side to run the Nightly-build on PRs which are modifying capabilities in CI.  This means changes in oneDAL can be done in a less-blind fashion for their impact on the nightly (and will have a follow-up PR after this is merged). This means the Nightly-build can be used for checking when CI is changed in oneDAL.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
