### PR TITLE
[enhancement] refactor onedal ```to_table```

### DIFF
--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -33,7 +33,7 @@ def _convert_one_to_table(arg):
 
 
 def to_table(*args):
-    """Convert scalars and/or arrays into oneDAL tables.
+    """Create oneDAL tables from scalars and/or arrays.
 
     Note: this implementation can be used with contiguous scipy.sparse, numpy
     arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -27,13 +27,30 @@ def _apply_and_pass(func, *args, **kwargs):
     return tuple(map(lambda arg: func(arg, **kwargs), args))
 
 
-def convert_one_to_table(arg):
+def _convert_one_to_table(arg):
     # All inputs for table conversion must be array-like or sparse, not scalars
     return _backend.to_table(np.atleast_2d(arg) if np.isscalar(arg) else arg)
 
 
 def to_table(*args):
-    return _apply_and_pass(convert_one_to_table, *args)
+    """Convert scalars and/or arrays into oneDAL tables.
+
+    Note: this implementation can be used with contiguous scipy.sparse, numpy
+    arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the
+    original array data. Scalars will be copies. Arrays may be modified in-
+    place by oneDAL during computation. This works for data located on CPU and
+    DPC++-enabled Intel GPUs. Only singular datatypes are allowed.
+
+    Parameters
+    ----------
+    *args : {scalar, numpy array, sycl_usm_ndarray, csr matrix, or csr array}
+        arg1, arg2... The arrays should be given as arguments.
+
+    Returns
+    -------
+    tables: {oneDAL homogeneous tables}
+    """
+    return _apply_and_pass(_convert_one_to_table, *args)
 
 
 if _is_dpc_backend:

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -43,7 +43,7 @@ def to_table(*args):
 
     Parameters
     ----------
-    *args : {scalar, numpy array, sycl_usm_ndarray, csr matrix, or csr array}
+    *args : {scalar, numpy array, sycl_usm_ndarray, csr_matrix, or csr_array}
         arg1, arg2... The arrays should be given as arguments.
 
     Returns

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -49,7 +49,7 @@ if _is_dpc_backend:
             if xp == dpnp:
                 return dpnp.array(dpnp.dpctl.tensor.asarray(table), copy=False)
             else:
-                return xp.asarray(table)       
+                return xp.asarray(table)
 
     except ImportError:
 

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -64,7 +64,7 @@ if _is_dpc_backend:
         # be removed entirely.
         import dpnp
 
-        def _onedal_gpu_table_to_array(table, xp=None):
+        def _table_to_array(table, xp=None):
             # By default DPNP ndarray created with a copy.
             # TODO:
             # investigate why dpnp.array(table, copy=False) doesn't work.
@@ -76,7 +76,7 @@ if _is_dpc_backend:
 
     except ImportError:
 
-        def _onedal_gpu_table_to_array(table, xp=None):
+        def _table_to_array(table, xp=None):
             return xp.asarray(table)
 
     from ..common._policy import _HostInteropPolicy
@@ -126,7 +126,7 @@ if _is_dpc_backend:
                     _backend.from_table(table), usm_type="device", sycl_queue=sycl_queue
                 )
             else:
-                return _onedal_gpu_table_to_array(table, xp=xp)
+                return _table_to_array(table, xp=xp)
 
         return _backend.from_table(table)
 

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -39,7 +39,8 @@ def to_table(*args):
     arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the
     original array data. Scalars will be copies. Arrays may be modified in-
     place by oneDAL during computation. This works for data located on CPU and
-    SYCL-enabled Intel GPUs. Only singular datatypes are allowed.
+    SYCL-enabled Intel GPUs. Data may only be of a single type per array (i.e.
+    must be homogeneous).
 
     Parameters
     ----------

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -39,7 +39,7 @@ def to_table(*args):
     arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the
     original array data. Scalars will be copies. Arrays may be modified in-
     place by oneDAL during computation. This works for data located on CPU and
