### PR TITLE
FIX: Pass required argument to IncrementalBasicStatistics during onedal tests

### DIFF
--- a/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -39,9 +39,9 @@ def test_multiple_options_on_gold_data(queue, weighted, dtype):
     incbs = IncrementalBasicStatistics()
     for i in range(2):
         if weighted:
-            incbs.partial_fit(X_split[i], weights_split[i], queue=queue)
+            incbs.partial_fit(X_split[i], np.dtype(dtype), weights_split[i], queue=queue)
         else:
-            incbs.partial_fit(X_split[i], queue=queue)
+            incbs.partial_fit(X_split[i], np.dtype(dtype), queue=queue)
 
     result = incbs.finalize_fit()
 
@@ -86,9 +86,11 @@ def test_single_option_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
+            incbs.partial_fit(
+                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+            )
         else:
-            incbs.partial_fit(data_split[i], queue=queue)
+            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
     result = incbs.finalize_fit()
 
     res = getattr(result, result_option + "_")
@@ -124,9 +126,11 @@ def test_multiple_options_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
+            incbs.partial_fit(
+                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+            )
         else:
-            incbs.partial_fit(data_split[i], queue=queue)
+            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
     result = incbs.finalize_fit()
 
     res_mean, res_max, res_sum = result.mean_, result.max_, result.sum_
@@ -172,9 +176,11 @@ def test_all_option_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
+            incbs.partial_fit(
+                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+            )
         else:
-            incbs.partial_fit(data_split[i], queue=queue)
+            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
     result = incbs.finalize_fit()
 
     if weighted:
@@ -209,8 +215,8 @@ def test_incremental_estimator_pickle(queue, dtype):
     X = gen.uniform(low=-0.3, high=+0.7, size=(10, 10))
     X = X.astype(dtype)
     X_split = np.array_split(X, 2)
-    incbs.partial_fit(X_split[0], queue=queue)
-    incbs_loaded.partial_fit(X_split[0], queue=queue)
+    incbs.partial_fit(X_split[0], np.dtype(dtype), queue=queue)
+    incbs_loaded.partial_fit(X_split[0], np.dtype(dtype), queue=queue)
 
     assert incbs._need_to_finalize == True
     assert incbs_loaded._need_to_finalize == True
@@ -252,8 +258,8 @@ def test_incremental_estimator_pickle(queue, dtype):
     )
     assert_allclose(partial_sum_squares_centered, partial_sum_squares_centered_loaded)
 
-    incbs.partial_fit(X_split[1], queue=queue)
-    incbs_loaded.partial_fit(X_split[1], queue=queue)
+    incbs.partial_fit(X_split[1], np.dtype(dtype), queue=queue)
+    incbs_loaded.partial_fit(X_split[1], np.dtype(dtype), queue=queue)
     assert incbs._need_to_finalize == True
     assert incbs_loaded._need_to_finalize == True
 

--- a/sklearnex/basic_statistics/tests/test_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_basic_statistics.py
@@ -26,6 +26,7 @@ from onedal.tests.utils._dataframes_support import (
     get_dataframes_and_queues,
     get_queues,
 )
+from sklearnex import config_context
 from sklearnex.basic_statistics import BasicStatistics
 from sklearnex.tests.utils import gen_sparse_dataset
 


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Fixes an issue introduced by previous PR: 
https://github.com/uxlfoundation/scikit-learn-intelex/pull/3142

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
