### PR TITLE
scikit-learn 1.6 GPU deselections

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -533,5 +533,9 @@ gpu:
   # Deselection for Scikit-Learn 1.4 GPU conformance
   - model_selection/tests/test_validation.py::test_learning_curve_some_failing_fits_warning >=1.4
 
-  # Deselection for Scikit-Learn 1.5 GPU conformance (kd-tree knn not implemented for GPU)
-  - neighbors/tests/test_neighbors.py::test_neighbors_metrics[float64-42-l2]
+  # Deselections for Scikit-Learn 1.6 GPU conformance (no GPU kd tree, no rfe implementation, GPU ensemble misalignment)
+  - neighbors/tests/test_neighbors.py::test_neighbors_metrics[42-float64-l2]
+  - feature_selection/tests/test_rfe.py::test_rfe_with_sample_weight
+  - tests/test_common.py::test_estimators[RandomForestRegressor(n_estimators=5)-check_regressor_data_not_an_array]
+  - tests/test_common.py::test_estimators[RandomForestClassifier(n_estimators=5)-check_class_weight_classifiers]
+  - tests/test_common.py::test_estimators[ExtraTreesClassifier(n_estimators=5)-check_class_weight_classifiers]


### PR DESCRIPTION
## Description

Deselections for scikit-learn 1.6 GPU conformance failures

<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
