### PR TITLE
MAINT: More temporary deselections due to bug with csr tables

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -328,7 +328,6 @@ deselected_tests:
   - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims1-full-k-means++-None]
   - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims2-full-k-means++-None]
   - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims2-elkan-k-means++-None]
-
   # Fails in stock scikit-learn: checks that data is modified in-place when not strictly required
   - linear_model/tests/test_base.py::test_inplace_data_preprocessing
 


### PR DESCRIPTION
## Description

As a follow up from https://github.com/uxlfoundation/scikit-learn-intelex/pull/2674

Other tests involving the same bugged codepath are also causing sporadic failures, such as in here:
https://github.com/uxlfoundation/scikit-learn-intelex/actions/runs/18363143289/job/52310600412?pr=2715#step:14:11519

This PR deselects those. They can be re-enabled again once the bug causing these sporadic failures is fixed on the oneDAL side.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
