### PR TITLE
FIX: Fix linting in onedal logreg file

### DIFF
--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -90,7 +90,7 @@ class BaseLogisticRegression(metaclass=ABCMeta):
 
     def _create_model(self, coef_, intercept_, xp):
         model = self.model()
-        # Packed coefficients have shape (1, n_features_ + 1), the first element is a placeholder for bias. 
+        # Packed coefficients have shape (1, n_features_ + 1), the first element is a placeholder for bias.
         # If fit_intercept is set to False the first element is set to 0.
         if self.fit_intercept:
             intercept_ = xp.reshape(intercept_, (-1, 1))


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Previous PR added a comment line through the web interface that ended up failing the linting job due to trailing whitespace. This PR fixes it.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
