### PR TITLE
[CI] remove check 2025.2 kmeans and knn conformance

### DIFF
--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -133,8 +133,6 @@ def test_dense_vs_sparse(queue, init, algorithm, dims):
     from sklearnex.cluster import KMeans
 
     if init == "random" or (not _IS_INTEL and init == "k-means++"):
-        if daal_check_version((2025, "P", 600)):
-            pytest.fail("Re-verify failure of k-means++ in 2025.6 oneDAL")
         pytest.skip(f"{init} initialization for sparse K-means is non-conformant.")
 
     # For higher level of sparsity (smaller density) the test may fail

--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -132,7 +132,7 @@ def test_results_on_dense_gold_data(dataframe, queue, algorithm):
 def test_dense_vs_sparse(queue, init, algorithm, dims):
     from sklearnex.cluster import KMeans
 
-    if init == "random" or (not _IS_INTEL and init == "k-means++"):
+    if False:
         if daal_check_version((2025, "P", 200)):
             pytest.fail("Re-verify failure of k-means++ in 2025.2 oneDAL")
         pytest.skip(f"{init} initialization for sparse K-means is non-conformant.")

--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -132,9 +132,9 @@ def test_results_on_dense_gold_data(dataframe, queue, algorithm):
 def test_dense_vs_sparse(queue, init, algorithm, dims):
     from sklearnex.cluster import KMeans
 
-    if False:
-        if daal_check_version((2025, "P", 200)):
-            pytest.fail("Re-verify failure of k-means++ in 2025.2 oneDAL")
+    if init == "random" or (not _IS_INTEL and init == "k-means++"):
+        if daal_check_version((2025, "P", 600)):
+            pytest.fail("Re-verify failure of k-means++ in 2025.6 oneDAL")
         pytest.skip(f"{init} initialization for sparse K-means is non-conformant.")
 
     # For higher level of sparsity (smaller density) the test may fail

--- a/sklearnex/tests/test_run_to_run_stability.py
+++ b/sklearnex/tests/test_run_to_run_stability.py
@@ -153,8 +153,6 @@ def _skip_neighbors(estimator, method):
         and method
         in ["score", "predict", "kneighbors", "kneighbors_graph", "predict_proba"]
     ):
-        if daal_check_version((2025, "P", 200)):
-            pytest.fail("Re-verify failure of algorithms in oneDAL 2025.2")
         pytest.skip(f"{estimator} shows instability on non-Intel(R) hardware")
 
 


### PR DESCRIPTION
## Description

Poison-pill check for 2025.2 k-means init and knn. These poison-pill checks are changed to tickets in the backlog.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
