### PR TITLE
MAINT: Test deselection due to small numeric differences

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -396,6 +396,9 @@ deselected_tests:
   - metrics/tests/test_common.py::test_array_api_compliance
   - utils/tests/test_stats.py::test_weighted_percentile_array_api_consistency
 
+  # Tests for exact equality, but results have differences in the order of machine epsilon
+  - neighbors/tests/test_neighbors.py::test_KNeighborsClassifier_multioutput
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:


### PR DESCRIPTION
## Description

Deselects a new test that fails due to very small numeric differences between sklearn and sklearnex. Note that the test checks for exact equality, but here it ends up comparing results from different libraries, so this is expected.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
