### PR TITLE
FIX: Allow KNN with missing values

### DIFF
--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -70,7 +70,10 @@ class KNeighborsDispatchingBase(oneDALEstimator):
                 X,
                 dtype=[np.float64, np.float32],
                 accept_sparse=True,
-                force_all_finite=not self.effective_metric_.startswith("nan"),
+                force_all_finite=not (
+                    isinstance(self.effective_metric_, str)
+                    and self.effective_metric_.startswith("nan")
+                ),
             )
             self.n_samples_fit_ = _num_samples(self._fit_X)
             self.n_features_in_ = _num_features(self._fit_X)


### PR DESCRIPTION
## Description

KNN algorithms on sklearn support data with missing values, but sklearnex makes a check for 'all finite'. This PR makes it fall back to sklearn when receiving data that has missing values.

Disclaimer: I'm not 100% sure about whether oneDAL supports KNN with missing values or not.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
