### PR TITLE
Set token permission for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read-all
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -21,7 +21,7 @@ on:
     types: [opened, edited, synchronize, ready_for_review, converted_to_draft]
 
 permissions:
-  contents: read-all
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -21,7 +21,7 @@ on:
     types: [opened, edited, synchronize, ready_for_review, converted_to_draft]
 
 permissions:
-  contents: read
+  contents: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -20,8 +20,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review, converted_to_draft]
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -15,7 +15,7 @@ on:
       - .github/renovate.json
 
 permissions:
-  contents: read
+  contents: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -14,8 +14,7 @@ on:
       - .github/workflows/renovate-validation.yml
       - .github/renovate.json
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -15,7 +15,7 @@ on:
       - .github/renovate.json
 
 permissions:
-  contents: read-all
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}


### PR DESCRIPTION
## Description

Fix OpenSSF scan failure

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [X] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [X] I have added a respective label(s) to PR if I have a permission for that.
- [X] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [X] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [X] I have extended testing suite if new functionality was introduced in this PR.

