### PR TITLE
FIX: Correct default argument for multiclass in logistic path

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -91,7 +91,7 @@ def __logistic_regression_path(
     dual=False,
     penalty="l2",
     intercept_scaling=1.0,
-    multi_class="warn",
+    multi_class="auto",
     random_state=None,
     check_input=True,
     max_squared_sum=None,


### PR DESCRIPTION
## Description

This PR updates the default argument for 'multiclass' in logistic path to match with what sklearn has been using since version 0.22:
https://github.com/scikit-learn/scikit-learn/blame/4abf564cb4ac58d61fbbe83552c28f764284a69d/sklearn/linear_model/_logistic.py#L113C18-L113C22

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
