### PR TITLE
[maintenance] use standard ```_is_numpy_namespace``` for numpy namespace checking in PCA

### DIFF
--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -45,6 +45,7 @@ if daal_check_version((2024, "P", 100)):
     from sklearn.decomposition import PCA as _sklearn_PCA
 
     from onedal.decomposition import PCA as onedal_PCA
+    from onedal.utils._array_api import _is_numpy_namespace
 
     @control_n_jobs(decorated_methods=["fit", "transform", "fit_transform"])
     class PCA(oneDALEstimator, _sklearn_PCA):
@@ -224,7 +225,7 @@ if daal_check_version((2024, "P", 100)):
             else:
                 components = self.components_
 
-            if "numpy" not in xp.__name__:
+            if not _is_numpy_namespace(xp):
                 # DPCtl and dpnp require inputs to be on the same device for
                 # matrix multiplication and division. The type and location
                 # of the components and mean are dependent on the sklearn


### PR DESCRIPTION
## Description

```_is_numpy_namespace``` was introduced in #1861 which is used for overall numpy namespace checking.  This swaps a custom check with our standard one in order to reduce maintenance and make general conformance across the codebase.  This was also done in ```IncrementalEmpericalCovariance```.

No performance benchmarks necessary.
---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
