### PR TITLE
MAINT: More deselections due to small numeric differences in logistic regression

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -369,6 +369,7 @@ deselected_tests:
   - linear_model/tests/test_logistic.py::test_newton_cholesky_fallback_to_lbfgs
   - linear_model/tests/test_logistic.py::test_logistic_cv_sparse[csr_array]
   - linear_model/tests/test_logistic.py::test_logistic_cv_sparse[csr_matrix]
+  - linear_model/tests/test_logistic.py::test_logistic_cv_multinomial_score
   - tests/test_common.py::test_estimators[LogisticRegressionCV(cv=3,max_iter=5)-check_sample_weight_equivalence_on_dense_data]
   - ensemble/tests/test_bagging.py::test_estimators_samples >=1.0,<1.1
   - ensemble/tests/test_voting.py::test_sample_weight >=1.0,<1.1


### PR DESCRIPTION
## Description

Deselects another test that can fail due to small numeric differences that are expected from the implementation of logistic regression in sklearnex.

Note that this deselected test is not currently causing any failure in any CI job, but the failure can be observed when testing things locally in some setups.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
