### PR TITLE
MAINT: More temporary deselections due to bug with csr tables (v2)

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -324,6 +324,10 @@ deselected_tests:
   # Probably can also removed the kmeans ones above once these are fixed.
   - cluster/tests/test_k_means.py::test_float_precision[42-KMeans-sparse_matrix]
   - cluster/tests/test_k_means.py::test_float_precision[42-KMeans-sparse_array]
+  - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims0-elkan-k-means++-None]
+  - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims1-full-k-means++-None]
+  - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims2-full-k-means++-None]
+  - cluster/tests/test_kmeans.py::test_dense_vs_sparse[dims2-elkan-k-means++-None]
 
   # Fails in stock scikit-learn: checks that data is modified in-place when not strictly required
   - linear_model/tests/test_base.py::test_inplace_data_preprocessing


### PR DESCRIPTION
## Description

Copy of https://github.com/uxlfoundation/scikit-learn-intelex/pull/2716

Somehow, github added a duplicated commit with different hashes which resulted in that PR hanging during the automated github checks for mergeability. I was trying to close it and reopen it, but it didn't let me reopen after closing, so creating a new PR

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] All CI jobs are green or I have provided justification why they aren't.
</details>
