### PR TITLE
Remove separate CI steps for sklearnex preview

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -88,17 +88,6 @@ steps:
       TBBROOT: ${{ variables.TBBROOT }}
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
       NO_DPC: ${{ variables.NO_DPC }}
-    displayName: "Sklearn testing"
-    condition: succeededOrFailed()
-  - script: |
-      . /usr/share/miniconda/etc/profile.d/conda.sh
-      conda activate CB
-      if [ -n "${TBBROOT}" ] && [ "${TBBROOT}" != "${CONDA_PREFIX}" ]; then source ${TBBROOT}/env/vars.sh; fi
-      if [ -z "${NO_DPC}" ]; then export CPU="cpu"; fi
-      bash .ci/scripts/run_sklearn_tests.sh $CPU
-    env:
-      TBBROOT: ${{ variables.TBBROOT }}
-      NO_DPC: ${{ variables.NO_DPC }}
       SKLEARNEX_PREVIEW: "YES"
-    displayName: "Sklearn testing [preview]"
+    displayName: "Sklearn testing"
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -51,12 +51,7 @@ steps:
   - script: |
       source activate CB
       bash .ci/scripts/run_sklearn_tests.sh
-    displayName: 'Sklearn testing'
-    condition: succeededOrFailed()
-  - script: |
-      source activate CB
-      bash .ci/scripts/run_sklearn_tests.sh
     env:
       SKLEARNEX_PREVIEW: "YES"
-    displayName: 'Sklearn testing [preview]'
+    displayName: 'Sklearn testing'
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -72,17 +72,7 @@ steps:
     displayName: 'Sklearn testing'
     condition: succeededOrFailed()
     env:
+      SKLEARNEX_PREVIEW: "YES"
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
       DALROOT: ${{ variables.DALROOT }}
       TBBROOT: ${{ variables.TBBROOT }}
-  - script: |
-      call activate CB
-      if defined DALROOT call "%DALROOT%\env\vars.bat"
-      if defined TBBROOT call "%TBBROOT%\env\vars.bat"
-      bash .ci/scripts/run_sklearn_tests.sh
-    env:
-      SKLEARNEX_PREVIEW: "YES"
-      DALROOT: ${{ variables.DALROOT }}
-      TBBROOT: ${{ variables.TBBROOT }}
-    displayName: 'Sklearn testing [preview]'
-    condition: succeededOrFailed()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           source venv/bin/activate
           source .github/scripts/activate_components.sh
           export COVERAGE_FILE=$(pwd)/.coverage.sklearn
+          export SKLEARNEX_PREVIEW='YES'
           if [ "${{ steps.set-env.outputs.DPCFLAG }}" == "" ]; then export CPU=cpu; fi
           bash .ci/scripts/run_sklearn_tests.sh $CPU
       - name: Create coverage report
@@ -167,13 +168,6 @@ jobs:
           name: coverage_lnx_Py${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}
           path: |
             *_lnx${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}.info
-      - name: Sklearn testing [preview]
-        run: |
-          source venv/bin/activate
-          source .github/scripts/activate_components.sh
-          if [ "${{ steps.set-env.outputs.DPCFLAG }}" == "" ]; then export CPU=cpu; fi
-          export SKLEARNEX_PREVIEW='YES'
-          bash .ci/scripts/run_sklearn_tests.sh $CPU
 
   sklearn_win:
     needs: onedal_nightly
@@ -287,6 +281,7 @@ jobs:
           call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
           set PYTHON=python
           set COVERAGE_FILE=%cd%\.coverage.sklearnex
+          set SKLEARNEX_PREVIEW=YES
           cd ..
           call scikit-learn-intelex\conda-recipe\run_test.bat scikit-learn-intelex\
       - name: Sklearn testing
@@ -309,14 +304,6 @@ jobs:
           name: coverage_win_Py${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}
           path: |
              *_win${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}.info
-      - name: Sklearn testing [preview]
-        shell: cmd
-        run: |
-          call .\venv\Scripts\activate.bat
-          call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
-          if "${{ steps.set-env.outputs.DPCFLAG }}"=="" set CPU=cpu
-          set SKLEARNEX_PREVIEW=YES
-          bash .ci/scripts/run_sklearn_tests.sh %CPU%
 
   build_uxl:
     if: github.repository == 'uxlfoundation/scikit-learn-intelex'
@@ -474,6 +461,7 @@ jobs:
         run: |
           source .github/scripts/activate_components.sh
           export COVERAGE_FILE=$(pwd)/.coverage.sklearnex
+          export SKLEARNEX_PREVIEW='YES'
           cd .ci
           ../conda-recipe/run_test.sh
       - name: Sklearn testing
@@ -491,8 +479,3 @@ jobs:
           name: coverage_uxl_lnx_${{ matrix.DEVICE }}
           path: |
             *uxl_lnx_${{ matrix.DEVICE }}.info
-      - name: Sklearn testing [preview]
-        run: |
-          source .github/scripts/activate_components.sh
-          export SKLEARNEX_PREVIEW='YES'
-          bash .ci/scripts/run_sklearn_tests.sh ${{ matrix.DEVICE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,6 @@ jobs:
           call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
           set PYTHON=python
           set COVERAGE_FILE=%cd%\.coverage.sklearnex
-          set SKLEARNEX_PREVIEW=YES
           cd ..
           call scikit-learn-intelex\conda-recipe\run_test.bat scikit-learn-intelex\
       - name: Sklearn testing
@@ -290,6 +289,7 @@ jobs:
           call .\venv\Scripts\activate.bat
           call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
           set COVERAGE_FILE=%cd%\.coverage.sklearn
+          set SKLEARNEX_PREVIEW=YES
           if "${{ steps.set-env.outputs.DPCFLAG }}"=="" set CPU=cpu
           bash .ci/scripts/run_sklearn_tests.sh %CPU%
       - name: Create coverage report
@@ -461,13 +461,13 @@ jobs:
         run: |
           source .github/scripts/activate_components.sh
           export COVERAGE_FILE=$(pwd)/.coverage.sklearnex
-          export SKLEARNEX_PREVIEW='YES'
           cd .ci
           ../conda-recipe/run_test.sh
       - name: Sklearn testing
         run: |
           source .github/scripts/activate_components.sh
           export COVERAGE_FILE=$(pwd)/.coverage.sklearn
+          export SKLEARNEX_PREVIEW='YES'
           bash .ci/scripts/run_sklearn_tests.sh ${{ matrix.DEVICE }}
       - name: Create coverage report
         run: |


### PR DESCRIPTION
## Description

Separate testing for preview functionality of sklearnex is not required since there is no intersection between regular and preview scopes of sklearnex.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A
