### PR TITLE
MAINT: Avoid absolute rpath links to oneDAL when not using a conda environment

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -25,7 +25,7 @@ fi
 
 if [ -z "${DALROOT}" ]; then
     export DALROOT=${PREFIX}
-elif [ "${DALROOT}" != "${CONDA_PREFIX}" ]; then
+elif [ "${DALROOT}" != "${CONDA_PREFIX}" ] && [ ! -z "${CONDA_PREFIX}" ]; then
     # source oneDAL if DALROOT is set outside of conda-build
     source ${DALROOT}/env/vars.sh
     export DALRPATH=--abs-rpath


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

There is a script used internally by the conda recipe to build the package which adds absolute paths to oneDAL's .so files in the sklearnex .so files when oneDAL comes from a non-conda installation.

This script is also used for other purposes besides conda packaging, where there is no conda environment, and thus the oneDAL folders always end up in the rpath in such scenarios.

This PR modified the condition to be both "oneDAL is not in the conda-managed folder" and "the script is running under a conda environment".

It appears nothing broke from this change but better to double-check everything that might be affected.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
