### PR TITLE
Add sklearnex interface for polynomial kernel

### DIFF
--- a/sklearnex/svm/tests/test_poly_kernel_sklearnex.py
+++ b/sklearnex/svm/tests/test_poly_kernel_sklearnex.py
@@ -7,7 +7,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
+# Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
@@ -15,23 +15,29 @@
 # ==============================================================================
 
 import numpy as np
+from scipy import sparse
+from sklearn.metrics.pairwise import polynomial_kernel as sklearn_poly_kernel
 
 from sklearnex.svm.poly_kernel import poly_kernel
 
 
-def test_poly_kernel_basic():
+def test_poly_kernel_dense():
+    """Test poly_kernel on dense input arrays."""
     X = np.array([[1, 2], [3, 4]])
     Y = np.array([[5, 6], [7, 8]])
 
-    K = poly_kernel(X, Y, gamma=1.0, coef0=0.0, degree=2)
+    result = poly_kernel(X, Y, degree=2, gamma=0.5, coef0=1)
+    expected = sklearn_poly_kernel(X, Y, degree=2, gamma=0.5, coef0=1)
 
-    # expected polynomial kernel manually
-    expected = (np.dot(X, Y.T)) ** 2
-    assert np.allclose(K, expected), "Polynomial kernel computation is incorrect"
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
-def test_poly_kernel_default_Y():
-    X = np.array([[1, 2], [3, 4]])
-    K = poly_kernel(X)
-    expected = (np.dot(X, X.T)) ** 3  # default degree=3
-    assert np.allclose(K, expected), "Polynomial kernel with Y=None is incorrect"
+def test_poly_kernel_sparse_fallback():
+    """Test that poly_kernel falls back to sklearn implementation for sparse inputs."""
+    X = sparse.csr_matrix([[1, 0], [0, 1]])
+    Y = sparse.csr_matrix([[0, 1], [1, 0]])
+
+    result = poly_kernel(X, Y, degree=3, gamma=1.0, coef0=1.0)
+    expected = sklearn_poly_kernel(X, Y, degree=3, gamma=1.0, coef0=1.0)
+
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
This PR introduces a new poly_kernel interface in the sklearnex.svm module that wraps the existing oneDAL poly_kernel implementation.

The function supports X, Y, gamma, coef0, degree, and optional SYCL queue.

Includes tests in sklearnex/svm/tests/test_poly_kernel_sklearnex.py to validate correctness.

All code passes pre-commit checks, including black, isort, and numpydoc.

This enhancement allows Scikit-learn users to leverage the oneDAL backend for polynomial kernel computations via sklearnex.