### PR TITLE
TEST: Loosen tolerances for float32 linear regression

### DIFF
--- a/onedal/linear_model/tests/test_incremental_linear_regression.py
+++ b/onedal/linear_model/tests/test_incremental_linear_regression.py
@@ -70,11 +70,11 @@ def test_full_results(queue, num_blocks, dtype):
         tol = 5e-3 if model.coef_.dtype == np.float32 else 1e-5
     else:
         tol = 3e-3 if model.coef_.dtype == np.float32 else 1e-5
-    atol = 1e-4 if model.coef_.dtype == np.float32 else 1e-6
+    atol = 5e-4 if model.coef_.dtype == np.float32 else 1e-6
     assert_allclose(coef, model.coef_.T, rtol=tol, atol=atol)
 
     tol = 3e-3 if model.intercept_.dtype == np.float32 else 1e-5
-    assert_allclose(intercept, model.intercept_, rtol=tol)
+    assert_allclose(intercept, model.intercept_, rtol=tol, atol=atol)
 
     Xt = gen.random(size=(num_samples_test, num_features), dtype=dtype)
     gtr = Xt @ coef + intercept[np.newaxis, :]
@@ -82,7 +82,7 @@ def test_full_results(queue, num_blocks, dtype):
     res = model.predict(Xt, queue=queue)
 
     tol = 2e-4 if res.dtype == np.float32 else 1e-7
-    assert_allclose(gtr, res, rtol=tol)
+    assert_allclose(gtr, res, rtol=tol, atol=atol)
 
 
 @pytest.mark.parametrize("queue", get_queues())

--- a/onedal/linear_model/tests/test_linear_regression.py
+++ b/onedal/linear_model/tests/test_linear_regression.py
@@ -175,7 +175,7 @@ def test_overdetermined_system(queue, dtype, fit_intercept):
         b = Xi.T @ y
         x = np.r_[np.squeeze(model.coef_), model.intercept_]
     residual = A @ x - b
-    assert np.all(np.abs(residual) < (1e-6 if dtype is np.float64 else 1e-5))
+    assert np.all(np.abs(residual) < (1e-6 if dtype is np.float64 else 5e-5))
 
 
 @pytest.mark.parametrize("queue", get_queues())


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Slightly loosens tolerances for some float32 tests that are failing in some jobs. See for example here:
https://github.com/uxlfoundation/scikit-learn-intelex/actions/runs/25037017482/job/73330966956?pr=3128#step:13:16733

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
