### PR TITLE
FIX: Fix KMeans prediction on sparse data after dense fit

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -24,6 +24,7 @@ if daal_check_version((2023, "P", 200)):
     import warnings
 
     import numpy as np
+    from scipy.sparse import issparse
     from sklearn.cluster import KMeans as _sklearn_KMeans
     from sklearn.exceptions import ConvergenceWarning
     from sklearn.metrics.pairwise import (
@@ -385,10 +386,6 @@ if daal_check_version((2023, "P", 200)):
                 )
 
         def _onedal_predict(self, X, sample_weight=None, queue=None):
-            if sklearn_check_version("1.9"):
-                check_same_namespace(
-                    X, self, attribute="cluster_centers_", method="predict"
-                )
             xp, _ = get_namespace(X)
             X = validate_data(
                 self,
@@ -397,6 +394,15 @@ if daal_check_version((2023, "P", 200)):
                 reset=False,
                 dtype=[xp.float64, xp.float32],
             )
+            if sklearn_check_version("1.9"):
+                # Note: this errors out in scikit-learn, but is supported by oneDAL.
+                # The 'if' part can be removed once issue is fixed in sklearn side:
+                # https://github.com/scikit-learn/scikit-learn/issues/34132
+                # But note that this won't work for array API classes on CPU
+                if not (isinstance(self.cluster_centers_, np.ndarray) and issparse(X)):
+                    check_same_namespace(
+                        X, self, attribute="cluster_centers_", method="predict"
+                    )
             return self._onedal_estimator.predict(X, queue=queue)
 
         def _onedal_supported(self, method_name, *data):
@@ -455,10 +461,6 @@ if daal_check_version((2023, "P", 200)):
             )
 
         def _onedal_transform(self, X, queue=None):
-            if sklearn_check_version("1.9"):
-                check_same_namespace(
-                    X, self, attribute="cluster_centers_", method="transform"
-                )
             xp, is_array_api = get_namespace(X)
             X = validate_data(
                 self,
@@ -469,6 +471,11 @@ if daal_check_version((2023, "P", 200)):
                 order="C",
                 accept_large_sparse=False,
             )
+            if sklearn_check_version("1.9"):
+                if not (isinstance(self.cluster_centers_, np.ndarray) and issparse(X)):
+                    check_same_namespace(
+                        X, self, attribute="cluster_centers_", method="transform"
+                    )
 
             if is_array_api:
                 centers = xp.asarray(self.cluster_centers_)
@@ -500,10 +507,6 @@ if daal_check_version((2023, "P", 200)):
             )
 
         def _onedal_score(self, X, y=None, sample_weight=None, queue=None):
-            if sklearn_check_version("1.9"):
-                check_same_namespace(
-                    X, self, attribute="cluster_centers_", method="score"
-                )
             xp, _ = get_namespace(X)
             X = validate_data(
                 self,
@@ -512,6 +515,11 @@ if daal_check_version((2023, "P", 200)):
                 reset=False,
                 dtype=[xp.float64, xp.float32],
             )
+            if sklearn_check_version("1.9"):
+                if not (isinstance(self.cluster_centers_, np.ndarray) and issparse(X)):
+                    check_same_namespace(
+                        X, self, attribute="cluster_centers_", method="score"
+                    )
             return self._onedal_estimator.score(X, queue=queue)
 
         def _save_attributes(self):

--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -18,9 +18,14 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+import scipy.sparse as sp
 from numpy.testing import assert_allclose
-from scipy.sparse import csr_matrix
 from sklearn.datasets import make_blobs
+
+if hasattr(sp, "csr_array"):
+    CSR_CTOR = sp.csr_array
+else:
+    CSR_CTOR = sp.csr_matrix
 
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
@@ -84,7 +89,7 @@ def test_sklearnex_import_for_sparse_data(queue, algorithm, init):
     from sklearnex.cluster import KMeans
 
     X_dense = generate_dense_dataset(1000, 10, 0.5, 3)
