### PR TITLE
Python 3.13 support

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -70,9 +70,6 @@ jobs:
       Python3.12:
         PYTHON_VERSION: '3.12'
         NUMPY_VERSION: '2.1'
-      Python3.13:
-        PYTHON_VERSION: '3.13'
-        NUMPY_VERSION: '2.1'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -96,9 +93,6 @@ jobs:
     matrix:
       Python3.12:
         PYTHON_VERSION: '3.12'
-        NUMPY_VERSION: '2.1'
-      Python3.13:
-        PYTHON_VERSION: '3.13'
         NUMPY_VERSION: '2.1'
   pool:
     vmImage: 'windows-2022'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -137,8 +137,8 @@ jobs:
       Python3.12_Sklearn1.4:
         PYTHON_VERSION: '3.12'
         SKLEARN_VERSION: '1.4'
-      Python3.12_Sklearn1.5:
-        PYTHON_VERSION: '3.12'
+      Python3.13_Sklearn1.5:
+        PYTHON_VERSION: '3.13'
         SKLEARN_VERSION: '1.5'
   pool:
     vmImage: 'ubuntu-22.04'
@@ -164,8 +164,8 @@ jobs:
       Python3.12_Sklearn1.4:
         PYTHON_VERSION: '3.12'
         SKLEARN_VERSION: '1.4'
-      Python3.12_Sklearn1.5:
-        PYTHON_VERSION: '3.12'
+      Python3.13_Sklearn1.5:
+        PYTHON_VERSION: '3.13'
         SKLEARN_VERSION: '1.5'
   pool:
     vmImage: 'windows-2022'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -70,6 +70,9 @@ jobs:
       Python3.12:
         PYTHON_VERSION: '3.12'
         NUMPY_VERSION: '2.1'
+      Python3.13:
+        PYTHON_VERSION: '3.13'
+        NUMPY_VERSION: '2.1'
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -93,6 +96,9 @@ jobs:
     matrix:
       Python3.12:
         PYTHON_VERSION: '3.12'
+        NUMPY_VERSION: '2.1'
+      Python3.13:
+        PYTHON_VERSION: '3.13'
         NUMPY_VERSION: '2.1'
   pool:
     vmImage: 'windows-2022'

--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 import logging
+import sys
 import threading
 from functools import wraps
 from inspect import Parameter, signature
@@ -212,14 +213,16 @@ def control_n_jobs(decorated_methods: list = []):
             and isinstance(original_class.__doc__, str)
             and "n_jobs : int" not in original_class.__doc__
         ):
-            parameters_doc_tail = "\n    Attributes"
-            n_jobs_doc = """
-    n_jobs : int, default=None
-        The number of jobs to use in parallel for the computation.
-        ``None`` means using all physical cores
-        unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all logical cores.
-        See :term:`Glossary <n_jobs>` for more details.
+            # Python 3.13 removed extra tab in class doc string
+            tab = "    " if sys.version_info.minor < 13 else ""
+            parameters_doc_tail = f"\n{tab}Attributes"
+            n_jobs_doc = f"""
+{tab}n_jobs : int, default=None
+{tab}    The number of jobs to use in parallel for the computation.
+{tab}    ``None`` means using all physical cores
+{tab}    unless in a :obj:`joblib.parallel_backend` context.
+{tab}    ``-1`` means using all logical cores.
+{tab}    See :term:`Glossary <n_jobs>` for more details.
 """
             original_class.__doc__ = original_class.__doc__.replace(
                 parameters_doc_tail, n_jobs_doc + parameters_doc_tail

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,6 +12,6 @@ pandas==2.2.3 ; python_version >= '3.11'
 xgboost==2.1.2
 lightgbm==4.5.0
 catboost==1.2.7 ; python_version < '3.11' # TODO: Remove 3.11 condition when catboost supports numpy 2.0
-shap==0.46.0
+shap==0.46.0 ; python_version < '3.13'
 array-api-compat==1.9.1
 array-api-strict==2.2


### PR DESCRIPTION
## Description

Python 3.13 support changes:
- Update doc string modification in n_jobs support utilities
- Change Python3.12_Sklearn1.5 CondaEnv CI job to Python3.13_Sklearn1.5 

Applied as patch in conda-forge: https://github.com/conda-forge/scikit-learn-intelex-feedstock/pull/49

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A
