### PR TITLE
Install pip, etc. on conda create step

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -30,7 +30,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml pip setuptools wheel
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/pipeline/build-and-test-mac.yml
+++ b/.ci/pipeline/build-and-test-mac.yml
@@ -19,7 +19,7 @@ steps:
       sudo chown -R $USER $CONDA
       conda config --set always_yes yes --set changeps1 no
       conda update -q conda
-      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich clang-format pyyaml
+      conda create -n CB -c conda-forge python=$(PYTHON_VERSION) dal-devel mpich clang-format pyyaml pip setuptools wheel
     displayName: Create Anaconda environment
   - script: |
       source activate CB

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -18,7 +18,7 @@ steps:
     displayName: Add conda to PATH
   - script: |
       (echo default_channels: & echo   - https://conda.anaconda.org/conda-forge) >> C:\Users\VssAdministrator\.condarc
-      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml pip setuptools wheel
     displayName: 'Create Anaconda environment'
   - script: |
       call activate CB

--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -26,5 +26,5 @@ steps:
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate build-env
-      conda build . --python $(PYTHON_VERSION) --numpy $(NUMPY_VERSION)
+      conda-build . --python $(PYTHON_VERSION) --numpy $(NUMPY_VERSION)
     displayName: "Conda build and test"

--- a/.ci/pipeline/conda-recipe-win.yml
+++ b/.ci/pipeline/conda-recipe-win.yml
@@ -27,5 +27,5 @@ steps:
     displayName: "Conda create"
   - script: |
       call activate build-env
-      conda build . --python $(PYTHON_VERSION) --numpy $(NUMPY_VERSION)
+      conda-build . --python $(PYTHON_VERSION) --numpy $(NUMPY_VERSION)
     displayName: "Conda build and test"

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -48,7 +48,7 @@ jobs:
       conda config --append channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda
-      conda create -y -q -n CB -c conda-forge python=$(python.version) dal-devel impi-devel
+      conda create -y -q -n CB -c conda-forge python=$(python.version) dal-devel impi-devel pip setuptools wheel
       . /usr/share/miniconda/etc/profile.d/conda.sh
       conda activate CB
       pip install -r dependencies-dev
@@ -73,7 +73,7 @@ jobs:
       conda config --show channels
       conda config --append channels conda-forge
       conda update -y -q conda
-      conda create -y -q -n CB -c conda-forge python=$(python.version) dal-devel impi-devel
+      conda create -y -q -n CB -c conda-forge python=$(python.version) dal-devel impi-devel pip setuptools wheel
     displayName: 'Conda create'
   - script: |
       bash .ci/scripts/describe_system.sh


### PR DESCRIPTION
## Description

Explicitly installs pip, setuptools, wheel deps in conda create step in all cases where any are used, as they are no longer dependencies of python. On a similar note, conda-build either needs to be installed into base or used conda-build executable directly.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
