### PR TITLE
Enable Coverity scan for C++

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -45,7 +45,16 @@ jobs:
     displayName: 'Install Coverity tool'
   - script: |
       cd $(Build.Repository.LocalPath)
+      conda config --append channels conda-forge
+      conda config --set channel_priority strict
+      conda update -y -q conda
+      conda create -y -q -n CB -c conda-forge python=$(python.version) dal-devel impi-devel
+      . /usr/share/miniconda/etc/profile.d/conda.sh
+      conda activate CB
+      pip install -r dependencies-dev
+      export DALROOT=$CONDA_PREFIX
       $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int --no-command --fs-capture-search .
+      $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int -- python setup.py build_ext --inplace
       zip -r daal4py.zip cov-int
     displayName: 'Perform Coverity scan'
   - script: |


### PR DESCRIPTION
## Description

Updates coverity job to instrument scikit build
test scan - https://scan.coverity.com/projects/napetrov-daal4py?tab=overview
---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.

**Testing**

- [ ] I have run it locally and tested the changes extensively.

