### PR TITLE
FIX: Restore data movements in `train_test_split`

### DIFF
--- a/sklearnex/model_selection/split.py
+++ b/sklearnex/model_selection/split.py
@@ -23,5 +23,5 @@ from onedal._device_offload import support_input_format
 # end up being inefficient if the inputs are of some array API class, but
 # this function allows multiple data arguments so it's not easy to make checks
 # on them for whether to move the data beforehand.
-if not sklearn_check_version("1.7") and sklearn_check_version("1.5"):
+if not sklearn_check_version("1.8") and sklearn_check_version("1.5"):
     train_test_split = support_input_format(train_test_split)

--- a/sklearnex/model_selection/split.py
+++ b/sklearnex/model_selection/split.py
@@ -14,4 +14,14 @@
 # limitations under the License.
 # ===============================================================================
 
+from daal4py.sklearn._utils import sklearn_check_version
 from daal4py.sklearn.model_selection import train_test_split
+from onedal._device_offload import support_input_format
+
+# Needed due to some issues with array API support on the scikit-learn side
+# for the internal safe indexer tool which daal4py uses. Note that this will
+# end up being inefficient if the inputs are of some array API class, but
+# this function allows multiple data arguments so it's not easy to make checks
+# on them for whether to move the data beforehand.
+if not sklearn_check_version("1.7") and sklearn_check_version("1.5"):
+    train_test_split = support_input_format(train_test_split)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Follow up from https://github.com/uxlfoundation/scikit-learn-intelex/pull/3147

Now that some CI jobs started working again, turns out that it might indeed be necessary to use `support_input_format` for function `train_test_split` in older versions of scikit-learn.

I was unable to reproduce the CI failure (with/without DPC, with/without scipy array API enabling) that occurs with array-api-strict using the same package versions, but I guess it should be theoretically possible to bump into it. I couldn't think of any better way of solving it so this PR restores the `support_input_format` wrapper depending on sklearn version.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.


</details>
