### PR TITLE
Update of DPC dependencies for CI and conda-recipe

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -20,7 +20,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml dpcpp_linux-64=2025.0 dpcpp-cpp-rt=2025.0
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025.0 impi-devel=2021.14 pyyaml dpcpp_linux-64=2025.0 dpcpp-cpp-rt=2025.0
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -43,6 +43,7 @@ steps:
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       if [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.18 dpnp=0.16; fi
+      conda uninstall --force numpy numpy-base
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -27,7 +27,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml dpcpp-cpp-rt=2025.0
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -43,6 +43,7 @@ steps:
       ./conda-recipe/build.sh
     displayName: "Build daal4py/sklearnex"
   - script: |
+      . /opt/intel/oneapi/setvars.sh
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -27,7 +27,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich pyyaml "dpcpp-cpp-rt=2024.2.0"
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich pyyaml "dpcpp-cpp-rt=2025.0.0"
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -48,7 +48,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.11') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.17.0 dpnp=0.15.0; fi
+      if [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.18.1 dpnp=0.16.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -48,7 +48,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10\|3.11\|3.12') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10\|3.11') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -17,18 +17,16 @@ steps:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
     displayName: "apt-get"
   - script: |
-      bash .ci/scripts/install_dpcpp.sh
-    displayName: "dpcpp installation"
-  - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      bash .ci/scripts/describe_system.sh
-    displayName: "System info"
-  - script: |
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich pyyaml "dpcpp-cpp-rt=2025.0.0"
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml dpcpp_linux-64=2025.0 dpcpp-cpp-rt=2025.0
     displayName: "Conda create"
+  - script: |
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      bash .ci/scripts/describe_system.sh
+    displayName: "System info"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -36,7 +34,6 @@ steps:
       pip list
     displayName: "Install develop requirements"
   - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       export DALROOT=$CONDA_PREFIX

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -48,6 +48,8 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
+      # dpep installation is set to pypi to avoid conflict of numpy versions from pip and conda
+      # py312 is disabled due to segfault on exit of program with usage of dpctl
       if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10\|3.11') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
       pip list
     displayName: "Install testing requirements"

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -17,16 +17,18 @@ steps:
   - script: sudo apt-get update && sudo apt-get install -y clang-format
     displayName: "apt-get"
   - script: |
+      bash .ci/scripts/install_dpcpp.sh
+    displayName: "dpcpp installation"
+  - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
+      bash .ci/scripts/describe_system.sh
+    displayName: "System info"
+  - script: |
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025.0 impi-devel=2021.14 pyyaml dpcpp_linux-64=2025.0 dpcpp-cpp-rt=2025.0
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml dpcpp-cpp-rt=2025.0
     displayName: "Conda create"
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      bash .ci/scripts/describe_system.sh
-    displayName: "System info"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
@@ -34,6 +36,7 @@ steps:
       pip list
     displayName: "Install develop requirements"
   - script: |
+      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       export DALROOT=$CONDA_PREFIX
@@ -45,7 +48,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.12') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -42,11 +42,10 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
-      if [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.18 dpnp=0.16; fi
-      conda uninstall --force numpy numpy-base
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
+      if [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -48,7 +48,7 @@ steps:
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.12') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
+      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10\|3.11\|3.12') ] && [ $(SKLEARN_VERSION) != "1.0" ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -27,7 +27,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel=2025 mpich pyyaml dpcpp-cpp-rt=2025.0
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -43,7 +43,6 @@ steps:
       ./conda-recipe/build.sh
     displayName: "Build daal4py/sklearnex"
   - script: |
-      . /opt/intel/oneapi/setvars.sh
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -42,10 +42,10 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
+      if [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.18 dpnp=0.16; fi
       bash .ci/scripts/setup_sklearn.sh $(SKLEARN_VERSION)
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
-      if [ $(SKLEARN_VERSION) != "1.0" ]; then conda install -q -y -c https://software.repos.intel.com/python/conda/ dpctl=0.18.1 dpnp=0.16.0; fi
       pip list
     displayName: "Install testing requirements"
   - script: |

--- a/.ci/scripts/install_dpcpp.sh
+++ b/.ci/scripts/install_dpcpp.sh
@@ -21,5 +21,5 @@ rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
 echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
 sudo apt-get update
-sudo apt-get install -y intel-dpcpp-cpp-compiler-2024.2
+sudo apt-get install -y intel-dpcpp-cpp-compiler-2025.0
 sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
   build:
     - make  # [linux]
     - dpcpp_linux-64  # [linux64]
+    - kernel-headers_linux-64 ==4.18.0  # [linux64]
     # - dpcpp_win-64  # [win]
     - {{ compiler('cxx') }}  # [linux64 or win]
     # conda-forge feedstock specific

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -67,7 +67,6 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - dpcpp-cpp-rt  # [linux64]
     # dal pinning depends on the recipe location (repo or feedstock)
     - dal
     # - dal =={{ version }}
@@ -76,6 +75,8 @@ test:
   requires:
     - pyyaml
     - impi_rt  # [not win]
+    # DPC part of sklearnex is optional
+    - dpcpp-cpp-rt  # [linux64]
     # TODO: enable data parallel frameworks when they are available on conda-forge
     # - dpctl
     # - dpnp

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -77,7 +77,7 @@ requirements:
 test:
   requires:
     - pyyaml
-    - impi_rt  # [not win]
+    - mpich  # [not win]
     # DPC part of sklearnex is optional
     - dpcpp-cpp-rt  # [linux64]
     # TODO: enable data parallel frameworks when they are available on conda-forge

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,12 +41,14 @@ build:
   - DPCPPROOT
   - DALROOT
   - NO_DIST=1  # [win]
+  ignore_run_exports:
+  - dpcpp_linux-64  # [linux64]
+  # - dpcpp_win-64  # [win]
 
 requirements:
   build:
     - make  # [linux]
     - dpcpp_linux-64  # [linux64]
-    - kernel-headers_linux-64 ==4.18.0  # [linux64]
     # - dpcpp_win-64  # [win]
     - {{ compiler('cxx') }}  # [linux64 or win]
     # conda-forge feedstock specific
@@ -59,14 +61,15 @@ requirements:
     - cython
     - jinja2
     - pybind11
-    - numpy {{ numpy }}
-    - impi-devel  # [not win]
+    - numpy
+    - mpich  # [not win]
     # dal-devel pinning depends on the recipe location (repo or feedstock)
     - dal-devel
     # - dal-devel =={{ version }}
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
+    - scikit-learn
     # dal pinning depends on the recipe location (repo or feedstock)
     - dal
     # - dal =={{ version }}
@@ -82,7 +85,6 @@ test:
     # - dpnp
     # next deps are synced with requirements-test.txt
     - pytest
-    - scikit-learn
     - pandas
     - xgboost
     - lightgbm

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - jinja2
     - pybind11
     - numpy
-    - mpich  # [not win]
+    - impi-devel  # [not win]
     # dal-devel pinning depends on the recipe location (repo or feedstock)
     - dal-devel
     # - dal-devel =={{ version }}
@@ -77,7 +77,7 @@ requirements:
 test:
   requires:
     - pyyaml
-    - mpich  # [not win]
+    - impi_rt  # [not win]
     # DPC part of sklearnex is optional
     - dpcpp-cpp-rt  # [linux64]
     # TODO: enable data parallel frameworks when they are available on conda-forge


### PR DESCRIPTION
## Description

Changes:
- Update DPC compiler, DPC runtime libraries and oneDAL development files to 2025 version in CI
- Update DPCTL and DPNP versions and their installation channel to PyPI for environment consistency
- Pin linux kernel headers in conda recipe to reflect GLIBC>=2.28 dependency of dal-devel dpc part
- Move DPC runtime libraries to optional dependencies in conda recipe

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A, CI update.
