### PR TITLE
[maintenance] Remove unnecessary base class in `onedal.linear_model.LogisticRegression`

### DIFF
--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -27,9 +27,17 @@ from ..datatypes import from_table, to_table
 from ..utils.validation import _check_n_features, _is_csr, _num_features
 
 
-class BaseLogisticRegression(metaclass=ABCMeta):
-    @abstractmethod
-    def __init__(self, tol, C, fit_intercept, solver, max_iter, algorithm):
+class LogisticRegression(metaclass=ABCMeta):
+
+    def __init__(
+        self,
+        tol=1e-4,
+        C=1.0,
+        fit_intercept=True,
+        solver="newton-cg",
+        max_iter=100,
+        algorithm="dense_batch",
+    ):
         self.tol = tol
         self.C = C
         self.fit_intercept = fit_intercept
@@ -145,26 +153,3 @@ class BaseLogisticRegression(metaclass=ABCMeta):
         result = self._infer(X, queue)
         y = from_table(result.probabilities, like=X)
         return y
-
-
-class LogisticRegression(BaseLogisticRegression):
-
-    def __init__(
-        self,
-        tol=1e-4,
-        C=1.0,
-        fit_intercept=True,
-        solver="newton-cg",
-        max_iter=100,
-        *,
-        algorithm="dense_batch",
-        **kwargs,
-    ):
-        super().__init__(
-            tol=tol,
-            C=C,
-            fit_intercept=fit_intercept,
-            solver=solver,
-            max_iter=max_iter,
-            algorithm=algorithm,
-        )


### PR DESCRIPTION
## Description

Continuing to cut things down, this abstraction is also unnecessary and does not match other implementations.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
