### PR TITLE
[enhancement] remove contiguous check from ```_check_array```

### DIFF
--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -35,12 +35,12 @@ def _convert_one_to_table(arg):
 def to_table(*args):
     """Create oneDAL tables from scalars and/or arrays.
 
-    Note: this implementation can be used with contiguous scipy.sparse, numpy
-    ndarrays, DPCTL/DPNP usm_ndarrays and scalars. Tables will use pointers to the
-    original array data. Scalars will be copies. Arrays may be modified in-
-    place by oneDAL during computation. This works for data located on CPU and
-    SYCL-enabled Intel GPUs. Each array may only be of a single datatype (i.e.
-    each must be homogeneous).
+    Note: this implementation can be used with scipy.sparse, numpy ndarrays,
+    DPCTL/DPNP usm_ndarrays and scalars. Tables will use pointers to the
+    original array data. Scalars and non-contiguous arrays will be copies. 
+    Arrays may be modified in-place by oneDAL during computation. This works
+    for data located on CPU and SYCL-enabled Intel GPUs. Each array may only
+    be of a single datatype (i.e. each must be homogeneous).
 
     Parameters
     ----------

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -37,7 +37,7 @@ def to_table(*args):
 
     Note: this implementation can be used with scipy.sparse, numpy ndarrays,
     DPCTL/DPNP usm_ndarrays and scalars. Tables will use pointers to the
-    original array data. Scalars and non-contiguous arrays will be copies. 
+    original array data. Scalars and non-contiguous arrays will be copies.
     Arrays may be modified in-place by oneDAL during computation. This works
     for data located on CPU and SYCL-enabled Intel GPUs. Each array may only
     be of a single datatype (i.e. each must be homogeneous).

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -155,9 +155,13 @@ dal::table convert_to_table(PyObject *obj) {
     }
     if (is_array(obj)) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
-        if (!array_is_behaved_C(ary) && !array_is_behaved_F(ary)) {
+        if (!PyArray_ISCARRAY_RO(ary) && !PyArray_ISFARRAY_RO(ary)) {
             // NOTE: this will make a C-contiguous deep copy of the data
+            // this is expected to be a special case
             ary = PyArray_GETCONTIGUOUS(ary);
+            res = convert_to_table(ary);
+            Py_DECREF(ary);
+            return res;
         }
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
         SET_NPY_FEATURE(array_type(ary),

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -159,9 +159,15 @@ dal::table convert_to_table(PyObject *obj) {
             // NOTE: this will make a C-contiguous deep copy of the data
             // this is expected to be a special case
             ary = PyArray_GETCONTIGUOUS(ary);
-            res = convert_to_table(reinterpret_cast<PyObject *>(ary));
-            Py_DECREF(ary);
-            return res;
+            if (ary) {
+                res = convert_to_table(reinterpret_cast<PyObject *>(ary));
+                Py_DECREF(ary);
+                return res;
+            } 
+            else {
+                throw std::invalid_argument(
+                "[convert_to_table] Numpy input could not be converted into onedal table.");
+            }
         }
 #define MAKE_HOMOGEN_TABLE(CType) res = convert_to_homogen_impl<CType>(ary);
         SET_NPY_FEATURE(array_type(ary),

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -159,7 +159,7 @@ dal::table convert_to_table(PyObject *obj) {
             // NOTE: this will make a C-contiguous deep copy of the data
             // this is expected to be a special case
             ary = PyArray_GETCONTIGUOUS(ary);
-            res = convert_to_table(ary);
+            res = convert_to_table(reinterpret_cast<PyObject *>(ary));
             Py_DECREF(ary);
             return res;
         }

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -34,6 +34,7 @@
 
 namespace oneapi::dal::python {
 
+using namespace pybind11::literals;
 // Please follow <https://intelpython.github.io/dpctl/latest/
 // api_reference/dpctl/sycl_usm_array_interface.html#sycl-usm-array-interface-attribute>
 // for the description of `__sycl_usm_array_interface__` protocol.

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -68,6 +68,8 @@ dal::table convert_to_homogen_impl(py::object obj) {
     const auto layout = get_sua_iface_layout(sua_iface_dict, r_count, c_count);
 
     if (layout == dal::data_layout::unknown){
+        // NOTE: this will make a C-contiguous deep copy of the data
+        // if possible, this is expected to be a special case
         py::object copy;
         if (py::hasattr(obj, "copy")){
             copy = obj.attr("copy")();

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -68,7 +68,7 @@ dal::table convert_to_homogen_impl(py::object obj) {
 
     if (layout == dal::data_layout::unknown){
         const auto shape = get_sua_shape(sua_iface_dict);
-        py::object copy = obj.attr("reshape")(shape, true); // get a contiguous copy
+        py::object copy = obj.attr("reshape")(shape, "copy"_a = true); // get a contiguous copy
         res = convert_to_homogen_impl<Type>(copy);
         copy.dec_ref();
         return res;

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -73,7 +73,7 @@ dal::table convert_to_homogen_impl(py::object obj) {
             copy = obj.attr("copy")();
         }
         else if (py::hasattr(obj, "__array_namespace__")){
-            const auto space = obj.attr("__array_namespace__");
+            const auto space = obj.attr("__array_namespace__")();
             copy = space.attr("asarray")(obj, "copy"_a = true);
         }
         else {

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -67,7 +67,7 @@ dal::table convert_to_homogen_impl(py::object obj) {
     const auto layout = get_sua_iface_layout(sua_iface_dict, r_count, c_count);
 
     if (layout == dal::data_layout::unknown){
-        py::object copy = obj.attr("copy")() // get a contiguous copy
+        py::object copy = obj.attr("copy")(); // get a contiguous copy
         res = convert_to_homogen_impl(copy);
         copy.dec_ref();
         return res;

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -67,7 +67,8 @@ dal::table convert_to_homogen_impl(py::object obj) {
     const auto layout = get_sua_iface_layout(sua_iface_dict, r_count, c_count);
 
     if (layout == dal::data_layout::unknown){
-        py::object copy = obj.attr("copy")(); // get a contiguous copy
+        const auto shape = get_sua_shape(sua_iface_dict);
+        py::object copy = obj.attr("reshape")(shape, true); // get a contiguous copy
         res = convert_to_homogen_impl<Type>(copy);
         copy.dec_ref();
         return res;

--- a/onedal/datatypes/data_conversion_sua_iface.cpp
+++ b/onedal/datatypes/data_conversion_sua_iface.cpp
@@ -68,7 +68,7 @@ dal::table convert_to_homogen_impl(py::object obj) {
 
     if (layout == dal::data_layout::unknown){
         py::object copy = obj.attr("copy")(); // get a contiguous copy
-        res = convert_to_homogen_impl(copy);
+        res = convert_to_homogen_impl<Type>(copy);
         copy.dec_ref();
         return res;
     }

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -383,17 +383,8 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     sua_iface, _, _ = _get_sycl_namespace(X)
     # X expected to be non-contiguous.
     assert not X.flags.c_contiguous and not X.flags.f_contiguous
-
-    # TODO:
-    # consistent error message.
-    if dataframe in "dpnp,dpctl":
-        expected_err_msg = (
-            "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
-        )
-        with pytest.raises(ValueError, match=expected_err_msg):
-            to_table(X)
-    else:
-        to_table(X)
+    X_t = to_table(X)
+    assert X_t and X_t.shape and X_t[1,1]
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -390,11 +390,10 @@ def test_to_table_non_contiguous_input(dataframe, queue):
         expected_err_msg = (
             "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
         )
-        expected_err_msg = "Numpy input Could not convert Python object to onedal table."
         with pytest.raises(ValueError, match=expected_err_msg):
             to_table(X)
     else:
-        to_table(x)
+        to_table(X)
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -384,7 +384,7 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     # X expected to be non-contiguous.
     assert not X.flags.c_contiguous and not X.flags.f_contiguous
     X_t = to_table(X)
-    assert X_t and X_t.shape and X_t.has_data
+    assert X_t and X_t.shape == (10, 3) and X_t.has_data
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -377,7 +377,7 @@ def test_sua_iface_interop_unsupported_dtypes(dataframe, queue, dtype):
 def test_to_table_non_contiguous_input(dataframe, queue):
     if dataframe in "dpnp,dpctl" and not _is_dpc_backend:
         pytest.skip("__sycl_usm_array_interface__ support requires DPC backend.")
-    X = np.mgrid[:10, :10]
+    X, _ = np.mgrid[:10, :10]
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     X = X[:, :3]
     sua_iface, _, _ = _get_sycl_namespace(X)
@@ -390,10 +390,11 @@ def test_to_table_non_contiguous_input(dataframe, queue):
         expected_err_msg = (
             "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
         )
-    else:
         expected_err_msg = "Numpy input Could not convert Python object to onedal table."
-    with pytest.raises(ValueError, match=expected_err_msg):
-        to_table(X)
+        with pytest.raises(ValueError, match=expected_err_msg):
+            to_table(X)
+    else:
+        to_table(x)
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -384,7 +384,7 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     # X expected to be non-contiguous.
     assert not X.flags.c_contiguous and not X.flags.f_contiguous
     X_t = to_table(X)
-    assert X_t and X_t.shape and X_t[1,1]
+    assert X_t and X_t.shape and X_t.has_data
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/utils/sua_iface_helpers.cpp
+++ b/onedal/datatypes/utils/sua_iface_helpers.cpp
@@ -163,7 +163,7 @@ dal::data_layout get_sua_iface_layout(const py::dict& sua_dict,
             return dal::data_layout::column_major;
         }
         else {
-            throw std::runtime_error("Wrong strides");
+            return dal::data_layout::unknown;
         }
     }
     else {

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -158,10 +158,6 @@ def _check_array(
     if not array.flags.aligned and not array.flags.writeable:
         array = np.array(array.tolist())
 
-    # TODO: If data is not contiguous copy to contiguous
-    # Need implemeted numpy table in oneDAL
-    if not array.flags.c_contiguous and not array.flags.f_contiguous:
-        array = np.ascontiguousarray(array, array.dtype)
     return array
 
 

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -153,11 +153,6 @@ def _check_array(
 
     if sp.issparse(array):
         return array
-
-    # TODO: Convert this kind of arrays to a table like in daal4py
-    if not array.flags.aligned and not array.flags.writeable:
-        array = np.array(array.tolist())
-
     return array
 
 


### PR DESCRIPTION
## Description

This PR makes ```to_table``` handle non-contiguous arrays natively.  The checks in ```_check_array``` are hardcoded for numpy inputs, and are applied regardless of the circumstance. This makes the check seamless, will remove a blocker for other non-numpy data types, and will help in the rollout of the new finite checker, where a future refactor will remove ```_check_array``` entirely and enforce the use of ```validate_data``` and ```_check_sample_weight``` in sklearnex.  This also removes three TODOs listed in the codebase.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
