### PR TITLE
FIX: Fix creation of oneDAL objects in linear models after fallbacks

### DIFF
--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -62,7 +62,7 @@ class BaseLinearRegression(metaclass=ABCMeta):
 
         return params
 
-    def _create_model(self, coef_, intercept_, xp):
+    def _create_model(self, coef_, intercept_, xp) -> None:
         model = self.model()
 
         dim0 = coef_.shape[0] if len(coef_.shape) > 1 else 1
@@ -93,8 +93,6 @@ class BaseLinearRegression(metaclass=ABCMeta):
         self.coef_ = coef_
         self.intercept_ = intercept_
         self._onedal_model = model
-
-        return model
 
     @supports_queue
     def fit(self, X, y, queue=None):

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -62,31 +62,32 @@ class BaseLinearRegression(metaclass=ABCMeta):
 
         return params
 
-    def _create_model(self):
+    def _create_model(self, coef_, intercept_, xp):
         model = self.model()
 
-        # force dtype and shape for all supported estimators to numpy
-
-        if np.isscalar(self.coef_):
-            coef = np.asarray(self.coef_).reshape(1, 1)
+        dim0 = coef_.shape[0] if len(coef_.shape) > 1 else 1
+        if dim0 == 1:
+            coef_ = xp.reshape(coef_, (1, -1))
+        if self.fit_intercept:
+            intercept_ = xp.reshape(intercept_, (dim0, -1))
+            packed_coefficients = xp.concat([intercept_, coef_], axis=1)
         else:
-            # generalized atleast_2d for numpy and array_api inputs
-            # if an empty array, will fail for a multitude of reasons
-            coef = from_table(
-                to_table(self.coef_[None] if self.coef_.ndim == 1 else self.coef_)
-            )
-        if np.isscalar(self.intercept_):
-            intercept = np.asarray(self.intercept_).reshape(1, 1)
-        else:
-            intercept = from_table(to_table(self.intercept_))
+            if hasattr(coef_, "device"):
+                packed_coefficients = xp.zeros(
+                    (dim0, coef_.shape[1] + 1), device=coef_.device
+                )
+            else:
+                # Note: on numpy<2, these objects and functions do not have
+                # the 'device' attribute/argument.
+                packed_coefficients = xp.zeros((dim0, coef_.shape[1] + 1))
+            packed_coefficients[:, 1:] = coef_
 
-        # will do automatic dtype promotion based on the two datatypes
-        packed_coefficients = np.concatenate((intercept, coef), axis=1)
-
+        # packed_coefficients = xp.reshape(packed_coefficients, (1, -1))
         model.packed_coefficients = to_table(
             packed_coefficients, queue=QM.get_global_queue()
         )
-
+        self.coef_ = coef_
+        self.intercept_ = intercept_
         self._onedal_model = model
 
         return model
@@ -156,9 +157,6 @@ class BaseLinearRegression(metaclass=ABCMeta):
         _check_is_fitted(self)
 
         _check_n_features(self, X, False)
-
-        if self._onedal_model is None:
-            self._onedal_model = self._create_model()
 
         X_table = to_table(X, queue=queue)
         params = self._get_onedal_params(X_table.dtype)

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -87,9 +87,7 @@ class BaseLinearRegression(metaclass=ABCMeta):
             packed_coefficients[:, 1:] = coef_
 
         # packed_coefficients = xp.reshape(packed_coefficients, (1, -1))
-        model.packed_coefficients = to_table(
-            packed_coefficients, queue=QM.get_global_queue()
-        )
+        model.packed_coefficients = to_table(packed_coefficients)
         self.coef_ = coef_
         self.intercept_ = intercept_
         self._onedal_model = model

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -25,7 +25,6 @@ from ..common._backend import bind_default_backend
 from ..common._estimator_checks import _check_is_fitted
 from ..common.hyperparameters import get_hyperparameters
 from ..datatypes import from_table, to_table
-from ..utils import _sycl_queue_manager as QM
 from ..utils.validation import _check_n_features, _num_features
 
 

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -70,7 +70,11 @@ class BaseLinearRegression(metaclass=ABCMeta):
             coef_ = xp.reshape(coef_, (1, -1))
         if self.fit_intercept:
             intercept_ = xp.reshape(intercept_, (dim0, -1))