-    DPC++-enabled Intel GPUs. Only singular datatypes are allowed.
+    SYCL-enabled Intel GPUs. Only singular datatypes are allowed.
 
     Parameters
     ----------

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -36,7 +36,7 @@ def to_table(*args):
     """Create oneDAL tables from scalars and/or arrays.
 
     Note: this implementation can be used with contiguous scipy.sparse, numpy
-    arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the
+    ndarrays, DPCTL/DPNP usm_ndarrays and scalars. Tables will use pointers to the
     original array data. Scalars will be copies. Arrays may be modified in-
     place by oneDAL during computation. This works for data located on CPU and
     SYCL-enabled Intel GPUs. Each array may only be of a single datatype (i.e.

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -39,8 +39,8 @@ def to_table(*args):
     arrays, sycl_usm_ndarrays, and scalars. Tables will use pointers to the
     original array data. Scalars will be copies. Arrays may be modified in-
     place by oneDAL during computation. This works for data located on CPU and
-    SYCL-enabled Intel GPUs. Data may only be of a single type per array (i.e.
-    must be homogeneous).
+    SYCL-enabled Intel GPUs. Each array may only be of a single datatype (i.e.
+    each must be homogeneous).
 
     Parameters
     ----------

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -57,6 +57,11 @@ def to_table(*args):
 if _is_dpc_backend:
 
     try:
+        # try/catch is used here instead of dpep_helpers because
+        # of circular import issues of _data_conversion.py and
+        # utils/validation.py. This is a temporary fix until the
+        # issue with dpnp is addressed, at which point this can
+        # be removed entirely.
         import dpnp
 
         def _onedal_gpu_table_to_array(table, xp=None):

--- a/onedal/datatypes/table.cpp
+++ b/onedal/datatypes/table.cpp
@@ -78,6 +78,12 @@ ONEDAL_PY_INIT_MODULE(table) {
 #endif // ONEDAL_DATA_PARALLEL
 
     m.def("to_table", [](py::object obj) {
+        #ifdef ONEDAL_DATA_PARALLEL
+        if (py::hasattr(obj, "__sycl_usm_array_interface__")) {
+            return convert_from_sua_iface(obj);
+        }
+        #endif // ONEDAL_DATA_PARALLEL
+
         auto* obj_ptr = obj.ptr();
         return convert_to_table(obj_ptr);
     });
@@ -86,12 +92,6 @@ ONEDAL_PY_INIT_MODULE(table) {
         auto* obj_ptr = convert_to_pyobject(t);
         return obj_ptr;
     });
-
-#ifdef ONEDAL_DATA_PARALLEL
-    m.def("sua_iface_to_table", [](py::object obj) {
-        return convert_from_sua_iface(obj);
-    });
-#endif // ONEDAL_DATA_PARALLEL
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -368,7 +368,7 @@ def test_sua_iface_interop_unsupported_dtypes(dataframe, queue, dtype):
 
     expected_err_msg = "Unable to convert from SUA interface: unknown data type"
     with pytest.raises(ValueError, match=expected_err_msg):
-        to_table(X, sua_iface=sua_iface)
+        to_table(X)
 
 
 @pytest.mark.parametrize(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -68,7 +68,7 @@ if _is_dpc_backend:
                 X = xp.astype(X, dtype=xp.float64)
             dtype = get_dtype(X)
             params = bs_DBSCAN._get_onedal_params(dtype)
-            X_table = to_table(X, sua_iface=sua_iface)
+            X_table = to_table(X)
             # TODO:
             # check other candidates for the dummy base oneDAL func.
             # oneDAL backend func is needed to check result table checks.
@@ -251,7 +251,7 @@ def test_input_sua_iface_zero_copy(dataframe, queue, order, dtype):
 
     sua_iface, X_dp_namespace, _ = _get_sycl_namespace(X_dp)
 
-    X_table = to_table(X_dp, sua_iface=sua_iface)
+    X_table = to_table(X_dp)
     _assert_sua_iface_fields(X_dp, X_table)
 
     X_dp_from_table = from_table(
@@ -339,7 +339,7 @@ def test_sua_iface_interop_invalid_shape(dataframe, queue, data_shape):
         "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
     )
     with pytest.raises(ValueError, match=expected_err_msg):
-        to_table(X, sua_iface=sua_iface)
+        to_table(X)
 
 
 @pytest.mark.skipif(
@@ -393,7 +393,7 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     else:
         expected_err_msg = "Numpy input Could not convert Python object to onedal table."
     with pytest.raises(ValueError, match=expected_err_msg):
-        to_table(X, sua_iface=sua_iface)
+        to_table(X)
 
 
 @pytest.mark.skipif(
@@ -411,4 +411,4 @@ def test_sua_iface_interop_if_no_dpc_backend(dataframe, queue, dtype):
 
     expected_err_msg = "SYCL usm array conversion to table requires the DPC backend"
     with pytest.raises(RuntimeError, match=expected_err_msg):
-        to_table(X, sua_iface=sua_iface)
+        to_table(X)

--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -160,7 +160,7 @@ if _is_dpc_backend:
             # fitted attributes (ending with a trailing underscore).
             check_is_fitted(self)
             sua_iface, xp, _ = _get_sycl_namespace(X)
-            X_table = to_table(X, sua_iface=sua_iface)
+            X_table = to_table(X)
             returned_X = from_table(
                 X_table, sua_iface=sua_iface, sycl_queue=X.sycl_queue, xp=xp
             )

--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -142,8 +142,8 @@ if _is_dpc_backend:
 
         def fit(self, X, y=None):
             sua_iface, xp, _ = _get_sycl_namespace(X)
-            X_table = to_table(X, sua_iface=sua_iface)
-            y_table = to_table(y, sua_iface=sua_iface)
+            X_table = to_table(X)
+            y_table = to_table(y)
             # The presence of the fitted attributes (ending with a trailing
             # underscore) is required for the correct check. The cleanup of
             # the memory will occur at the estimator instance deletion.


### PR DESCRIPTION
## Description

Changes needed to simplify its interface and to correct circular import problems occurring in #2126 (i.e. onedal.validation is used throughout, and adding onedal's assert_all_finite is not possible).  There is an avoidance of using the dpep_helpers because of the circular import of importing ```onedal.utils``` which imports some of ```onedal.utils.validation``` in the ```__init__.py``` file, therefore importing ```onedal.utils._dpep_helpers``` has to be done carefully. A follow up PR with an associated ticket will revert this change in the future.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
