### PR TITLE
MAINT: Deselect new sklearn test that imports from private module

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -480,6 +480,9 @@ deselected_tests:
   # but sklearnex does use the parameter regardless.
   - linear_model/tests/test_logistic.py::test_logisticregression_warns_with_n_jobs
 
+  # Creates a LinearRegression on-the-fly, but from a private module so patching doesn't affect it
+  - utils/_repr_html/tests/test_estimator.py::test_get_visual_block_transformed_target_regressor
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Deselects a new test in sklearn which creates a `LinearRegression()` object inside it and checks the class, but it does so by importing from a private module in sklearn (which patching does not cover) and comparing the class against a public module (which is affected by patching).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
