### PR TITLE
ENH: Increase correction pairs used for quasi Newton approximations

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -249,6 +249,11 @@ def __logistic_regression_path(
             iprint = [-1, 50, 1, 100, 101][
                 np.searchsorted(np.array([0, 1, 2, 3]), verbose)
             ]
+            # Note: this uses more correction pairs than the implementation in scikit-learn,
+            # which means better approximation of the Hessian at the expense of slower updates.
+            # This is beneficial for high-dimensional convex problems without bound constraints
+            # like the logistic regression being fitted here. For larger problems with sparse
+            # data (currently not supported), it might benefit from increasing the number further.
             opt_res = optimize.minimize(
                 func,
                 w0,
@@ -257,6 +262,7 @@ def __logistic_regression_path(
                 args=extra_args,
                 options={
                     "maxiter": max_iter,
+                    "maxcor": 50,
                     "maxls": 50,
                     "gtol": tol,
                     "ftol": 64 * np.finfo(float).eps,


### PR DESCRIPTION
## Description

Logistic regression calls the L-BFGS-B solver from SciPy with mostly default parameters mimicking scikit-learn. The parameters for the solver were meant as default choices for a general solver that's aimed at solving non-convex and bound-constrained problems, but for a comparatively easier problem like L2-regularized logistic regression, they are not optimal - instead, better approximations to the true Hessian (through more corrections in the underlying quasi-Newton approximations) are typically beneficial for high-dimensional datasets.

Benchmarks on an Ice Lake machine (note: comparison is main branch against this, so relative numbers below 1 mean improvement in this PR):
<img width="2698" height="383" alt="image" src="https://github.com/user-attachments/assets/4aea318c-ba17-4491-9eeb-47c1b9385470" />

<img width="2698" height="383" alt="image" src="https://github.com/user-attachments/assets/0255fdf3-7afa-4d7d-b677-3a4630be6b4d" />


**Note:** In many of these benchmarks, the solver is not reaching convergence, so the comparison is not always apples-to-apples. Cases where neither branch reached convergence are highlighted in yellow in the screenshots above:
```
Increase the number of iterations to improve the convergence (max_iter=200).
You might also want to scale the data as shown in:
    https://scikit-learn.org/stable/modules/preprocessing.html
Please also refer to the documentation for alternative solver options:
    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression
  n_iter_i = _check_optimize_result(
/export/users/dcortes/repos/sklex-benchenv/daal4py/sklearn/linear_model/logistic_path.py:266: ConvergenceWarning: lbfgs failed to converge after 200 iteration(s) (status=1):
STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT
````

Hence, even though some cases might look like performance degradations here, they are actually reaching better solutions, so it's not an exact comparison.

**Note2:** the docs CI job is failing due to a rate limiting issue with medium.com.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.

</details>
