### PR TITLE
FIX: Don't issue warning about unsupported sample weights

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -501,18 +501,6 @@ if daal_check_version((2023, "P", 200)):
                 reset=False,
                 dtype=[xp.float64, xp.float32],
             )
-
-            if not sklearn_check_version("1.5") and sklearn_check_version("1.3"):
-                if isinstance(sample_weight, str) and sample_weight == "deprecated":
-                    sample_weight = None
-
-                if sample_weight is not None:
-                    warnings.warn(
-                        "'sample_weight' was deprecated in version 1.3 and "
-                        "will be removed in 1.5.",
-                        FutureWarning,
-                    )
-
             return self._onedal_estimator.score(X, queue=queue)
 
         def _save_attributes(self):


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

KMeans has some conditions to throw a warning when calling `.score()` with sample weights saying that they are deprecated and scheduled for removal, but I cannot find any evidence that they ever were deprecated in scikit-learn.

Note that this would only happen between versions 1.3 through 1.5, which are not supported, so the condition should have been reachable either way.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
