### PR TITLE
Remove wiki references for doc build

### DIFF
--- a/doc/sources/building-from-source.rst
+++ b/doc/sources/building-from-source.rst
@@ -24,7 +24,7 @@ The |sklearnex| predominantly functions as a frontend to the |onedal| by leverag
 
 .. note:: Python packages ``dal`` (conda) and ``daal`` (PyPI) provide the same components, but due to naming availability in these repositories, they are distributed under different names.
 
-As a library, the |sklearnex| consists of a Python codebase with Python extension modules written in C++ and Cython, with some of those modules being optional. These extension modules require compilation before being used, for which a C++ compiler along with other dependencies is required. In the case of GPU-related modules, a SYCL compiler (such as `Intel's DPC++ <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html>`__) is required, and in the case of distributed mode, whether on CPU or on GPU, an `MPI <https://en.wikipedia.org/wiki/Message_Passing_Interface>`__ backend is required, such as `Intel MPI <https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html>`__.
+As a library, the |sklearnex| consists of a Python codebase with Python extension modules written in C++ and Cython, with some of those modules being optional. These extension modules require compilation before being used, for which a C++ compiler along with other dependencies is required. In the case of GPU-related modules, a SYCL compiler (such as `Intel's DPC++ <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html>`__) is required, and in the case of distributed mode, whether on CPU or on GPU, an MPI backend is required, such as `Intel MPI <https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html>`__.
 
 The extension modules are as follows:
 

--- a/doc/sources/distributed_daal4py.rst
+++ b/doc/sources/distributed_daal4py.rst
@@ -23,8 +23,7 @@ Introduction
 
 Module :ref:`daal4py <about_daal4py>` within the |sklearnex| offers distributed versions of
 some algorithms that can run on compute clusters managed through the
-`MPI <https://en.wikipedia.org/wiki/Message_Passing_Interface>`__ framework, optionally aided
-by |mpi4py|.
+MPI framework, optionally aided by |mpi4py|.
 
 Compared to the :ref:`SMPD mode <distributed>` in the ``sklearnex`` module which runs on multiple
 GPUs, the distributed mode of algorithms in the ``daal4py`` module runs on CPU-based nodes - i.e.

--- a/doc/sources/quick-start.rst
+++ b/doc/sources/quick-start.rst
@@ -34,7 +34,7 @@ Patching
 **********************
 
 Once you install the |sklearnex|, you can replace estimator classes (algorithms) that exist in the ``sklearn`` module from |sklearn| with their optimized versions from the extension.
-This action is called *patching* or `monkey patching <https://en.wikipedia.org/wiki/Monkey_patch>`__. This is not a permanent change so you can always undo the patching if necessary.
+This action is called *patching* or *monkey patching*. This is not a permanent change so you can always undo the patching if necessary.
 
 To patch |sklearn| with the |sklearnex|, the following methods can be used:
 


### PR DESCRIPTION
## Description

Removes references to wikipedia due to rate limiting issues in azure pipelines doc build step. Generally these references are not essential.

<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

