### PR TITLE
MAINT: Ensure newer oneDAL gets installed in conda jobs

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -35,7 +35,7 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
-      if [ -z "${DALROOT}" ]; then conda install -q -y -c conda-forge dal-devel; fi
+      if [ -z "${DALROOT}" ]; then conda install -q -y -c conda-forge "dal-devel>=2025.6.1"; fi
       pip install -r dependencies-dev
       pip list
     env:

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -26,7 +26,7 @@ steps:
       pip install cpufeature
       pip install -r dependencies-dev
       pip list
-      if not defined DALROOT conda install -q -y -c conda-forge dal-devel
+      if not defined DALROOT conda install -q -y -c conda-forge "dal-devel>=2025.6.1"
     displayName: 'Install develop requirements'
     env:
       DALROOT: ${{ variables.DALROOT }}


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/oneTBB/issues/1787

This PR ensures that a recent version of oneDAL gets installed in the conda CI jobs, possibly downgrading transiive dependencies along the way if needed.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.
