### PR TITLE
FIX: Use default compiler when building sklearn from source

### DIFF
--- a/.ci/scripts/setup_sklearn.sh
+++ b/.ci/scripts/setup_sklearn.sh
@@ -29,6 +29,7 @@ if [ "$sklearn_version" == "main" ]; then
     # install sklearn build dependencies
     pip install threadpoolctl joblib scipy
     # install sklearn from main branch of git repo
+    unset CC CXX CFLAGS CXXFLAGS LDFLAGS MAKEFLAGS 
     pip install git+https://github.com/scikit-learn/scikit-learn.git@main
 else
     sed -i.bak -E "s/scikit-learn==[0-9a-zA-Z.]*/scikit-learn==${sklearn_version}.*/" requirements-test.txt


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

For some reason, under the latest meson, when it builds scikit-learn from source in jobs that pull it from their GH main branch, it selects ICX as the default compiler, which then results in failures due to Cython not being able to work with it.

This PR fixes the issue by unsetting environment variables related to compilation before attempting to install scikit-learn from source.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
