### PR TITLE
[maintenance] fix C++ codecov coverage

### DIFF
--- a/.github/scripts/generate_coverage_reports.sh
+++ b/.github/scripts/generate_coverage_reports.sh
@@ -30,7 +30,7 @@ if [[ -n "${SKLEARNEX_GCOV}" ]]; then
         GCOV_EXE="gcov"
     fi
     echo $GCOV_EXE
-    FILTER=$(realpath ./onedal).*
+    FILTER=.*onedal/.*
     echo $FILTER
     
     NUMPY_TEST=$(python -m pip freeze | grep numpy)
@@ -39,7 +39,7 @@ if [[ -n "${SKLEARNEX_GCOV}" ]]; then
     # the build numpy, this must be previously set as NUMPY_BUILD
     python -m pip install gcovr $NUMPY_BUILD
     
-    gcovr --gcov-executable "${GCOV_EXE}" -r . -v --lcov --filter "${FILTER}" -o coverage_cpp_"${1}".info
+    gcovr --gcov-executable "${GCOV_EXE}" -r . -v --lcov --filter "${FILTER}" --gcov-object-directory build/ --gcov-ignore-errors=source_not_found -o coverage_cpp_"${1}".info
     
     # reinstall previous numpy
     python -m pip install $NUMPY_TEST

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -137,6 +137,8 @@ if(IFACE STREQUAL "host")
     endif()
 
     if(SKLEARNEX_GCOV)
+        # Disable precompile headers as this causes issues in header coverage generation
+        set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
         if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
             if(WIN32)
                 set(CMAKE_CXX_FLAGS "/clang:--coverage ${CMAKE_CXX_FLAGS}")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -204,6 +204,8 @@ elseif(IFACE_IS_DPC OR IFACE_IS_SPMD_DPC)
     endif()
 
     if(SKLEARNEX_GCOV)
+        # Disable precompile headers as this causes issues in header coverage generation
+        set(CMAKE_DISABLE_PRECOMPILE_HEADERS ON)
         if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND WIN32)
             set(CMAKE_CXX_FLAGS "/clang:-Xarch_host /clang:--coverage ${CMAKE_CXX_FLAGS}")
             list(APPEND ONEDAL_LIBRARIES "clang_rt.profile-x86_64.lib")


### PR DESCRIPTION
## Description

we lost access of the C++ coverage at some point. This was due to changes in gcovr (by the looks of it). This adds some specificity and flexibility to get gcov files back.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