-            packed_coefficients = xp.concat([intercept_, coef_], axis=1)
+            if xp is np:
+                # workaround for numpy<2
+                packed_coefficients = xp.concatenate([intercept_, coef_], axis=1)
+            else:
+                packed_coefficients = xp.concat([intercept_, coef_], axis=1)
         else:
             if hasattr(coef_, "device"):
                 packed_coefficients = xp.zeros(

--- a/onedal/linear_model/tests/test_incremental_linear_regression.py
+++ b/onedal/linear_model/tests/test_incremental_linear_regression.py
@@ -140,6 +140,7 @@ def test_reconstruct_model(queue, dtype):
     model = IncrementalLinearRegression(fit_intercept=True)
     model.coef_ = coef.T
     model.intercept_ = intercept
+    model._onedal_model = model._create_model(model.coef_, model.intercept_, np)
 
     res = model.predict(X, queue=queue)
 

--- a/onedal/linear_model/tests/test_incremental_linear_regression.py
+++ b/onedal/linear_model/tests/test_incremental_linear_regression.py
@@ -140,7 +140,7 @@ def test_reconstruct_model(queue, dtype):
     model = IncrementalLinearRegression(fit_intercept=True)
     model.coef_ = coef.T
     model.intercept_ = intercept
-    model._onedal_model = model._create_model(model.coef_, model.intercept_, np)
+    model._create_model(model.coef_, model.intercept_, np)
 
     res = model.predict(X, queue=queue)
 

--- a/onedal/linear_model/tests/test_linear_regression.py
+++ b/onedal/linear_model/tests/test_linear_regression.py
@@ -143,6 +143,7 @@ def test_reconstruct_model(queue, dtype):
     model = LinearRegression(fit_intercept=True)
     model.coef_ = coef.T
     model.intercept_ = intp
+    model._onedal_model = model._create_model(model.coef_, model.intercept_, np)
 
     res = model.predict(X, queue=queue)
 

--- a/onedal/linear_model/tests/test_linear_regression.py
+++ b/onedal/linear_model/tests/test_linear_regression.py
@@ -143,7 +143,7 @@ def test_reconstruct_model(queue, dtype):
     model = LinearRegression(fit_intercept=True)
     model.coef_ = coef.T
     model.intercept_ = intp
-    model._onedal_model = model._create_model(model.coef_, model.intercept_, np)
+    model._create_model(model.coef_, model.intercept_, np)
 
     res = model.predict(X, queue=queue)
 

--- a/sklearnex/linear_model/_base_linear_model.py
+++ b/sklearnex/linear_model/_base_linear_model.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+
+from ..utils._array_api import get_namespace
+
+
+# Adds common methods to create oneDAL objects after a fallback
+class _BaseLinearModel(ABC):
+    @abstractmethod
+    def _initialize_onedal_estimator(self, override_fit_intercept: bool = False) -> None:
+        raise NotImplementedError()
+
+    def _get_fit_intercept(self, override_fit_intercept: bool = False) -> bool:
+        if not override_fit_intercept:
+            return self.fit_intercept
+        else:
+            if isinstance(self.intercept_, float):
+                return self.intercept_ != 0.0
+            else:
+                xp, _ = get_namespace(self.coef_)
+                return bool(xp.all(self.intercept_ != 0))
+
+    def _initialize_onedal_estimator_from_coefs(self) -> None:
+        xp, _ = get_namespace(self.coef_)
+        self._initialize_onedal_estimator(override_fit_intercept=True)
+        self._onedal_estimator._create_model(self.coef_, self.intercept_, xp)

--- a/sklearnex/linear_model/_base_linear_model.py
+++ b/sklearnex/linear_model/_base_linear_model.py
@@ -1,3 +1,18 @@
+# ==============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 from abc import ABC, abstractmethod
 
 from ..utils._array_api import get_namespace

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -31,6 +31,7 @@ from .._utils import PatchingConditionsChain, get_patch_message, register_hyperp
 from ..base import oneDALEstimator
 from ..utils._array_api import enable_array_api, get_namespace
 from ..utils.validation import validate_data
+from ._base_linear_model import _BaseLinearModel
 
 if not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize
@@ -39,7 +40,7 @@ if not sklearn_check_version("1.2"):
 @enable_array_api("1.5")  # validate_data y_numeric requires sklearn >=1.5
 @register_hyperparameters({"fit": ("linear_regression", "train")})
 @control_n_jobs(decorated_methods=["fit", "predict", "score"])
-class LinearRegression(oneDALEstimator, _sklearn_LinearRegression):
+class LinearRegression(oneDALEstimator, _sklearn_LinearRegression, _BaseLinearModel):
     __doc__ = _sklearn_LinearRegression.__doc__
 
     if sklearn_check_version("1.2"):
@@ -247,8 +248,11 @@ class LinearRegression(oneDALEstimator, _sklearn_LinearRegression):
 
         return patching_status
 
-    def _initialize_onedal_estimator(self):
-        onedal_params = {"fit_intercept": self.fit_intercept, "copy_X": self.copy_X}
+    def _initialize_onedal_estimator(self, override_fit_intercept: bool = False) -> None:
+        onedal_params = {
+            "fit_intercept": self._get_fit_intercept(override_fit_intercept),
+            "copy_X": self.copy_X,
+        }
         self._onedal_estimator = self._onedal_LinearRegression(**onedal_params)
 
     def _onedal_fit(self, X, y, sample_weight, queue=None):
@@ -309,9 +313,7 @@ class LinearRegression(oneDALEstimator, _sklearn_LinearRegression):
         )
 
         if not hasattr(self, "_onedal_estimator"):
