### PR TITLE
TEST: Fix incorrect comparison of function values in lasso

### DIFF
--- a/daal4py/sklearn/linear_model/tests/test_enet.py
+++ b/daal4py/sklearn/linear_model/tests/test_enet.py
@@ -29,7 +29,7 @@ def fn_lasso(model, X, y, lambda_):
     resid = y - model.predict(X)
     fn_ssq = resid.reshape(-1) @ resid.reshape(-1)
     fn_l1 = np.abs(model.coef_).sum()
-    return fn_ssq + lambda_ * fn_l1
+    return (1 / (2 * X.shape[0])) * fn_ssq + lambda_ * fn_l1
 
 
 @pytest.mark.parametrize("nrows", [10, 20])
@@ -62,7 +62,7 @@ def test_enet_is_correct(nrows, ncols, n_targets, fit_intercept, positive, l1_ra
     # Note: lasso is not guaranteed to have a unique global optimum.
     # If the coefficients do not match, this makes another check on
     # the optimality of the function values instead. It checks that
-    # the result from daal4py is no worse than 2% off scikit-learn's.
+    # the result from daal4py is no worse than scikit-learn's.
 
     tol = 1e-6 if n_targets == 1 else 1e-5
     try:
@@ -72,7 +72,7 @@ def test_enet_is_correct(nrows, ncols, n_targets, fit_intercept, positive, l1_ra
             raise e
         fn_d4p = fn_lasso(model_d4p, X, y, model_d4p.alpha)
         fn_skl = fn_lasso(model_skl, X, y, model_skl.alpha)
-        assert fn_d4p <= fn_skl * 1.02
+        assert fn_d4p <= fn_skl
 
     if fit_intercept:
         np.testing.assert_allclose(
@@ -120,7 +120,7 @@ def test_lasso_is_correct(nrows, ncols, n_targets, fit_intercept, positive, alph
     except AssertionError as e:
         fn_d4p = fn_lasso(model_d4p, X, y, model_d4p.alpha)
         fn_skl = fn_lasso(model_skl, X, y, model_skl.alpha)
-        assert fn_d4p <= fn_skl * 1.02
+        assert fn_d4p <= fn_skl
 
     if positive:
         assert np.all(model_d4p.coef_ >= 0)


### PR DESCRIPTION
## Description

Previous PR adding tests for lasso/enet had a mistake in the calculation of the objective function that needs to be minimized. This PR fixes it, and along the way tightens the tests as it seems oneDAL is generating more correct results by this metric than scikit-learn.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
