### PR TITLE
FIX, MAINT: Implement 'everything follows X' and namespace checks for KNN

### DIFF
--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -32,9 +32,6 @@ from sklearnex.neighbors.knn_unsupervised import NearestNeighbors
 
 from ..utils._array_api import enable_array_api, get_namespace
 
-if sklearn_check_version("1.9"):
-    from sklearn.utils._array_api import check_same_namespace
-
 
 @enable_array_api
 @control_n_jobs(decorated_methods=["fit", "kneighbors", "_kneighbors"])

--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -31,7 +31,9 @@ from sklearnex.neighbors.common import KNeighborsDispatchingBase
 from sklearnex.neighbors.knn_unsupervised import NearestNeighbors
 
 from ..utils._array_api import enable_array_api, get_namespace
-from ..utils.validation import validate_data
+
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import check_same_namespace
 
 
 @enable_array_api
@@ -141,6 +143,10 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, _sklearn_LocalOutlierFactor)
             self._fit_X = xp.asarray(self._fit_X, device=device)
         return self
 
+    # Note: this is overriding an internal method from scikit-learn with
+    # the same signature. In this case, 'validate_data' is called during
+    # 'decision_function', which calls '.kneighbors()'. Hence, it doesn't
+    # need to validate the namespace of 'X' with '_fit_X' here.
     def _predict(self, X=None):
         check_is_fitted(self)
 

--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -29,6 +29,7 @@ from daal4py.sklearn._utils import is_sparse, sklearn_check_version
 
 if sklearn_check_version("1.9"):
     from sklearn.utils._sparse import _align_api_if_sparse
+    from sklearn.utils._array_api import get_namespace_and_device, move_to
 
 from onedal._device_offload import _transfer_to_host
 from onedal.utils._array_api import _is_numpy_namespace
@@ -37,7 +38,6 @@ from onedal.utils.validation import _check_array, _num_features, _num_samples
 from .._utils import PatchingConditionsChain
 from ..base import oneDALEstimator
 from ..utils._array_api import get_namespace
-from ..utils.validation import validate_data
 
 
 class KNeighborsDispatchingBase(oneDALEstimator):
@@ -51,11 +51,20 @@ class KNeighborsDispatchingBase(oneDALEstimator):
             # if user attempts to classify a point that was zero distance from one
             # or more training points, those training points are weighted as 1.0
             # and the other points as 0.0
-            with xp.errstate(divide="ignore"):
-                dist = 1.0 / dist
+            if _is_numpy_namespace(xp):
+                with xp.errstate(divide="ignore"):
+                    dist = 1.0 / dist
+            else:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    dist = 1.0 / dist
             inf_mask = xp.isinf(dist)
             inf_row = xp.any(inf_mask, axis=1)
-            dist[inf_row] = inf_mask[inf_row]
+            if _is_numpy_namespace(xp):
+                # Note: older numpy do not have 'np.astype'
+                dist[inf_row] = inf_mask[inf_row]
+            else:
+                dist[inf_row] = xp.astype(inf_mask[inf_row], dist.dtype)
             return dist
         elif callable(weights):
             return weights(dist)
@@ -84,11 +93,19 @@ class KNeighborsDispatchingBase(oneDALEstimator):
         array-like
             Predicted values.
         """
-        xp, _ = get_namespace(y_train)
-        if not _is_numpy_namespace(xp):
+        # Note: in theory, the logic should be that 'y_train' should be converted
+        # to the namespace of 'neigh_dist', but by this point, 'y_train' should
+        # already have been moved to X's namespace, so it's fine to move 'neigh_dist'.
+        if sklearn_check_version("1.9"):
+            xp, _, device = get_namespace_and_device(y_train)
+            neigh_dist = move_to(neigh_dist, xp=xp, device=device)
+            neigh_ind = move_to(neigh_ind, xp=xp, device=device)
+        else:
+            xp, _ = get_namespace(y_train)
             device = getattr(y_train, "device", None)
-            neigh_dist = xp.asarray(neigh_dist, device=device)
-            neigh_ind = xp.asarray(neigh_ind, device=device)
+            if not _is_numpy_namespace(xp):
+                neigh_dist = xp.asarray(neigh_dist, device=device)
+                neigh_ind = xp.asarray(neigh_ind, device=device)
 
         weights = self._get_weights(neigh_dist, weights_param)
 
@@ -113,9 +130,7 @@ class KNeighborsDispatchingBase(oneDALEstimator):
             y_pred_shape = (neigh_ind.shape[0], _y.shape[1])
             if not _is_numpy_namespace(xp):
                 # Array API: pass device to ensure same device as input
-                y_pred = xp.empty(
-                    y_pred_shape, dtype=neigh_dist.dtype, device=neigh_ind.device
-                )
+                y_pred = xp.empty(y_pred_shape, dtype=neigh_dist.dtype, device=device)
             else:
                 # Numpy: no device parameter
                 y_pred = xp.empty(y_pred_shape, dtype=neigh_dist.dtype)
@@ -164,11 +179,16 @@ class KNeighborsDispatchingBase(oneDALEstimator):
         array-like
             Class probabilities.
         """
