### PR TITLE
MAINT: Don't install unneeded MPICH

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -30,7 +30,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) pyyaml
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -19,7 +19,7 @@ steps:
       sudo chown -R $USER $CONDA
       conda config --set always_yes yes --set changeps1 no
       conda update -q conda
-      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich clang-format pyyaml
+      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel pyyaml
     displayName: Create Anaconda environment
   - script: |
       source activate CB


### PR DESCRIPTION
## Description

CI jobs are installing MPICH to run tests with conda, which is not required anymore since now the conda recipe has an explicit dependency on MPI (picking Intel's version) for both building and testing.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