-    X_sparse = csr_matrix(X_dense)
+    X_sparse = CSR_CTOR(X_dense)
 
     kmeans_sparse = KMeans(
         n_clusters=3, random_state=0, algorithm=algorithm, init=init
@@ -143,7 +148,7 @@ def test_dense_vs_sparse(queue, init, algorithm, dims):
     # For higher level of sparsity (smaller density) the test may fail
     n_samples, n_features, density, n_clusters = dims
     X_dense = generate_dense_dataset(n_samples, n_features, density, n_clusters)
-    X_sparse = csr_matrix(X_dense)
+    X_sparse = CSR_CTOR(X_dense)
 
     if init == "arraylike":
         np.random.seed(2024 + n_samples + n_features + n_clusters)
@@ -261,3 +266,24 @@ def test_cov_error_on_incompatible_devices(with_array_api):
         _ = model.transform(X_gpu)
     with pytest.raises(ValueError, match=err_match):
         _ = model.score(X_gpu)
+
+
+@pytest.mark.parametrize("array_api", [False, True])
+def test_sp_predict_on_dense_fit(array_api):
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(50, 3), dtype=np.float32)
+    X_sp = CSR_CTOR(X)
+
+    with config_context(array_api_dispatch=array_api):
+        model = KMeans().fit(X)
+        sp_pred = model.predict(X_sp)
+        sp_transf = model.transform(X_sp)
+        sp_score = model.score(X_sp)
+
+        dense_pred = model.predict(X)
+        dense_transf = model.transform(X)
+        dense_score = model.score(X)
+
+        np.testing.assert_allclose(sp_pred, dense_pred)
+        np.testing.assert_allclose(sp_transf, dense_transf, rtol=1e-4, atol=1e-4)
+        np.testing.assert_allclose(sp_score, dense_score, rtol=1e-6, atol=1e-6)

--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ===============================================================================
 
+from contextlib import nullcontext
+
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -167,6 +169,10 @@ def test_dense_vs_sparse(queue, init, algorithm, dims):
     )
 
 
+@pytest.mark.skipif(
+    not sklearn_check_version("1.5"),
+    reason="Functionality introduced in later sklearn versions.",
+)
 @pytest.mark.parametrize("output_format", ["set_output", "config_context"])
 @pytest.mark.parametrize("transform_output", ["polars", "pandas"])
 def test_transform_output_torch(output_format, transform_output):
@@ -268,13 +274,20 @@ def test_cov_error_on_incompatible_devices(with_array_api):
         _ = model.score(X_gpu)
 
 
-@pytest.mark.parametrize("array_api", [False, True])
+@pytest.mark.parametrize(
+    "array_api", [False] + ([True] if sklearn_check_version("1.5") else [])
+)
 def test_sp_predict_on_dense_fit(array_api):
     rng = np.random.default_rng(seed=123)
     X = rng.random(size=(50, 3), dtype=np.float32)
     X_sp = CSR_CTOR(X)
 
-    with config_context(array_api_dispatch=array_api):
+    ctx = (
+        config_context(array_api_dispatch=array_api)
+        if sklearn_check_version("1.5")
+        else nullcontext()
+    )
+    with ctx:
         model = KMeans().fit(X)
         sp_pred = model.predict(X_sp)
         sp_transf = model.transform(X_sp)

--- a/sklearnex/cluster/tests/test_kmeans.py
+++ b/sklearnex/cluster/tests/test_kmeans.py
@@ -277,7 +277,7 @@ def test_cov_error_on_incompatible_devices(with_array_api):
 @pytest.mark.parametrize(
     "array_api", [False] + ([True] if sklearn_check_version("1.5") else [])
 )
-def test_sp_predict_on_dense_fit(array_api):
+def test_sparse_predict_on_dense_fit(array_api):
     rng = np.random.default_rng(seed=123)
     X = rng.random(size=(50, 3), dtype=np.float32)
     X_sp = CSR_CTOR(X)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Fixes an issue in which namespace checks error out if a KMeans model is fitted to dense data but then used to predict on sparse data.

The error is actually coming from scikit-learn:
https://github.com/scikit-learn/scikit-learn/issues/34132

It's not possible to fix it in other cases where this should be supported like linear models, because the error in those cases comes from scikit-learn's code.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
