### PR TITLE
[maintenance] Remove unused memory leak testing SYCL function (#2887 followup)

### DIFF
--- a/onedal/common/policy.cpp
+++ b/onedal/common/policy.cpp
@@ -81,7 +81,6 @@ void instantiate_data_parallel_policy(py::module& m) {
     policy.def("get_device_name", [](const dp_policy_t& policy) {
         return get_device_name(policy);
     });
-    m.def("get_used_memory", &get_used_memory, py::return_value_policy::take_ownership);
 }
 #endif // ONEDAL_DATA_PARALLEL
 #ifdef ONEDAL_DATA_PARALLEL_SPMD

--- a/onedal/common/sycl_interfaces.cpp
+++ b/onedal/common/sycl_interfaces.cpp
@@ -175,13 +175,6 @@ std::uint32_t get_device_id(const sycl::queue& queue) {
     }
 }
 
-std::size_t get_used_memory(const py::object& syclobj) {
-    const auto& device = get_queue_from_python(syclobj).get_device();
-    std::size_t total_memory = device.get_info<sycl::info::device::global_mem_size>();
-    std::size_t free_memory = device.get_info<sycl::ext::intel::info::device::free_memory>();
-    return total_memory - free_memory;
-}
-
 std::uint32_t get_device_id(const dp_policy_t& policy) {
     const auto& queue = policy.get_queue();
     return get_device_id(queue);

--- a/onedal/common/sycl_interfaces.hpp
+++ b/onedal/common/sycl_interfaces.hpp
@@ -51,7 +51,6 @@ using dp_policy_t = detail::data_parallel_policy;
 
 std::uint32_t get_device_id(const sycl::queue& queue);
 std::uint32_t get_device_id(const dp_policy_t& policy);
-std::size_t get_used_memory(const py::object& syclobj);
 std::string get_device_name(const dp_policy_t& policy);
 std::string get_device_name(const sycl::device& device);
 


### PR DESCRIPTION
## Description

Memory leak testing was removed in #2887, but only removed the testing. Related GPU memory leak testing pybind11 code was not removed. This removes the vestigial code.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
