### PR TITLE
MAINT: Implement 'everything follows X' for BasicStatistics

### DIFF
--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -102,7 +102,7 @@ class IncrementalBasicStatistics(BasicStatistics):
         return data
 
     @supports_queue
-    def partial_fit(self, X, sample_weight=None, queue=None):
+    def partial_fit(self, X, dtype, sample_weight=None, queue=None):
         """Generate partial statistics from batch data in `_partial_result`.
 
         Parameters
@@ -110,6 +110,10 @@ class IncrementalBasicStatistics(BasicStatistics):
         X : array-like of shape (n_samples, n_features)
             Training data batch, where `n_samples` is the number of samples
             in the batch, and `n_features` is the number of features.
+
+        dtype : np.dtype
+            DType of 'X', as as a NumPy dtype or as otherwise a class that
+            would be recognize by the pybind11 module.
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample.
@@ -131,7 +135,7 @@ class IncrementalBasicStatistics(BasicStatistics):
         X_table, sample_weight_table = to_table(X, sample_weight, queue=queue)
 
         if not hasattr(self, "_onedal_params"):
-            self._onedal_params = self._get_onedal_params(False, dtype=X.dtype)
+            self._onedal_params = self._get_onedal_params(False, dtype=dtype)
 
         self._partial_result = self.partial_compute(
             self._onedal_params, self._partial_result, X_table, sample_weight_table

--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -112,7 +112,7 @@ class IncrementalBasicStatistics(BasicStatistics):
             in the batch, and `n_features` is the number of features.
 
         dtype : np.dtype
-            DType of 'X', as as a NumPy dtype or as otherwise a class that
+            DType of 'X', as a NumPy dtype or as otherwise a class that
             would be recognize by the pybind11 module.
 
         sample_weight : array-like of shape (n_samples,), default=None

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -30,6 +30,12 @@ from ..utils.validation import _check_sample_weight, validate_data
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import StrOptions
 
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import (
+        get_namespace_and_device,
+        move_to,
+    )
+
 
 @enable_array_api
 @control_n_jobs(decorated_methods=["fit"])
@@ -156,7 +162,10 @@ class BasicStatistics(oneDALEstimator, BaseEstimator):
         return patching_status
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):
-        xp, _ = get_namespace(X, sample_weight)
+        if sklearn_check_version("1.9"):
+            xp, _, device = get_namespace_and_device(X)
+        else:
+            xp, _ = get_namespace(X, sample_weight)
         X = validate_data(
             self,
             X,

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -32,6 +32,14 @@ from ..utils.validation import _check_sample_weight, validate_data
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
 
+if sklearn_check_version("1.9"):
+    from sklearn.utils._array_api import (
+        check_same_namespace,
+        get_namespace_and_device,
+        move_to,
+        _matching_numpy_dtype,
+    )
+
 import numbers
 
 
@@ -186,6 +194,8 @@ class IncrementalBasicStatistics(oneDALEstimator, BaseEstimator):
                 sample_weight = _check_sample_weight(
                     sample_weight, X, dtype=[xp.float64, xp.float32]
                 )
+        else:
+            xp = None
 
         if first_pass:
             self.n_samples_seen_ = X.shape[0]
@@ -198,7 +208,14 @@ class IncrementalBasicStatistics(oneDALEstimator, BaseEstimator):
                 result_options=self.result_options
             )
 
-        self._onedal_estimator.partial_fit(X, sample_weight=sample_weight, queue=queue)
+        if sklearn_check_version("1.9"):
+            dtype = _matching_numpy_dtype(X, xp=xp)
+        else:
+            dtype = X.dtype
+
+        self._onedal_estimator.partial_fit(
+            X, dtype, sample_weight=sample_weight, queue=queue
+        )
         self._need_to_finalize = True
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):
@@ -221,7 +238,7 @@ class IncrementalBasicStatistics(oneDALEstimator, BaseEstimator):
             self._onedal_estimator._reset()
 
         for batch in gen_batches(X.shape[0], self.batch_size_):
-            X_batch = X[batch]
+            X_batch = X[batch, :]
             weights_batch = sample_weight[batch] if sample_weight is not None else None
             self._onedal_partial_fit(
                 X_batch, weights_batch, queue=queue, check_input=False

--- a/sklearnex/basic_statistics/tests/test_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_basic_statistics.py
@@ -14,19 +14,18 @@
 # limitations under the License.
 # ==============================================================================
 
+import array_api_strict
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from scipy import sparse as sp
 
-from daal4py.sklearn._utils import daal_check_version
+from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from onedal.basic_statistics.tests.utils import options_and_tests
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
     get_dataframes_and_queues,
     get_queues,
 )
-from sklearnex import config_context
 from sklearnex.basic_statistics import BasicStatistics
 from sklearnex.tests.utils import gen_sparse_dataset
 
@@ -401,3 +400,26 @@ def test_results_have_underscores(underscore_first):
     else:
         assert not hasattr(bs, "mean")
         assert hasattr(bs, "mean_")
+
+
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"),
+    reason="Test for functionality introduced in later scikit-learn versions.",
+)
+@pytest.mark.parametrize(
+    "X_xp",
+    [np, array_api_strict],
+)
+@pytest.mark.parametrize(
+    "w_xp",
+    [np, array_api_strict],
+)
+def test_bs_weights_in_different_namespace(X_xp, w_xp, with_array_api):
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3))
+    w = rng.gamma(1, size=X.shape[0])
+
+    X = X_xp.asarray(X)
+    w = w_xp.asarray(w)
+
+    BasicStatistics().fit(X, w)

--- a/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 # ===============================================================================
 
+import array_api_strict
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from daal4py.sklearn._utils import daal_check_version
+from daal4py.sklearn._utils import sklearn_check_version
 from onedal.basic_statistics.tests.utils import options_and_tests
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
     get_dataframes_and_queues,
 )
+from onedal.tests.utils._device_selection import is_sycl_device_available
 from sklearnex.basic_statistics import IncrementalBasicStatistics
 
 
@@ -450,3 +452,30 @@ def test_results_have_underscores(underscore_first):
     else:
         assert not hasattr(bs, "mean")
         assert hasattr(bs, "mean_")
+
+
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"),
+    reason="Test for functionality introduced in later scikit-learn versions.",
+)
+@pytest.mark.parametrize(
+    "X_xp",
+    [np, array_api_strict],
+)
+@pytest.mark.parametrize(
+    "w_xp",
+    [np, array_api_strict],
+)
+def test_incbs_weights_in_different_namespace(X_xp, w_xp, with_array_api):
+    from sklearnex.basic_statistics import IncrementalBasicStatistics
+
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3))
+    w = rng.gamma(1, size=X.shape[0])
+
+    X_ = X_xp.asarray(X)
+    w_ = w_xp.asarray(w)
+
+    incbs = IncrementalBasicStatistics().fit(X_, w_)
+    incbs.partial_fit(X_, w_)
+    incbs.partial_fit(X_, w)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Implements 'everything follows X' logic for `BasicStatistics` and `IncrementalBasicStatistics`.

Depends on https://github.com/uxlfoundation/scikit-learn-intelex/pull/3117 and currently includes the commits from it.

This is purposefully not testing `.partial_fit()` due to the logic for mixed devices not being established yet at this point, and due to issues with the computed results on GPU.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