-            self._initialize_onedal_estimator()
-            self._onedal_estimator.coef_ = self.coef_
-            self._onedal_estimator.intercept_ = self.intercept_
+            self._initialize_onedal_estimator_from_coefs()
 
         res = self._onedal_estimator.predict(X, queue=queue)
         if res.shape[1] == 1 and self.coef_.ndim == 1:

--- a/sklearnex/linear_model/ridge.py
+++ b/sklearnex/linear_model/ridge.py
@@ -42,10 +42,11 @@ if daal_check_version((2024, "P", 600)):
     from ..base import oneDALEstimator
     from ..utils._array_api import enable_array_api, get_namespace
     from ..utils.validation import validate_data
+    from ._base_linear_model import _BaseLinearModel
 
     @enable_array_api("1.5")  # validate_data y_numeric requires sklearn >=1.5
     @control_n_jobs(decorated_methods=["fit", "predict", "score"])
-    class Ridge(oneDALEstimator, _sklearn_Ridge):
+    class Ridge(oneDALEstimator, _sklearn_Ridge, _BaseLinearModel):
         __doc__ = _sklearn_Ridge.__doc__
 
         if sklearn_check_version("1.2"):
@@ -275,9 +276,11 @@ if daal_check_version((2024, "P", 600)):
                 f"Unknown method {method_name} in {self.__class__.__name__}"
             )
 
-        def _initialize_onedal_estimator(self):
+        def _initialize_onedal_estimator(
+            self, override_fit_intercept: bool = False
+        ) -> None:
             onedal_params = {
-                "fit_intercept": self.fit_intercept,
+                "fit_intercept": self._get_fit_intercept(override_fit_intercept),
                 "alpha": self.alpha,
                 "copy_X": self.copy_X,
             }
@@ -347,9 +350,7 @@ if daal_check_version((2024, "P", 600)):
             )
 
             if not hasattr(self, "_onedal_estimator"):
-                self._initialize_onedal_estimator()
-                self._onedal_estimator.coef_ = self.coef_
-                self._onedal_estimator.intercept_ = self.intercept_
+                self._initialize_onedal_estimator_from_coefs()
 
             res = self._onedal_estimator.predict(X, queue=queue)
             if res.shape[1] == 1 and self.coef_.ndim == 1:

--- a/sklearnex/linear_model/tests/test_linear_common.py
+++ b/sklearnex/linear_model/tests/test_linear_common.py
@@ -61,7 +61,8 @@ def test_predict_after_fallback(fit_intercept, dim_y, estimator):
     reason="Functionality introduced in later scikit-learn versions.",
 )
 @pytest.mark.parametrize("fit_intercept", [True, False])
