### PR TITLE
[maintenance] remove unused `k_means` function from `onedal.cluster`

### DIFF
--- a/onedal/cluster/__init__.py
+++ b/onedal/cluster/__init__.py
@@ -17,9 +17,9 @@
 from daal4py.sklearn._utils import daal_check_version
 
 from .dbscan import DBSCAN
-from .kmeans import KMeans, k_means
+from .kmeans import KMeans
 
-__all__ = ["DBSCAN", "KMeans", "k_means"]
+__all__ = ["DBSCAN", "KMeans"]
 
 if daal_check_version((2023, "P", 200)):
     from .kmeans_init import KMeansInit, kmeans_plusplus

--- a/onedal/cluster/kmeans.py
+++ b/onedal/cluster/kmeans.py
@@ -363,36 +363,3 @@ class KMeans(_BaseKMeans):
 
     def fit_transform(self, X, y=None, queue=None):
         return self.fit(X, queue=queue).transform(X)
-
-
-def k_means(
-    X,
-    n_clusters,
-    *,
-    init="k-means++",
-    n_init="auto",
-    max_iter=300,
-    verbose=False,
-    tol=1e-4,
-    random_state=None,
-    copy_x=True,
-    algorithm="lloyd",
-    return_n_iter=False,
-    queue=None,
-):
-    est = KMeans(
-        n_clusters=n_clusters,
-        init=init,
-        n_init=n_init,
-        max_iter=max_iter,
-        verbose=verbose,
-        tol=tol,
-        random_state=random_state,
-        copy_x=copy_x,
-        algorithm=algorithm,
-    ).fit(X, queue=queue)
-
-    if return_n_iter:
-        return est.cluster_centers_, est.labels_, est.inertia_, est.n_iter_
-    else:
-        return est.cluster_centers_, est.labels_, est.inertia_


### PR DESCRIPTION
## Description

Remove unused code for simplicity, code uniformity, and brevity.  This has no other precedent and is untested, no code coverage, and no testing.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
