### PR TITLE
MAINT: Fix warning about unused n_jobs in LogisticRegression from newer scikit-learn

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -48,6 +48,7 @@
 
 import numbers
 import os
+from functools import partial
 
 import numpy as np
 import scipy.optimize as optimize
@@ -445,12 +446,26 @@ def logistic_regression_path_d4p(
 
 def daal4py_fit(self, X, y, sample_weight=None):
     which, what = logistic_module, "_logistic_regression_path"
-    replacer = logistic_regression_path
+    # Note: as of scikit-learn1.8, 'n_jobs' is deprecated for logistic regression
+    # and throws a warning. Their functions still have 'n_threads' as a parameter,
+    # but since 1.8, they hard-code it to 1 in the calls from logistic regression.
+    # This is a workaround to avoid getting a warning. If scikit-learn removes
+    # the 'n_jobs' parameter (scheduled for version 1.10), then this workaround
+    # can be safely removed.
+    if sklearn_check_version("1.8"):
+        n_jobs = self.n_jobs
+        replacer = partial(logistic_regression_path, n_threads=n_jobs)
+        if self.n_jobs is not None:
+            self.n_jobs = None
+    else:
+        replacer = logistic_regression_path
     try:
         setattr(which, what, replacer)
         clf = LogisticRegression_original.fit(self, X, y, sample_weight)
     finally:
         setattr(which, what, lr_path_original)
+        if sklearn_check_version("1.8"):
+            self.n_jobs = n_jobs
     return clf
 
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -48,7 +48,6 @@
 
 import numbers
 import os
-from functools import partial
 
 import numpy as np
 import scipy.optimize as optimize
@@ -459,11 +458,9 @@ def daal4py_fit(self, X, y, sample_weight=None):
     # objects at this point will have no effect on the value passed to oneDAL.
     if sklearn_check_version("1.8"):
         n_jobs = self.n_jobs
-        replacer = partial(logistic_regression_path, n_threads=n_jobs)
         if self.n_jobs is not None:
             self.n_jobs = None
-    else:
-        replacer = logistic_regression_path
+    replacer = logistic_regression_path
     try:
         setattr(which, what, replacer)
         clf = LogisticRegression_original.fit(self, X, y, sample_weight)

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -456,7 +456,8 @@ def daal4py_fit(self, X, y, sample_weight=None):
     # 'control_n_jobs', which acts on the sklearnex side before calling these
     # daal4py functions for logistic regression, so setting 'n_jobs' in the estimator
     # objects at this point will have no effect on the value passed to oneDAL.
-    if sklearn_check_version("1.8"):
+    # TODO: remove this once scikit-learn1.8 and 1.9 are no longer supported.
+    if (not sklearn_check_version("1.10")) and sklearn_check_version("1.8"):
         n_jobs = self.n_jobs
         if self.n_jobs is not None:
             self.n_jobs = None
@@ -466,7 +467,7 @@ def daal4py_fit(self, X, y, sample_weight=None):
         clf = LogisticRegression_original.fit(self, X, y, sample_weight)
     finally:
         setattr(which, what, lr_path_original)
-        if sklearn_check_version("1.8"):
+        if (not sklearn_check_version("1.10")) and sklearn_check_version("1.8"):
             self.n_jobs = n_jobs
     return clf
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -452,6 +452,11 @@ def daal4py_fit(self, X, y, sample_weight=None):
     # This is a workaround to avoid getting a warning. If scikit-learn removes
     # the 'n_jobs' parameter (scheduled for version 1.10), then this workaround
     # can be safely removed.
+    # Note2: the function 'logistic_regression_path' takes an argument 'n_threads',
+    # but does not use it. The number of threads for oneDAL is set through wrapper
+    # 'control_n_jobs', which acts on the sklearnex side before calling these
+    # daal4py functions for logistic regression, so setting 'n_jobs' in the estimator
+    # objects at this point will have no effect on the value passed to oneDAL.
     if sklearn_check_version("1.8"):
         n_jobs = self.n_jobs
         replacer = partial(logistic_regression_path, n_threads=n_jobs)

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -476,6 +476,10 @@ deselected_tests:
   # but sklearnex has support for different solvers when passing array API, so it doesn't change the default.
   - linear_model/tests/test_ridge.py::test_array_api_error_and_warnings_for_solver_parameter[dpnp]
 
+  # Scikit-learn expects warning about passing n_jobs which has no effect,
+  # but sklearnex does use the parameter regardless.
+  - linear_model/tests/test_logistic.py::test_logisticregression_warns_with_n_jobs
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -20,7 +20,6 @@ from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from daal4py.sklearn.linear_model.logistic_path import (
     LogisticRegression as _daal4py_LogisticRegression,
 )
-from onedal._device_offload import support_input_format
 
 from ..base import oneDALEstimator
 

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -702,9 +702,10 @@ def test_array_api_logreg(dataframe, queue, y_type):
     ), f"score should return a scalar, got type {type(score)}"
 
 
+# TODO: remove this once scikit-learn1.8 and 1.9 are no longer supported.
 @pytest.mark.skipif(
     not sklearn_check_version("1.8"),
-    reason="Workaround for warning issued in newer scikit-learn versions",
+    reason="Workaround for warning issued in specific scikit-learn versions",
 )
 @pytest.mark.allow_sklearn_fallback
 def test_no_warning_for_n_jobs():

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -700,3 +700,26 @@ def test_array_api_logreg(dataframe, queue, y_type):
     assert isinstance(
         score, (float, np.floating, np.number)
     ), f"score should return a scalar, got type {type(score)}"
+
+
+@pytest.mark.skipif(
+    not sklearn_check_version("1.8"),
+    reason="Workaround for warning issued in newer scikit-learn versions",
+)
+@pytest.mark.allow_sklearn_fallback
+def test_no_warning_for_n_jobs():
+    from sklearnex.linear_model import LogisticRegression
+
+    model = LogisticRegression(n_jobs=2, solver="newton-cholesky")
+
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3))
+    y = rng.integers(2, size=X.shape[0])
+    w = rng.standard_gamma(1, size=X.shape[0])
+
+    # Note: this is meant to trigger a fallback by passing weights and a
+    # solver which is not supported by oneDAL. If oneDAL starts supporting
+    # this setting, it should find some other way of triggering a fallback.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=FutureWarning)
+        model.fit(X, y, w)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Scikit-learn deprecated the `n_jobs` parameter for LogisticRegression, and now throws warnings during sklearnex tests about this parameter being unsupported, but the parameter is still used by sklearnex and is meant to be user modifyable. This PR fixes the warning.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
