### PR TITLE
FIX: Fix KNN warning on unused metric parameter during fallbacks

### DIFF
--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -294,13 +294,21 @@ class KNeighborsDispatchingBase(oneDALEstimator):
 
         # For minkowski distance, use more efficient methods where available
         if self.metric == "minkowski":
-            self.effective_metric_params_["p"] = effective_p
+            can_remove_p = False
             if effective_p == 1:
                 self.effective_metric_ = "manhattan"
+                can_remove_p = True
             elif effective_p == 2:
                 self.effective_metric_ = "euclidean"
+                can_remove_p = True
             elif effective_p == np.inf:
                 self.effective_metric_ = "chebyshev"
+                can_remove_p = True
+            if can_remove_p:
+                if "p" in self.effective_metric_params_:
+                    self.effective_metric_params_.pop("p")
+            else:
+                self.effective_metric_params_["p"] = effective_p
 
     def _validate_kneighbors_bounds(self, n_neighbors, query_is_train, X):
         n_samples_fit = self.n_samples_fit_
@@ -487,7 +495,8 @@ class KNeighborsDispatchingBase(oneDALEstimator):
             self.n_features_in_ = X.n_features_in_
             # Check if X has _onedal_estimator as an instance attribute (not class attribute)
             if "_onedal_estimator" in X.__dict__:
-                self.effective_metric_params_.pop("p")
+                if "p" in self.effective_metric_params_:
+                    self.effective_metric_params_.pop("p")
                 if self._fit_method == "ball_tree":
                     X._tree = BallTree(
                         X._fit_X,
@@ -572,7 +581,7 @@ class KNeighborsDispatchingBase(oneDALEstimator):
             result_method = self._fit_method
 
         p_less_than_one = (
-            "p" in self.effective_metric_params_.keys()
+            "p" in self.effective_metric_params_
             and self.effective_metric_params_["p"] < 1
         )
         if not patching_status.and_condition(

--- a/sklearnex/neighbors/tests/test_neighbors.py
+++ b/sklearnex/neighbors/tests/test_neighbors.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 # ===============================================================================
 
+import warnings
+
 import array_api_strict
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.sparse as sp
 from numpy.testing import assert_allclose, assert_array_equal
 from sklearn import datasets
 from sklearn.base import is_regressor
+
+if hasattr(sp, "csr_array"):
+    CSR_CTOR = sp.csr_array
+else:
+    CSR_CTOR = sp.csr_matrix
 
 from daal4py.sklearn._utils import sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
@@ -186,6 +194,23 @@ def test_p_present_if_metric_is_minkowski():
     assert knn.effective_metric_ == "minkowski"
     assert "p" in knn.effective_metric_params_
     assert knn.effective_metric_params_["p"] == 3
+
+
+# This triggers a fallback on the call to 'predict' by passing
+# a sparse matrix, which is not supported by oneDAL. If this
+# changes, a fallback would need to be triggered in some other way.
+@pytest.mark.allow_sklearn_fallback
+def test_no_metric_args_warning_on_fallback():
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(25, 3))
+    y = rng.standard_normal(size=X.shape[0])
+
+    X_sp = CSR_CTOR(X)
+
+    knn = KNeighborsRegressor(algorithm="brute").fit(X, y)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _ = knn.predict(X_sp)
 
 
 # Note: this doesn't check 'kneighbors_graph', because that function


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Fixes an issue with an unused metric parameter being passed to sklearn during fallbacks, which triggers a warning.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
