### PR TITLE
FIX: Fix treating binary multinomial as logistic in GPU logreg

### DIFF
--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -313,6 +313,7 @@ Classification
        - ``penalty`` != `'l2'`
        - ``dual`` = `True`
        - ``intercept_scaling`` != `1`
+       - ``multi_class`` = `'multinomial'`
        - ``warm_start`` = `True`
        - ``l1_ratio`` != 0 and ``l1_ratio`` != ``None``
        - Only binary classification is supported

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -210,6 +210,10 @@ if daal_check_version((2024, "P", 1)):
                     (self.solver == "newton-cg", "Only newton-cg solver is supported."),
                     (self.warm_start == False, "Warm start is not supported."),
                     (
+                        not (self.multi_class == "multinomial"),
+                        "multi_class='multinomial is not supported.",
+                    ),
+                    (
                         not self.l1_ratio,
                         "l1 ratio is not supported.",
                     ),


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/scikit-learn-intelex/pull/2513

This undoes part of the previous PR. Turns out scikit-learn is doing theoretically incorrect computations when passing `multiclass="multinomial"` and the data is binary, while sklearnex is still calling oneDAL which uses a (theoretically correct) binary logistic function.

PR https://github.com/uxlfoundation/scikit-learn-intelex/pull/2628 adds a test for this variant on CPU, but it looks like this isn't tested anywhere on GPU.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