-        xp, _ = get_namespace(y_train)
-        if not _is_numpy_namespace(xp):
+        if sklearn_check_version("1.9"):
+            xp, _, device = get_namespace_and_device(y_train)
+            neigh_dist = move_to(neigh_dist, xp=xp, device=device)
+            neigh_ind = move_to(neigh_ind, xp=xp, device=device)
+        else:
+            xp, _ = get_namespace(y_train)
             device = getattr(y_train, "device", None)
-            neigh_dist = xp.asarray(neigh_dist, device=device)
-            neigh_ind = xp.asarray(neigh_ind, device=device)
+            if not _is_numpy_namespace(xp):
+                neigh_dist = xp.asarray(neigh_dist, device=device)
+                neigh_ind = xp.asarray(neigh_ind, device=device)
 
         _y = y_train
         classes_ = classes
@@ -207,9 +227,9 @@ class KNeighborsDispatchingBase(oneDALEstimator):
                 proba_k = xp.zeros(
                     (n_classes, n_queries),
                     dtype=neigh_dist.dtype,
-                    device=neigh_dist.device,
+                    device=device,
                 )
-                zero = xp.zeros(1, dtype=neigh_dist.dtype, device=neigh_dist.device)
+                zero = xp.zeros(1, dtype=neigh_dist.dtype, device=device)
                 for c in range(n_classes):
                     mask = pred_labels == c
                     proba_k[c, :] = xp.sum(xp.where(mask, weights_k, zero), axis=1)
@@ -654,6 +674,8 @@ class KNeighborsDispatchingBase(oneDALEstimator):
     def _onedal_cpu_supported(self, method_name, *data):
         return self._onedal_supported("cpu", method_name, *data)
 
+    # Note: since this transfers the data to host, it doesn't validate
+    # that the array namespaces and devices of 'X' and '_fit_X' match.
     def kneighbors_graph(self, X=None, n_neighbors=None, mode="connectivity"):
         check_is_fitted(self)
         if n_neighbors is None:

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -33,6 +33,13 @@ from ..utils._array_api import enable_array_api, get_namespace
 from ..utils.validation import validate_data
 from .common import KNeighborsDispatchingBase
 
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import (
+        check_same_namespace,
+        get_namespace_and_device,
+        move_to,
+    )
+
 
 @enable_array_api
 @control_n_jobs(
@@ -72,7 +79,12 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
         )
 
     def fit(self, X, y):
-        xp, is_array_api = get_namespace(X)
+        if sklearn_check_version("1.9"):
+            xp, is_array_api, device = get_namespace_and_device(X)
+        else:
+            xp, is_array_api = get_namespace(X)
+            device = getattr(X, "device", None)
+
         dispatch(
             self,
             "fit",
@@ -86,7 +98,6 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
         # Ensure _fit_X matches the input namespace so that
         # kneighbors(X=None) can use get_namespace(self._fit_X).
         if is_array_api and not _is_numpy_namespace(xp):
-            device = getattr(X, "device", None)
             self._fit_X = xp.asarray(self._fit_X, device=device)
         return self
 
@@ -169,7 +180,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
         )
 
         # Process classification targets before passing to onedal
