### PR TITLE
MAINT: Skip linear regression test that fails due to tolerances

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -467,6 +467,9 @@ deselected_tests:
   # CI jobs in sklearnex compile scikit-learn from source, not necessarily with the same toolkits as sklearn's CIs
   - preprocessing/tests/test_polynomial.py::test_sizeof_LARGEST_INT_t
 
+  # Fails due to numeric tolerances on some AMD systems
+  - linear_model/tests/test_base.py::test_linear_regression_vs_lstsq[float32]
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Skips a test from scikit-learn that has been producing failures in multiple jobs when the runner is an AMD machine without avx512.

Example:
```
================================== FAILURES ===================================
__________________ test_linear_regression_vs_lstsq[float32] ___________________

dtype = <class 'numpy.float32'>

    @pytest.mark.parametrize("dtype", [np.float64, np.float32])
    def test_linear_regression_vs_lstsq(dtype):
        """
        Check that LinearRegression is as good as `scipy.linalg.lstsq`.
        Non regression test for issue #33032.
        """
        rng = np.random.RandomState(1137)
        n_samples = 500_000
    
        x1 = rng.rand(n_samples)
        x2 = 0.3 * x1 + 0.1 * rng.rand(n_samples)
        X = np.column_stack([x1, x2])
        y = X @ [0.5, 2.0] + 0.1 * rng.rand(n_samples)
    
        X = X.astype(dtype)
        y = y.astype(dtype)
    
        coef_scipy = linalg.lstsq(X, y)[0]
        coef_sklearn = LinearRegression(fit_intercept=False).fit(X, y).coef_
    
        rmse_scipy = np.linalg.norm(y - X @ coef_scipy)
        rmse_sklearn = np.linalg.norm(y - X @ coef_sklearn)
>       assert rmse_sklearn == pytest.approx(rmse_scipy, rel=1e-6)
E       assert np.float32(24.387865) == 24.38691520690918 � 2.4e-05
E         
E         comparison failed
E         Obtained: 24.38786506652832
E         Expected: 24.38691520690918 � 2.4e-05
```

Link: https://dev.azure.com/daal/daal4py/_build/results?buildId=58488&view=logs&j=950f1d62-c3cc-5d51-08d2-e6dd47db1841&t=aaee886b-1c31-541e-c596-9c472f025343&l=31285

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