-@pytest.mark.parametrize("dim_y", [1, 3])
+# Note: this is due to a bug that was fixed in later sklearn versions
+@pytest.mark.parametrize("dim_y", [1] + ([3] if sklearn_check_version("1.9") else []))
 @pytest.mark.parametrize("estimator", ["Ridge"])
 @pytest.mark.allow_sklearn_fallback
 def test_predict_after_fallback_array_api(

--- a/sklearnex/linear_model/tests/test_linear_common.py
+++ b/sklearnex/linear_model/tests/test_linear_common.py
@@ -1,3 +1,18 @@
+# ==============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 import warnings
 
 import array_api_strict

--- a/sklearnex/linear_model/tests/test_linear_common.py
+++ b/sklearnex/linear_model/tests/test_linear_common.py
@@ -1,0 +1,87 @@
+import warnings
+
+import array_api_strict
+import numpy as np
+import pytest
+
+from daal4py.sklearn._utils import sklearn_check_version
+
+
+@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize("dim_y", [1, 3])
+@pytest.mark.parametrize("estimator", ["LinearRegression", "Ridge"])
+@pytest.mark.allow_sklearn_fallback
+def test_predict_after_fallback(fit_intercept, dim_y, estimator):
+    from sklearnex import linear_model
+
+    model = getattr(linear_model, estimator)(fit_intercept=fit_intercept)
+
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3))
+    y = rng.random(X.shape[0] if dim_y == 1 else (X.shape[0], dim_y))
+    w = rng.standard_gamma(1, size=X.shape[0])
+
+    # Note: weights are not supported by oneDAL, so this should trigger a fallback.
+    # If they become supported in the future, this test would need to be adapted
+    # to trigger a fallback in some other way
+    model.fit(X, y, w)
+    assert not hasattr(model, "_onedal_estimator")
+
+    pred = model.predict(X)
+
+    assert hasattr(model, "_onedal_estimator")
+    if dim_y == 1:
+        expected_pred = X @ model.coef_ + model.intercept_
+    else:
+        expected_pred = X @ model.coef_.T
+        if fit_intercept:
+            expected_pred += model.intercept_.reshape((1, -1))
+
+    np.testing.assert_allclose(pred, expected_pred)
+
+
+# TODO: Extend this test to LinearRegression once scikit-learn adds array API support
+@pytest.mark.skipif(
+    not sklearn_check_version("1.8"),
+    reason="Functionality introduced in later scikit-learn versions.",
+)
+@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize("dim_y", [1, 3])
+@pytest.mark.parametrize("estimator", ["Ridge"])
+@pytest.mark.allow_sklearn_fallback
+def test_predict_after_fallback_array_api(
+    fit_intercept, dim_y, estimator, with_array_api
+):
+    from sklearnex import linear_model
+
+    model = getattr(linear_model, estimator)(fit_intercept=fit_intercept)
+
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3))
+    y = rng.random(X.shape[0] if dim_y == 1 else (X.shape[0], dim_y))
+    w = rng.standard_gamma(1, size=X.shape[0])
+
+    X = array_api_strict.asarray(X.astype(np.float32))
+    y = array_api_strict.asarray(y.astype(np.float32))
+    w = array_api_strict.asarray(w.astype(np.float32))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        model.fit(X, y, w)
+    assert not hasattr(model, "_onedal_estimator")
+
+    pred = model.predict(X)
+    assert pred.__class__ == X.__class__
+    assert pred.dtype == array_api_strict.float32
+
+    assert hasattr(model, "_onedal_estimator")
+    if dim_y == 1:
+        expected_pred = X @ model.coef_ + model.intercept_
+    else:
+        expected_pred = X @ model.coef_.T
+        if fit_intercept:
+            expected_pred += array_api_strict.reshape(model.intercept_, (1, -1))
+
+    pred = np.array(pred)
+    expected_pred = np.array(pred)
+    np.testing.assert_allclose(pred, expected_pred)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Fixes cases in which creation of oneDAL objects from fitted coefficients errors out due to incompatibilities with array API objects.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
