### PR TITLE
FIX: Fix train-test split not preserving pandas indices

### DIFF
--- a/daal4py/sklearn/model_selection/_split.py
+++ b/daal4py/sklearn/model_selection/_split.py
@@ -271,8 +271,8 @@ def train_test_split(*arrays, **options):
                     )
 
             if hasattr(arr, "index"):
-                train_arr.index = train
-                test_arr.index = test
+                train_arr.index = arr.index.take(train)
+                test_arr.index = arr.index.take(test)
 
             if hasattr(arr, "columns"):
                 train_arr.columns = arr.columns


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

ref https://github.com/uxlfoundation/scikit-learn-intelex/issues/2888

This PR fixes an issue with the patched train/test split function does not preserve the indices of pandas objects.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
