### PR TITLE
MAINT: Avoid deselecting valid KNN conformance tests for nan_euclidean

### DIFF
--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -37,9 +37,6 @@ class KNeighborsDispatchingBase(oneDALEstimator):
     def _fit_validation(self, X, y=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
-            effective_metric = self.effective_metric_
-        else:
-            effective_metric = self.metric
         check_feature_names(self, X, reset=True)
         if self.metric_params is not None and "p" in self.metric_params:
             if self.p is not None:
@@ -74,8 +71,8 @@ class KNeighborsDispatchingBase(oneDALEstimator):
                 dtype=[np.float64, np.float32],
                 accept_sparse=True,
                 force_all_finite=not (
-                    isinstance(effective_metric, str)
-                    and effective_metric.startswith("nan")
+                    isinstance(self.effective_metric_, str)
+                    and self.effective_metric_.startswith("nan")
                 ),
             )
             self.n_samples_fit_ = _num_samples(self._fit_X)


### PR DESCRIPTION
## Description

Some scikit-learn tests for KNN with metric `nan_euclidean` are deselected. These should work correctly by falling back to stock sklearn.

This PR removes the deselections.
<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
