### PR TITLE
MAINT: Deselect logistic regression cases that fail from small numeric differences

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -374,7 +374,8 @@ deselected_tests:
   - ensemble/tests/test_voting.py::test_sample_weight >=1.0,<1.1
   - tests/test_multioutput.py::test_multiclass_multioutput_estimator_predict_proba
   - model_selection/tests/test_search.py::test_search_cv_sample_weight_equivalence[estimator0]
-  - tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)) < 1.1
+  - tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])-check_sample_weights_invariance(kind=ones)] <1.1
+  - tests/test_common.py::test_estimators[StackingClassifier(estimators=[('est1',LogisticRegression(C=0.1)),('est2',LogisticRegression(C=1))])-check_sample_weights_invariance(kind=zeros)] <1.1
 
   # Scikit-learn does not constraint multinomial logistic intercepts to sum to zero.
   # Softmax function is invariant to additions by a constant, so even though the numbers


### PR DESCRIPTION
## Description

Deselects a few conformance tests that started failing with deviances in the order of 1e-6 after this PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2752

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
