### PR TITLE
MAINT: Temporarily deselect failing test until bug is fixed

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -318,7 +318,7 @@ deselected_tests:
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results[1e-08-sparse
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results[1e-100-sparse
   - cluster/tests/test_k_means.py::test_kmeans_elkan_results[0-sparse
-  # Temporary eselections due to a bug in oneDAL, remove once the issue is fixed.
+  # Temporary deselections due to a bug in oneDAL, remove once the issue is fixed.
   # Probably can also removed the kmeans ones above once these are fixed.
   - cluster/tests/test_k_means.py::test_float_precision[42-KMeans-sparse_matrix]
   - cluster/tests/test_k_means.py::test_float_precision[42-KMeans-sparse_array]


### PR DESCRIPTION
## Description

This PR temporarily adds deselections of a test that fails sporadically. There is definitely a bug on the oneDAL side, but it will take a while to fix, so in the meantime this deselects the tests.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
