### PR TITLE
FIX: Sort indices of sparse matrices

### DIFF
--- a/onedal/datatypes/numpy/data_conversion.hpp
+++ b/onedal/datatypes/numpy/data_conversion.hpp
@@ -32,6 +32,7 @@ namespace py = pybind11;
 PyObject *convert_to_pyobject(const dal::table &input);
 dal::table convert_to_table(py::object inp_obj,
                             py::object queue = py::none(),
-                            bool recursed = false);
+                            bool recursed = false,
+                            bool require_sparse_with_sorted_indices = true);
 
 } // namespace oneapi::dal::python::numpy

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -102,7 +102,6 @@ def validate_data(
     /,
     X="no_validation",
     y="no_validation",
-    require_sparse_with_sorted_indices=True,
     **kwargs,
 ):
     # force finite check to not occur in sklearn, default is True
@@ -135,14 +134,6 @@ def validate_data(
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="X")
         if check_y:
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="y")
-
-    if (
-        require_sparse_with_sorted_indices
-        and sp.issparse(X)
-        and hasattr(X, "has_sorted_indices")
-        and not X.has_sorted_indices
-    ):
-        X.sort_indices()
 
     return out
 


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/scikit-learn-intelex/issues/1880

This PR forcibly sorts the indices of sparse matrices before passing them to any routines in oneDAL if they aren't already sorted, as some algorithms assume that they come sorted and produce incorrect results when they aren't.

It's unclear yet which algorithms require this and which ones do not. For efficiency reasons, this additional step should be skipped in algorithms that don't need it, but that would need to be done over different PRs later on.

~It's also unclear yet if this is something that should be done on the oneDAL side instead, so leaving it as a draft PR for now.~ From internal discussions, this is a reasonable approach to follow, so moving out of draft.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have provided justification why performance has changed or why changes are not expected.
