### PR TITLE
DOC: Corrections about passing different array API classes to methods

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -68,11 +68,16 @@ in many cases they are.
 
 .. warning::
     If array API inputs are passed to an estimator's ``.fit()``, subsequent data passed to methods such as
-    ``.predict()`` or ``.score()`` of the fitted model might be of a different class than the ``X``/``y`` passed to
-    ``.fit()``, but **it must reside on the same device** - meaning: a model that was fitted with GPU arrays cannot
-    make predictions on CPU arrays, and a model fitted with CPU array API inputs cannot make predictions on GPU
-    arrays, even if they are of the same class. Attempting to pass data on the wrong device might lead to
-    process-wide crashes.
+    ``.predict()`` or ``.score()`` of the fitted model **must reside on the same device** - meaning: a model that
+    was fitted with GPU arrays cannot make predictions on CPU arrays, and a model fitted with CPU array API inputs
+    cannot make predictions on GPU arrays, even if they are of the same class. Attempting to pass data on the
+    wrong device might lead to process-wide crashes.
+
+.. note::
+    An estimator fitted to array API inputs should only be passed objects of the same class that was passed to
+    ``.fit()`` in subsequent calls to ``.predict()``, ``.score()``, and similar. In some cases, it might be
+    possible to pass a different class at prediction time without errors (particularly when fitting on CPU only),
+    but this is generally not supported and users should not rely on these interchanges working reliably.
 
 .. note::
     The ``target_offload`` option in config contexts and settings is not intended to work with array API
@@ -145,20 +150,6 @@ GPU operations on GPU arrays
                pred = model.predict(X[:5])
            assert isinstance(pred, torch.Tensor)
 
-           # Fitted models can be passed array API inputs of a different class
-           # than the training data, as long as their data resides in the same
-           # device. This now fits a model using a non-NumPy class whose data is on CPU.
-           X_cpu = torch.tensor(X_np, device="cpu")
-           y_cpu = torch.tensor(y_np, device="cpu")
-           model_cpu = LinearRegression()
-           with config_context(array_api_dispatch=True):
-               model_cpu.fit(X_cpu, y_cpu)
-               pred_torch = model_cpu.predict(X_cpu[:5])
-               pred_np = model_cpu.predict(X_cpu[:5].numpy())
-           assert isinstance(pred_torch, X_cpu.__class__)
-           assert isinstance(pred_np, np.ndarray)
-           assert pred_torch.__class__ != pred_np.__class__
-
     .. tab:: With DPNP arrays
        .. code-block:: python
 
@@ -192,20 +183,6 @@ GPU operations on GPU arrays
            with config_context(array_api_dispatch=True):
                pred = model.predict(X[:5])
            assert isinstance(pred, X.__class__)
-
-           # Fitted models can be passed array API inputs of a different class
-           # than the training data, as long as their data resides in the same
-           # device. This now fits a model using a non-NumPy class whose data is on CPU.
-           X_cpu = dpnp.array(X_np, device="cpu")
-           y_cpu = dpnp.array(y_np, device="cpu")
-           model_cpu = LinearRegression()
-           with config_context(array_api_dispatch=True):
-               model_cpu.fit(X_cpu, y_cpu)
-               pred_dpnp = model_cpu.predict(X_cpu[:5])
-               pred_np = model_cpu.predict(X_cpu[:5].asnumpy())
-           assert isinstance(pred_dpnp, X_cpu.__class__)
-           assert isinstance(pred_np, np.ndarray)
-           assert pred_dpnp.__class__ != pred_np.__class__
 
 
 ``array-api-strict``


### PR DESCRIPTION
## Description

The docs currently state that it should be possible to fit a model on some array API class and then pass inputs of a different array API class on the same device, but it came up during reviews of PRs from @icfaust that this is not actually supposed to work. This PR corrects the docs to reflect this.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
