### PR TITLE
MAINT: Ensure nightly jobs use newer packages as required

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -107,7 +107,7 @@ jobs:
   timeoutInMinutes: 120
   strategy:
     matrix:
-      Python3.11_SklearnMain:
+      Python3.13_SklearnMain:
         PYTHON_VERSION: '3.13'
         SKLEARN_VERSION: 'main'
   pool:


### PR DESCRIPTION
## Description

With scikit-learn 1.8, some new tests for array API functionalities were added which require newer versions of package `array-api-compat` that are not available for older python versions.

This PR updates the python version used for the nightly jobs that run against the main branch of sklearn.

Note that this doesn't actually solve the test failures, just shifts them to a different error, but the change is nevertheless required.

An attempt to deselect these tests on older python versions is handled in a different PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2803

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
