### PR TITLE
[fix] Make finite assert logging more informative in daal4py

### DIFF
--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -98,9 +98,9 @@ def _assert_all_finite(
     )
     _dal_ready = _patching_status.and_conditions(
         [
-            (X.ndim in [1, 2], "X has not 1 or 2 dimensions."),
-            (not np.any(np.equal(X.shape, 0)), "X shape contains 0."),
-            (dt in [np.float32, np.float64], "X dtype is not float32 or float64."),
+            (X.ndim in [1, 2], f"Input {input_name} does not have 1 or 2 dimensions."),
+            (not np.any(np.equal(X.shape, 0)), f"Input {input_name} shape contains a 0."),
+            (dt in [np.float32, np.float64], f"Input {input_name} dtype is not float32 or float64."),
         ]
     )
     _patching_status.write_log()

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -100,7 +100,10 @@ def _assert_all_finite(
         [
             (X.ndim in [1, 2], f"Input {input_name} does not have 1 or 2 dimensions."),
             (not np.any(np.equal(X.shape, 0)), f"Input {input_name} shape contains a 0."),
-            (dt in [np.float32, np.float64], f"Input {input_name} dtype is not float32 or float64."),
+            (
+                dt in [np.float32, np.float64],
+                f"Input {input_name} dtype is not float32 or float64.",
+            ),
         ]
     )
     _patching_status.write_log()


### PR DESCRIPTION
## Description

Fix problem observed in issue #2165

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