-        self._process_classification_targets(y, skip_validation=False)
+        self._process_classification_targets(X, y, skip_validation=False)
 
         # Call onedal backend
         onedal_params = {
@@ -200,7 +211,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
         # Post-processing
         self._save_attributes()
 
-    def _process_classification_targets(self, y, skip_validation=False):
+    def _process_classification_targets(self, X, y, skip_validation=False):
         """Process classification targets and set class-related attributes.
 
         Parameters
@@ -246,6 +257,10 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             self.classes_ = self.classes_[0]
             self._y = xp.reshape(self._y, (-1,))
 
+        if sklearn_check_version("1.9"):
+            xp_X, _, device = get_namespace_and_device(X)
+            self._y = move_to(self._y, xp=xp_X, device=device)
+
     def _onedal_predict(self, X, queue=None):
         if X is not None:
             xp, _ = get_namespace(X)
@@ -256,14 +271,20 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
                 accept_sparse="csr",
                 reset=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="predict")
 
         params = self._onedal_estimator._get_onedal_params(X)
         params["result_option"] = "responses"
         result = self._onedal_estimator._onedal_predict(
             self._onedal_estimator._onedal_model, X, params
         )
-        xp, _ = get_namespace(X)
         responses = from_table(result.responses, like=X)
+        if sklearn_check_version("1.9"):
+            xp, _, device = get_namespace_and_device(self.classes_)
+            responses = move_to(responses, xp=xp, device=device)
+        else:
+            xp, _ = get_namespace(X)
         return xp.take(
             self.classes_, xp.asarray(xp.reshape(responses, (-1,)), dtype=xp.int64)
         )
@@ -278,6 +299,8 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
                 accept_sparse="csr",
                 reset=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="predict_proba")
 
         neigh_dist, neigh_ind = self._onedal_estimator.kneighbors(X)
 
@@ -299,6 +322,8 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
                 accept_sparse="csr",
                 reset=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="kneighbors")
         else:
             query_is_train = True
             X = self._fit_X

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -31,6 +31,13 @@ from ..utils._array_api import enable_array_api, get_namespace
 from ..utils.validation import validate_data
 from .common import KNeighborsDispatchingBase
 
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import (
+        check_same_namespace,
+        get_namespace_and_device,
+        move_to,
+    )
+
 
 @enable_array_api("1.5")  # validate_data y_numeric requires sklearn >=1.5
 @control_n_jobs(decorated_methods=["fit", "predict", "kneighbors", "score"])
@@ -68,7 +75,11 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
         )
 
     def fit(self, X, y):
-        xp, is_array_api = get_namespace(X)
+        if sklearn_check_version("1.9"):
+            xp, is_array_api, device = get_namespace_and_device(X)
+        else:
+            xp, is_array_api = get_namespace(X)
+            device = getattr(X, "device", None)
         dispatch(
             self,
             "fit",
@@ -82,7 +93,6 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
         # Ensure _fit_X matches the input namespace so that
         # kneighbors(X=None) can use get_namespace(self._fit_X).
         if is_array_api and not _is_numpy_namespace(xp):
-            device = getattr(X, "device", None)
             self._fit_X = xp.asarray(self._fit_X, device=device)
         return self
 
@@ -138,7 +148,10 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
         )
 
     def _onedal_fit(self, X, y, queue=None):
-        xp, _ = get_namespace(X, y)
+        if sklearn_check_version("1.9"):
+            xp, _, device = get_namespace_and_device(X)
+        else:
+            xp, _ = get_namespace(X, y)
         self._set_effective_metric()
 
         X, y = validate_data(
@@ -150,6 +163,9 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
             multi_output=True,
             y_numeric=True,
         )
+
+        if sklearn_check_version("1.9"):
+            y = move_to(y, xp=xp, device=device)
 
         self._process_regression_targets(y)
         onedal_params = {
@@ -215,6 +231,13 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
                 accept_sparse="csr",
                 reset=False,
             )
+            # Note: if called before 'validate_data', this check would fail if 'X' is
+            # a 'DataFrame', since '_fit_X' would have already been converted to NumPy.
+            # Hence, it must come after the call to 'validate_data'. If the behavior
+            # of this validator changes in scikit-learn, these checks could be done
+            # earlier in the code for quicker errors.
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="predict")
         result = self._onedal_estimator._predict_gpu(X)
         return result
 
@@ -246,6 +269,8 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
             X = validate_data(
                 self, X, dtype=[xp.float64, xp.float32], accept_sparse="csr", reset=False
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="predict")
         return self._predict_skl_regression(X)
 
     def _onedal_kneighbors(
@@ -262,6 +287,8 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
                 accept_sparse="csr",
                 reset=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="kenighbors")
         else:
             query_is_train = True
             X = self._fit_X

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -29,6 +29,9 @@ from ..utils._array_api import enable_array_api, get_namespace
 from ..utils.validation import validate_data
 from .common import KNeighborsDispatchingBase
 
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import check_same_namespace, get_namespace_and_device
+
 
 @enable_array_api
 @control_n_jobs(decorated_methods=["fit", "kneighbors", "radius_neighbors"])
@@ -66,7 +69,12 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
         )
 
     def fit(self, X, y=None):
-        xp, is_array_api = get_namespace(X)
+        if sklearn_check_version("1.9"):
+            xp, is_array_api, device = get_namespace_and_device(X)
+        else:
+            xp, is_array_api = get_namespace(X)
+            device = getattr(X, "device", None)
+
         dispatch(
             self,
             "fit",
@@ -80,7 +88,6 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
         # Ensure _fit_X matches the input namespace so that
         # kneighbors(X=None) can use get_namespace(self._fit_X).
         if is_array_api and not _is_numpy_namespace(xp):
-            device = getattr(X, "device", None)
             self._fit_X = xp.asarray(self._fit_X, device=device)
         return self
 
@@ -189,6 +196,8 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
                 reset=False,
                 force_all_finite=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="predict")
         return self._onedal_estimator.predict(X, queue=queue)
 
     def _onedal_kneighbors(
@@ -205,6 +214,8 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
                 accept_sparse="csr",
                 reset=False,
             )
+            if sklearn_check_version("1.9"):
+                check_same_namespace(X, self, attribute="_fit_X", method="kneighbors")
         else:
             query_is_train = True
             X = self._fit_X

--- a/sklearnex/neighbors/tests/test_neighbors.py
+++ b/sklearnex/neighbors/tests/test_neighbors.py
@@ -14,15 +14,20 @@
 # limitations under the License.
 # ===============================================================================
 
+import array_api_strict
 import numpy as np
+import pandas as pd
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from sklearn import datasets
 
+from daal4py.sklearn._utils import sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
     _as_numpy,
     _convert_to_dataframe,
+    dpnp_available,
     get_dataframes_and_queues,
+    torch_available,
 )
 from sklearnex.neighbors import (
     KNeighborsClassifier,
@@ -30,6 +35,11 @@ from sklearnex.neighbors import (
     LocalOutlierFactor,
     NearestNeighbors,
 )
+
+if dpnp_available:
+    import dpnp
+if torch_available:
+    import torch
 
 
 @pytest.mark.parametrize("dataframe,queue", get_dataframes_and_queues())
@@ -173,3 +183,84 @@ def test_p_present_if_metric_is_minkowski():
     assert knn.effective_metric_ == "minkowski"
     assert "p" in knn.effective_metric_params_
     assert knn.effective_metric_params_["p"] == 3
+
+
+# Note: this doesn't check 'kneighbors_graph', because that function
+# transfers the data to NumPy internally, so it will not necessarily
+# end up erroring out.
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"), reason="Functionality introduced in alter versions."
+)
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
+def test_error_on_incompatible_namespaces(weights, with_array_api):
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(25, 3))
+    y = rng.standard_normal(size=X.shape[0])
+    Xa = array_api_strict.from_dlpack(X)
+    ya = array_api_strict.from_dlpack(y)
+
+    knn = KNeighborsRegressor(weights=weights).fit(X, y)
+
+    with pytest.raises(ValueError, match="same namespace"):
+        knn.predict(Xa)
+    with pytest.raises(ValueError, match="same namespace"):
+        knn.kneighbors(Xa)
+
+    knn = KNeighborsRegressor().fit(Xa, ya)
+    with pytest.raises(ValueError, match="same namespace"):
+        knn.predict(X)
+    with pytest.raises(ValueError, match="same namespace"):
+        knn.kneighbors(X)
+
+
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"),
+    reason="Functionality introduced in later scikit-learn versions.",
+)
+@pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])
+@pytest.mark.parametrize("y_xp", [np, pd, array_api_strict])
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
+@pytest.mark.parametrize("n_classes", [0, 2, 3])  # 0 == regression
+def test_mixed_array_namespaces(X_xp, y_xp, weights, n_classes, with_array_api):
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(50, 4))
+    if n_classes == 0:  # regressor
+        y = rng.standard_normal(size=X.shape[0])
+    else:
+        y = rng.integers(n_classes, size=X.shape[0])
+
+    if X_xp is pd:
+        X = pd.DataFrame(X)
+    else:
+        X = X_xp.asarray(X)
+    if y_xp is pd:
+        if n_classes != 0:
+            y = np.array(["a", "b", "c"])[y]
+        y = pd.Series(y)
+    else:
+        y = y_xp.asarray(y)
+
+    model = (KNeighborsClassifier if n_classes != 0 else KNeighborsRegressor)(
+        weights=weights
+    )
+    model.fit(X, y)
+    pred = model.predict(X)
+    _ = model.score(X, y)
+
+    _ = model.kneighbors(X)
+    _ = model.kneighbors_graph(X)
+
+    if n_classes != 0:
+        _ = model.predict_proba(X)
+
+    if n_classes == 0:
+        assert pred.__class__ == (X.__class__ if X_xp is not pd else np.ndarray)
+
+    # Note: this is a quick check to ensure that the result has the same
+    # kind of values as the input. There's no particular justification
+    # behind requiring 25% classification accuracy.
+    if n_classes != 0:
+        if y_xp is pd:
+            y_xp = np
+        pred_is_correct = y_xp.astype(y_xp.asarray(pred == y), y_xp.float32)
+        assert y_xp.sum(pred_is_correct) >= (0.25 * int(X.shape[0]))

--- a/sklearnex/neighbors/tests/test_neighbors.py
+++ b/sklearnex/neighbors/tests/test_neighbors.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from sklearn import datasets
+from sklearn.base import is_regressor
 
 from daal4py.sklearn._utils import sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
@@ -28,7 +29,9 @@ from onedal.tests.utils._dataframes_support import (
     dpnp_available,
     get_dataframes_and_queues,
     torch_available,
+    torch_xpu_available,
 )
+from onedal.tests.utils._device_selection import is_sycl_device_available
 from sklearnex.neighbors import (
     KNeighborsClassifier,
     KNeighborsRegressor,
@@ -251,10 +254,16 @@ def test_mixed_array_namespaces(X_xp, y_xp, weights, n_classes, with_array_api):
     _ = model.kneighbors_graph(X)
 
     if n_classes != 0:
-        _ = model.predict_proba(X)
+        proba = model.predict_proba(X)
+        if X_xp == pd:
+            assert isinstance(proba, np.ndarray)
+        else:
+            assert proba.__class__ == X.__class__
 
     if n_classes == 0:
         assert pred.__class__ == (X.__class__ if X_xp is not pd else np.ndarray)
+    else:
+        assert pred.__class__ == (y.__class__ if y_xp is not pd else np.ndarray)
 
     # Note: this is a quick check to ensure that the result has the same
     # kind of values as the input. There's no particular justification
@@ -264,3 +273,59 @@ def test_mixed_array_namespaces(X_xp, y_xp, weights, n_classes, with_array_api):
             y_xp = np
         pred_is_correct = y_xp.astype(y_xp.asarray(pred == y), y_xp.float32)
         assert y_xp.sum(pred_is_correct) >= (0.25 * int(X.shape[0]))
+
+
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"),
+    reason="Functionality introduced in later scikit-learn versions.",
+)
+@pytest.mark.skipif(
+    not is_sycl_device_available("gpu"), reason="Test checks GPU-specific functionality."
+)
+@pytest.mark.parametrize(
+    "X_xp, X_device",
+    ([(torch, "xpu"), (torch, "cpu")] if torch_xpu_available else [])
+    + ([(dpnp, "gpu"), (dpnp, "cpu")] if dpnp_available else []),
+)
+@pytest.mark.parametrize(
+    "y_xp, y_device",
+    ([(torch, "xpu"), (torch, "cpu")] if torch_xpu_available else [])
+    + ([(dpnp, "gpu"), (dpnp, "cpu")] if dpnp_available else [])
+    + [(pd, None)],
+)
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        KNeighborsRegressor(algorithm="brute"),
+        KNeighborsClassifier(algorithm="brute"),
+    ],
+)
+def test_knn_mixed_devices(X_xp, y_xp, X_device, y_device, estimator, with_array_api):
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(50, 4))
+    if is_regressor(estimator):
+        y = rng.standard_normal(size=X.shape[0])
+    else:
+        y = rng.integers(2, size=X.shape[0])
+
+    X = X_xp.asarray(X, device=X_device)
+    if y_xp is pd:
+        if is_regressor(estimator):
+            y = pd.Series(y)
+        else:
+            y = pd.Series(np.array(["a", "b"])[y])
+    else:
+        y = y_xp.asarray(y, device=y_device)
+
+    estimator.fit(X, y)
+    pred = estimator.predict(X)
+    if is_regressor(estimator):
+        assert pred.__class__ == X.__class__
+    else:
+        if y_xp is pd:
+            assert isinstance(pred, np.ndarray)
+        else:
+            assert pred.__class__ == y.__class__
+        proba = estimator.predict_proba(X)
+        assert proba.__class__ == X.__class__
+    _ = estimator.score(X, y)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

This PR:
* Implements the logic of 'everything follows X' for KNN classes.
* Implements the logic where class predictions from classifiers follow the 'y' namespace (e.g. so that it can return strings when fitting on GPU).
* Adds array API namespace and device checks for KNN methods that come after `.fit()` in order to throw informative Python exceptions instead of segfaults, the same way scikit-learn would do.
* Fixes some issues with internal functions that were not working with array_api_strict.

Includes the changes from https://github.com/uxlfoundation/scikit-learn-intelex/pull/3117 since they are also necessary for KNN classes.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
