### PR TITLE
MAINT: Pass namespace argument to fit_calibrator in sklearn1.8

### DIFF
--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -41,6 +41,9 @@ if sklearn_check_version("1.6"):
     from sklearn.utils.multiclass import check_classification_targets
     from sklearn.utils.validation import check_is_fitted
 
+    if sklearn_check_version("1.8"):
+        from ..utils._array_api import get_namespace
+
     def _prefit_CalibratedClassifierCV_fit(self, X, y, **fit_params):
         # This is a stop-gap solution where the cv='prefit' of CalibratedClassifierCV
         # was removed and the single fold solution needs to be maintained. Discussion
@@ -66,13 +69,24 @@ if sklearn_check_version("1.6"):
             # Reshape binary output from `(n_samples,)` to `(n_samples, 1)`
             predictions = predictions.reshape(-1, 1)
 
-        calibrated_classifier = _fit_calibrator(
-            estimator,
-            predictions,
-            y,
-            self.classes_,
-            self.method,
-        )
+        if sklearn_check_version("1.8"):
+            xp, _ = get_namespace(X, y)
+            calibrated_classifier = _fit_calibrator(
+                estimator,
+                predictions,
+                y,
+                self.classes_,
+                self.method,
+                xp,
+            )
+        else:
+            calibrated_classifier = _fit_calibrator(
+                estimator,
+                predictions,
+                y,
+                self.classes_,
+                self.method,
+            )
         self.calibrated_classifiers_.append(calibrated_classifier)
 
         first_clf = self.calibrated_classifiers_[0].estimator


### PR DESCRIPTION
## Description

SVM estimators involve calls to an internal method `_fit_calibrator` from sklearn, which starting with version 1.8, will require passing an array namespace as a required argument. This PR makes adjustments as necessary.

Note that this will generate merge conflicts with https://github.com/uxlfoundation/scikit-learn-intelex/pull/2209 - not sure if it'd be easier to merge this PR or to use that other one.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
