### PR TITLE
DOC: Clarify that GPU package is required for array API on CPU

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -33,7 +33,7 @@ on GPU without moving the data from host to device.
     global settings or using a :doc:`config_context <config-contexts>`.
 
 .. hint::
-    Executing computations on GPUs has additional dependencies, particularly on package ``scikit-learn-intelex-gpu`` - see
+    Executing computations on array API inputs (whether on CPUs or GPUs) requires additional dependencies, particularly on package ``scikit-learn-intelex-gpu`` - see
     :doc:`oneapi-gpu` for details.
 
 When passing array API inputs whose data is on a SYCL-enabled device (e.g. an Intel GPU), as


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Turns out that using DPNP arrays on CPU with array API requires the DPC modules, as those objects contain sycl queues and the logic for handling them is in `_onedal_py_dpc`.

This PR updates the documentation to clarify that the GPU package is required for array API also on CPU.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
