### PR TITLE
TEST: Don't test CPU sycl queues when DPC module is not available

### DIFF
--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -648,6 +648,7 @@ def test_table_convert_to_host_dlpack(dataframe, queue, order, data_shape, dtype
     assert X_out.flags.writeable
 
 
+@pytest.mark.skipif(_dpc_backend is None, reason="Functionality requires DPC module")
 @pytest.mark.parametrize("queue", get_queues())
 def test_table_writable_dlpack(queue):
     """Test if __dlpack__ attribute can be properly consumed by moving data

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable
 
 import pytest
 
+from onedal import _dpc_backend
 from onedal.utils._third_party import SyclQueue, dpctl_available
 
 if dpctl_available:
@@ -54,6 +55,8 @@ def get_queues(filter_: str = "cpu,gpu") -> list[SyclQueue]:
         or `pytest.xfail` instead.
     """
     queues = [None] if "cpu" in filter_ else []
+    if _dpc_backend is None:
+        return queues
 
     for i in filter_.split(","):
         try:

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 
 import functools
+import warnings
 from collections.abc import Iterable
 
 import pytest
@@ -56,6 +57,10 @@ def get_queues(filter_: str = "cpu,gpu") -> list[SyclQueue]:
     """
     queues = [None] if "cpu" in filter_ else []
     if _dpc_backend is None:
+        if "gpu" in filter_:
+            warnings.warn(
+                "Attempting to get a GPU queue, but DPC backend is not available."
+            )
         return queues
 
     for i in filter_.split(","):

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -145,7 +145,7 @@ def test_host_backend_target_offload(target):
             with sklearnex.config_context(target_offload=target):
                 est.fit(np.eye(5, 8))
     elif target != "auto":
-        with pytest.raises((ValueError, RuntimeError), match=err_msg):
+        with pytest.raises(Exception, match=err_msg):
             with sklearnex.config_context(target_offload=target):
                 est.fit(np.eye(5, 8))
     else:

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -137,11 +137,15 @@ def test_config_context_works():
 def test_host_backend_target_offload(target):
     from sklearnex.neighbors import NearestNeighbors
 
-    err_msg = r"DPC"
+    err_msg = r"DPC|SYCL"
 
     est = NearestNeighbors()
-    if target != "auto":
-        with pytest.raises(ValueError, match=err_msg):
+    if not isinstance(target, str):
+        with pytest.raises((ValueError, RuntimeError, TypeError)):
+            with sklearnex.config_context(target_offload=target):
+                est.fit(np.eye(5, 8))
+    elif target != "auto":
+        with pytest.raises((ValueError, RuntimeError), match=err_msg):
             with sklearnex.config_context(target_offload=target):
                 est.fit(np.eye(5, 8))
     else:

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -137,9 +137,7 @@ def test_config_context_works():
 def test_host_backend_target_offload(target):
     from sklearnex.neighbors import NearestNeighbors
 
-    err_msg = (
-        r"device use via \`target_offload\` is only supported with the DPC\+\+ backend"
-    )
+    err_msg = r"only supported with the DPC\+\+ backend"
 
     est = NearestNeighbors()
     if target != "auto":

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -131,7 +131,7 @@ def test_config_context_works():
 
 
 @pytest.mark.skipif(
-    onedal._default_backend.is_dpc, reason="requires host default backend"
+    not onedal._default_backend.is_dpc, reason="requires host default backend"
 )
 @pytest.mark.parametrize("target", ["auto", "cpu", "cpu:0", "gpu", 3])
 def test_host_backend_target_offload(target):

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -140,7 +140,11 @@ def test_host_backend_target_offload(target):
     err_msg = r"DPC"
 
     est = NearestNeighbors()
-    with pytest.raises(ValueError, match=err_msg):
+    if target != "auto":
+        with pytest.raises(ValueError, match=err_msg):
+            with sklearnex.config_context(target_offload=target):
+                est.fit(np.eye(5, 8))
+    else:
         with sklearnex.config_context(target_offload=target):
             est.fit(np.eye(5, 8))
 

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -131,7 +131,7 @@ def test_config_context_works():
 
 
 @pytest.mark.skipif(
-    not onedal._default_backend.is_dpc, reason="requires host default backend"
+    onedal._default_backend.is_dpc, reason="requires host default backend"
 )
 @pytest.mark.parametrize("target", ["auto", "cpu", "cpu:0", "gpu", 3])
 def test_host_backend_target_offload(target):

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -137,7 +137,7 @@ def test_config_context_works():
 def test_host_backend_target_offload(target):
     from sklearnex.neighbors import NearestNeighbors
 
-    err_msg = r"only supported with the DPC\+\+ backend"
+    err_msg = r"DPC"
 
     est = NearestNeighbors()
     if target != "auto":

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -140,11 +140,7 @@ def test_host_backend_target_offload(target):
     err_msg = r"DPC"
 
     est = NearestNeighbors()
-    if target != "auto":
-        with pytest.raises(ValueError, match=err_msg):
-            with sklearnex.config_context(target_offload=target):
-                est.fit(np.eye(5, 8))
-    else:
+    with pytest.raises(ValueError, match=err_msg):
         with sklearnex.config_context(target_offload=target):
             est.fit(np.eye(5, 8))
 

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -137,7 +137,14 @@ def test_config_context_works():
 def test_host_backend_target_offload(target):
     from sklearnex.neighbors import NearestNeighbors
 
-    err_msg = r"DPC|SYCL"
+    err_msg = "|".join(
+        [
+            r"SYCL Device '.+' could not be created",
+            r"Positional argument .+ is not a filter string or a SyclDevice",
+            r"oneDAL GPU/DPC\+\+ support is not available in the current installation",
+            r"device use via `target_offload` is only supported with the DPC\+\+ backend",
+        ]
+    )
 
     est = NearestNeighbors()
     if not isinstance(target, str):


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Some nightly jobs recently started failing with a message like this:
```
E       RuntimeError: oneDAL GPU/DPC++ support is not available in the current installation.
E         Reason: No module named 'onedal._onedal_py_dpc'
E         To enable SYCL/GPU acceleration, install the GPU extras:
E           pip install scikit-learn-intelex-gpu
E         or via conda:
E           conda install scikit-learn-intelex-gpu -c https://software.repos.intel.com/python/conda

onedal/__init__.py:180: RuntimeError
```

This comes from `_ensure_dpc_available`, which gets called during tests in BasicStatistics when they are passed a CPU queue.

The error makes sense, since the logic for handling queues is in the DPC module, but I don't know why it only started popping up recently.

Example of the error in CI: https://github.com/uxlfoundation/scikit-learn-intelex/actions/runs/24894507572/job/72895505497?pr=3127#step:13:102411

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
