### PR TITLE
DOC: Use correct names of IMPI packages for each installation method

### DIFF
--- a/doc/sources/distributed-mode.rst
+++ b/doc/sources/distributed-mode.rst
@@ -26,7 +26,7 @@ Several :doc:`GPU-supported algorithms <oneapi-gpu>`
 also provide distributed, multi-GPU computing capabilities via integration with |mpi4py|. The prerequisites
 match those of GPU computing, along with an MPI backend of your choice (`Intel MPI recommended
 <https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html>`_, available
-via the ``impi_rt`` python/conda package) and the |mpi4py| python package. If using |sklearnex|
+via the ``impi_rt`` / ``impi-rt`` python/conda package) and the |mpi4py| python package. If using |sklearnex|
 `installed from sources <https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/INSTALL.md#build-from-sources>`_,
 ensure that the spmd_backend is built.
 
@@ -49,9 +49,9 @@ ensure that the spmd_backend is built.
         .. tab:: From Intel's pip Index
             ::
 
-                pip install --index-url https://software.repos.intel.com/python/pypi mpi4py impi_rt
+                pip install --index-url https://software.repos.intel.com/python/pypi mpi4py impi-rt
 
-  It also requires the MPI runtime executable (``mpiexec`` / ``mpirun``) to be from the same library that was used to compile |sklearnex| or from a compatible library. Intel's MPI runtime library is offered as a Python package ``impi_rt`` and will be installed together with the ``mpi4py`` package if executing the commands above, but otherwise, it can be installed separately from different distribution channels:
+  It also requires the MPI runtime executable (``mpiexec`` / ``mpirun``) to be from the same library that was used to compile |sklearnex| or from a compatible library. Intel's MPI runtime library is offered as a Python package ``impi_rt`` (conda) / ``impi-rt`` (PyPI) and will be installed together with the ``mpi4py`` package if executing the commands above, but otherwise, it can be installed separately from different distribution channels:
 
     .. tabs::
         .. tab:: From conda-forge
@@ -67,12 +67,12 @@ ensure that the spmd_backend is built.
         .. tab:: From PyPI
             ::
 
-                pip install impi_rt
+                pip install impi-rt
 
         .. tab:: From Intel's pip Index
             ::
 
-                pip install --index-url https://software.repos.intel.com/python/pypi impi_rt
+                pip install --index-url https://software.repos.intel.com/python/pypi impi-rt
 
 
   Using other MPI backends that are not MPICH-compatible (e.g. OpenMPI) requires building |sklearnex| from source with that backend, and using an |mpi4py| built with that same backend.

--- a/doc/sources/distributed_daal4py.rst
+++ b/doc/sources/distributed_daal4py.rst
@@ -45,7 +45,7 @@ same algorithms to much larger problem sizes.
     the MPI runtime library managing the computations to be the same MPI backend library
     with which the |sklearnex| library was compiled, or to be ABI compatible with it.
     Distributions of the |sklearnex| in PyPI and conda-forge are both compiled with `Intel's MPI <https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html>`__
-    as MPI backend (offered as Python package ``impi_rt`` in both PyPI and conda): ::
+    as MPI backend (offered as Python package ``impi_rt`` in conda, or ``impi-rt`` in PyPI): ::
 
         conda install -c conda-forge impi_rt mpi=*=impi
 
@@ -77,7 +77,7 @@ same algorithms to much larger problem sizes.
         .. tab:: From Intel's pip Index
             ::
 
-                pip install --index-url https://software.repos.intel.com/python/pypi mpi4py impi_rt
+                pip install --index-url https://software.repos.intel.com/python/pypi mpi4py impi-rt
 
 
 Using distributed mode


### PR DESCRIPTION
## Description

I just noticed that the IMPI packages have different names in PyPI and conda:
https://pypi.org/project/impi-rt
https://anaconda.org/channels/conda-forge/packages/impi_rt

This PR updates the documentation to use the correct name according to the installation method.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
