### PR TITLE
Utilize native `to_table` functionality in `onedal.basic_statistics.IncrementalBasicStatistics`

### DIFF
--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -102,7 +102,7 @@ class IncrementalBasicStatistics(BasicStatistics):
         return data
 
     @supports_queue
-    def partial_fit(self, X, dtype, sample_weight=None, queue=None):
+    def partial_fit(self, X, sample_weight=None, queue=None):
         """Generate partial statistics from batch data in `_partial_result`.
 
         Parameters
@@ -110,10 +110,6 @@ class IncrementalBasicStatistics(BasicStatistics):
         X : array-like of shape (n_samples, n_features)
             Training data batch, where `n_samples` is the number of samples
             in the batch, and `n_features` is the number of features.
-
-        dtype : np.dtype
-            DType of 'X', as a NumPy dtype or as otherwise a class that
-            would be recognized by the pybind11 module.
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample.
@@ -135,7 +131,7 @@ class IncrementalBasicStatistics(BasicStatistics):
         X_table, sample_weight_table = to_table(X, sample_weight, queue=queue)
 
         if not hasattr(self, "_onedal_params"):
-            self._onedal_params = self._get_onedal_params(False, dtype=dtype)
+            self._onedal_params = self._get_onedal_params(False, dtype=X_table.dtype)
 
         self._partial_result = self.partial_compute(
             self._onedal_params, self._partial_result, X_table, sample_weight_table

--- a/onedal/basic_statistics/incremental_basic_statistics.py
+++ b/onedal/basic_statistics/incremental_basic_statistics.py
@@ -113,7 +113,7 @@ class IncrementalBasicStatistics(BasicStatistics):
 
         dtype : np.dtype
             DType of 'X', as a NumPy dtype or as otherwise a class that
-            would be recognize by the pybind11 module.
+            would be recognized by the pybind11 module.
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample.

--- a/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -86,9 +86,7 @@ def test_single_option_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(
-                data_split[i], weights_split[i], queue=queue
-            )
+            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
         else:
             incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()
@@ -126,9 +124,7 @@ def test_multiple_options_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(
-                data_split[i], weights_split[i], queue=queue
-            )
+            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
         else:
             incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()
@@ -176,9 +172,7 @@ def test_all_option_on_random_data(
 
     for i in range(num_batches):
         if weighted:
-            incbs.partial_fit(
-                data_split[i], weights_split[i], queue=queue
-            )
+            incbs.partial_fit(data_split[i], weights_split[i], queue=queue)
         else:
             incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()

--- a/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/onedal/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -39,9 +39,9 @@ def test_multiple_options_on_gold_data(queue, weighted, dtype):
     incbs = IncrementalBasicStatistics()
     for i in range(2):
         if weighted:
-            incbs.partial_fit(X_split[i], np.dtype(dtype), weights_split[i], queue=queue)
+            incbs.partial_fit(X_split[i], weights_split[i], queue=queue)
         else:
-            incbs.partial_fit(X_split[i], np.dtype(dtype), queue=queue)
+            incbs.partial_fit(X_split[i], queue=queue)
 
     result = incbs.finalize_fit()
 
@@ -87,10 +87,10 @@ def test_single_option_on_random_data(
     for i in range(num_batches):
         if weighted:
             incbs.partial_fit(
-                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+                data_split[i], weights_split[i], queue=queue
             )
         else:
-            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
+            incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()
 
     res = getattr(result, result_option + "_")
@@ -127,10 +127,10 @@ def test_multiple_options_on_random_data(
     for i in range(num_batches):
         if weighted:
             incbs.partial_fit(
-                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+                data_split[i], weights_split[i], queue=queue
             )
         else:
-            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
+            incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()
 
     res_mean, res_max, res_sum = result.mean_, result.max_, result.sum_
@@ -177,10 +177,10 @@ def test_all_option_on_random_data(
     for i in range(num_batches):
         if weighted:
             incbs.partial_fit(
-                data_split[i], np.dtype(dtype), weights_split[i], queue=queue
+                data_split[i], weights_split[i], queue=queue
             )
         else:
-            incbs.partial_fit(data_split[i], np.dtype(dtype), queue=queue)
+            incbs.partial_fit(data_split[i], queue=queue)
     result = incbs.finalize_fit()
 
     if weighted:
@@ -215,8 +215,8 @@ def test_incremental_estimator_pickle(queue, dtype):
     X = gen.uniform(low=-0.3, high=+0.7, size=(10, 10))
     X = X.astype(dtype)
     X_split = np.array_split(X, 2)
-    incbs.partial_fit(X_split[0], np.dtype(dtype), queue=queue)
-    incbs_loaded.partial_fit(X_split[0], np.dtype(dtype), queue=queue)
+    incbs.partial_fit(X_split[0], queue=queue)
+    incbs_loaded.partial_fit(X_split[0], queue=queue)
 
     assert incbs._need_to_finalize == True
     assert incbs_loaded._need_to_finalize == True
@@ -258,8 +258,8 @@ def test_incremental_estimator_pickle(queue, dtype):
     )
     assert_allclose(partial_sum_squares_centered, partial_sum_squares_centered_loaded)
 
-    incbs.partial_fit(X_split[1], np.dtype(dtype), queue=queue)
-    incbs_loaded.partial_fit(X_split[1], np.dtype(dtype), queue=queue)
+    incbs.partial_fit(X_split[1], queue=queue)
+    incbs_loaded.partial_fit(X_split[1], queue=queue)
     assert incbs._need_to_finalize == True
     assert incbs_loaded._need_to_finalize == True
 

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -207,9 +207,7 @@ class IncrementalBasicStatistics(oneDALEstimator, BaseEstimator):
                 result_options=self.result_options
             )
 
-        self._onedal_estimator.partial_fit(
-            X, sample_weight=sample_weight, queue=queue
-        )
+        self._onedal_estimator.partial_fit(X, sample_weight=sample_weight, queue=queue)
         self._need_to_finalize = True
 
     def _onedal_fit(self, X, sample_weight=None, queue=None):

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -37,7 +37,6 @@ if sklearn_check_version("1.9"):
         check_same_namespace,
         get_namespace_and_device,
         move_to,
-        _matching_numpy_dtype,
     )
 
 import numbers
@@ -208,13 +207,8 @@ class IncrementalBasicStatistics(oneDALEstimator, BaseEstimator):
                 result_options=self.result_options
             )
 
-        if sklearn_check_version("1.9"):
-            dtype = _matching_numpy_dtype(X, xp=xp)
-        else:
-            dtype = X.dtype
-
         self._onedal_estimator.partial_fit(
-            X, dtype, sample_weight=sample_weight, queue=queue
+            X, sample_weight=sample_weight, queue=queue
         )
         self._need_to_finalize = True
 


### PR DESCRIPTION
## Description

Changing implementation from #3142 to follow implementations in other onedal incremental estimators (covariance, PCA, linear regression, etc.). In general data is converted to tables, then onedal parameters are set (chronologically in the flow of a onedal module estimator). Functionality introduced in #2195 which creates a numpy dtype `dtype` attribute (history and discussion of it can be found there.
