### PR TITLE
DOC: Document unsupported `move_estimator_to`

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -166,6 +166,18 @@ For :obj:`sklearn.linear_model.LogisticRegression`, array API coverage is limite
 is allocated on a GPU device, so passing array API inputs on CPU other than NumPy arrays will not result
 in calling accelerated routines from the |sklearnex|.
 
+Function ``move_estimator_to``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting with version 1.9, |sklearn| provides an experimental utility ``sklearn.utils._array_api.move_estimator_to``,
+which can be used to move an estimator that was fitted with one array API library namespace and device to
+another.
+
+This function is not supported with estimators from the |sklearnex| at the moment. This lack of support
+also extends to cases where :doc:`patching <patching>` is applied, but the ``.fit()`` routine is handled
+through |sklearn| as a fallback (see :doc:`algorithms` for details) - meaning: ``move_estimator_to`` cannot
+be used with classes from the |sklearnex| regardless of which backend was used to fit the estimator.
+
 Example usage
 =============
 

--- a/doc/sources/unsupported.rst
+++ b/doc/sources/unsupported.rst
@@ -42,3 +42,8 @@ Callbacks
 ---------
 
 Callback functions (an experimental feature introduced in version 1.9 of |sklearn|) are not supported in estimators from the |sklearnex|. If supplied, they will not be used.
+
+Moving estimators
+-----------------
+
+Function ``sklearn.utils._array_api.move_estimator_to`` is currently not supported for estimator objects from the |sklearnex|. See :doc:`array_api` for more details.


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

It will take a while to support `move_estimator_to`, but sklearn1.9 which introduces this function is going to be released soon.

This PR documents lack of support for this. It should be undone once all estimators with array API support implement everything required to support it, which hopefully shouldn't take too long.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
