### PR TITLE
py3.14 compatibility

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,7 +13,7 @@ pandas==2.3.3 ; python_version >= '3.11'
 xgboost==2.1.4 ; python_version < '3.10'
 xgboost==3.1.2 ; python_version >= '3.10'
 lightgbm==4.6.0
-catboost==1.2.8 ; python_version < '3.14'
+catboost==1.2.8 ; python_version < '3.14' # TODO: Remove condition when catboost releases py3.14 package
 shap==0.49.1 ; python_version < '3.11'
 shap==0.50.0 ; python_version >= '3.11'
 treelite==4.6.1


### PR DESCRIPTION
## Description

For Private CI. Public will require more extensive changes to this repo later on.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
