### PR TITLE
[fix] Update comment in sklearnex/utils/validation.py

### DIFF
--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -45,14 +45,10 @@ if daal_check_version((2024, "P", 700)):
     from onedal.utils.validation import _assert_all_finite as _onedal_assert_all_finite
 
     def _onedal_supported_format(X, xp):
-        # array_api does not have a `strides` or `flags` attribute for testing memory
-        # order. When dlpack support is brought in for oneDAL, general support for
-        # array_api can be enabled and the hasattr check can be removed.
-        # _onedal_supported_format is therefore conservative in verifying attributes and
-        # does not support array_api. This will block onedal_assert_all_finite from being
-        # used for array_api inputs but will allow dpnp ndarrays and dpctl tensors.
-        # only check contiguous arrays to prevent unnecessary copying of data, even if
-        # non-contiguous arrays can now be converted to oneDAL tables.
+        # data should be checked if contiguous, as oneDAL will only use contiguous
+        # data from sklearnex. Unlike other oneDAL offloading, copying the data is
+        # specifically avoided as it has a non-negligible impact on speed. In that
+        # case use native sklearn ``_assert_all_finite``
         return X.dtype in [xp.float32, xp.float64] and is_contiguous(X)
 
 else:


### PR DESCRIPTION
## Description

Missing change in comment from #2296 .  This clarifies why ```is_contiguous``` is necessary, now that it supports array_api inputs.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

