### PR TITLE
DOC: Update array API docs after changes in logic and design

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -43,8 +43,7 @@ requested operation (e.g. call to ``.fit()`` / ``.predict()``
 on the estimator class being used) is :ref:`supported on device/GPU <sklearn_algorithms_gpu>`, computations
 will be performed on the device where the data lives, without involving any data transfers.
 
-Note that all of the inputs (e.g. ``X`` and ``y`` passed to ``.fit()`` methods) must be allocated on the same device for this to
-work. If the requested operation is not supported on the device where the data lives, then it will either fall
+If the requested operation is not supported on the device where the data lives, then it will either fall
 back to |sklearn|, or to an accelerated CPU version from the |sklearnex| when supported - these are controllable
 through options ``allow_sklearn_after_onedal`` (default is ``True``) and ``allow_fallback_to_host`` (default is
 ``False``), respectively, which are accepted by ``config_context`` and ``set_config`` after
@@ -66,11 +65,6 @@ be transferred to host if it isn't already, and the computations will happen on 
 .. hint::
     Enable :ref:`verbose` to see information about whether data transfers happen during an operation or not,
     whether an accelerated version from the extension is used, and where (CPU/device) the operation is executed.
-
-When passing array API inputs to methods such as ``.predict()`` of estimators with array API support, the output
-will always be of the same class as the inputs, but be aware that array attributes of fitted models (e.g. ``coef_``
-in a linear model) will not necessarily be of the same class as array API inputs passed to ``.fit()``, even though
-in many cases they are.
 
 .. warning::
     If array API inputs are passed to an estimator's ``.fit()``, subsequent data passed to methods such as
@@ -128,11 +122,6 @@ The following patched classes have support for array API inputs:
     next subsection.
 
 .. note::
-    While full array API support is currently not implemented for all classes, |dpnp_array| inputs are supported
-    by all the classes that have :ref:`GPU support <oneapi_gpu>`. Note however that if array API support is not
-    enabled in |sklearn|, when passing these classes as inputs, data will be transferred to host and then back to
-    device instead of being used directly.
-
     Result attributes of |sklearnex| classes which contain |sklearn| or |sklearnex| classes may not themselves be
     array API compliant. For example, ensemble algorithms contain decision tree estimators result objects which
     do not comply with the array API standard.


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

There have been several changes in how array API support works in scikit-learn and fixes in sklearnex that now make some statements in the documentation obsolete.

For example, by now all public-facing attributes of array API estimators should be of array API classes, which was not the case before, and implementation of 'everything follows X' logic is in progress, so now more potential input combinations are allowed.

The documentation will need further updates after implementing `move_to`.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
