### PR TITLE
DOC: Correct the phrase about DAAL interface deprecation

### DIFF
--- a/doc/sources/about_daal4py.rst
+++ b/doc/sources/about_daal4py.rst
@@ -26,7 +26,7 @@ over the |onedal|. It has been deprecated in favor of the newer ``sklearnex`` mo
 same package, which offers a more idiomatic and higher-level interface for calling accelerated
 routines from the |onedal| in Python.
 
-Internally, ``daal4py`` is a Python wrapper over the :ref:`now-deprecated "DAAL" interface <onedal:oneapi_vs_daal>`
+Internally, ``daal4py`` is a Python wrapper over the :ref:`legacy CPU-only "DAAL" interface <onedal:oneapi_vs_daal>`
 of the |onedal|, while ``sklearnex`` is a module built atop of the "oneAPI" interface, offering
 DPC-based features such as :ref:`GPU support <oneapi_gpu>`.
 


### PR DESCRIPTION
## Description

daal4py chapter was stating that DAAL API is deprecated when it is not actually.
This PR corrects that statement.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

The documentation was built successfully.

**Performance**

not applicable

</details>
