### PR TITLE
MAINT: Fix error type check for mismatched namespace test in covariance

### DIFF
--- a/sklearnex/covariance/tests/test_incremental_covariance.py
+++ b/sklearnex/covariance/tests/test_incremental_covariance.py
@@ -297,7 +297,7 @@ def test_score_verify_namespace(dispatch, dataframe, queue):
 
     if dispatch:
         cfg_context = config_context(array_api_dispatch=True)
-        err = pytest.raises(TypeError)
+        err = pytest.raises((TypeError, ValueError))
     else:
         # support_sycl_format will cause it to function
         cfg_context = nullcontext()


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Sklearn1.9 introduces new errors for mismatched namespaces. This PR fixes an existing test to consider the new error type.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>


- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
