### PR TITLE
MAINT: Skip conformance tests running with too old array API packages

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -388,10 +388,11 @@ deselected_tests:
   # These fail due to not printing everything that scikit-learn prints on verbose mode
   - cluster/tests/test_k_means.py::test_kmeans_verbose
 
-  # These require version numbers of array API packages that are not available on older Python versions
-  - metrics/tests/test_classification.py::test_probabilistic_metrics_array_api python<3.12
-  - metrics/tests/test_common.py::test_array_api_compliance python<3.12
-  - utils/tests/test_stats.py::test_weighted_percentile_array_api_consistency python<3.12
+  # These require version numbers of array API packages that are not available on older Python versions.
+  # Since it's not possible to select or deselect based on Python version, they are removed entirely.
+  - metrics/tests/test_classification.py::test_probabilistic_metrics_array_api
+  - metrics/tests/test_common.py::test_array_api_compliance
+  - utils/tests/test_stats.py::test_weighted_percentile_array_api_consistency
 
   # --------------------------------------------------------
   # No need to test daal4py patching


### PR DESCRIPTION
## Description

Some tests introduced in sklearn1.8 require versions of array API packages that are not available for older python versions.

Along with bumping the python versions used for the CI jobs that test against the main branch from sklearn, it's also required to skip these problematic tests once sklearn1.8 is released.

This PR tries to deselect the tests based on python versions, but I'm not sure that it will work as intended. Currently, it seems that all of the deselections work only on versions of scikit-learn, and I'm not sure what would be the logic for deselecting based on python versions or versions of other packages instead.

Note that the actual requirement is `array-api-strict>=2.4.1`, which in turn requires `python>=3.12`.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
