### PR TITLE
[maintenance] use inheritance to handle spmd support in `LogisticRegression`

### DIFF
--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -255,10 +255,6 @@ if daal_check_version((2024, "P", 1)):
             )
 
         def _onedal_score(self, X, y, sample_weight=None, queue=None):
-            if "spmd" in self._onedal_LogisticRegression.__module__:
-                raise RuntimeError(
-                    "score method is not supported for LogisticRegression SPMD estimator."
-                )
             return accuracy_score(
                 y, self._onedal_predict(X, queue=queue), sample_weight=sample_weight
             )
@@ -414,12 +410,6 @@ if daal_check_version((2024, "P", 1)):
 
         def _onedal_fit(self, X, y, sample_weight=None, queue=None):
             if queue is None or queue.sycl_device.is_cpu:
-                # We don't use onedal backend for CPU, so we need an additional check here
-                if "spmd" in self._onedal_LogisticRegression.__module__:
-                    raise RuntimeError(
-                        "Executing functions from SPMD backend requires a queue"
-                    )
-
                 # TODO add array-api support for CPU
                 return self._onedal_cpu_fit(X, y, sample_weight)
             assert sample_weight is None
@@ -471,12 +461,6 @@ if daal_check_version((2024, "P", 1)):
 
         # This should only be called when 'X' is on CPU
         def _error_out_on_incompatible_devices(self, X, method_name: str) -> None:
-            # We don't use onedal backend for CPU, so we need an additional check here
-            if "spmd" in self._onedal_LogisticRegression.__module__:
-                raise RuntimeError(
-                    "Executing functions from SPMD backend requires a queue"
-                )
-
             # This can happen when fitting on GPU and then passing a CPU array to predict
             if not isinstance(self.coef_, np.ndarray) and not issparse(self.coef_):
                 if sklearn_check_version("1.9"):

--- a/sklearnex/spmd/linear_model/logistic_regression.py
+++ b/sklearnex/spmd/linear_model/logistic_regression.py
@@ -31,12 +31,11 @@ class LogisticRegression(LogisticRegression_Batch):
             )
         return super()._onedal_fit(X, y, sample_weight=sample_weight, queue=queue)
 
-    def _onedal_predict(self, X, queue=None):
-        if queue is None or queue.sycl_device.is_cpu:
-            raise RuntimeError(
-                "Executing functions from SPMD backend requires a queue"
-            )
-        return super()._onedal_predict(X, queue=queue)
+    def _error_out_on_incompatible_devices(self, X, method_name: str) -> None:
+        # custom function in LogisticRegression which will trigger for cpu data
+        raise RuntimeError(
+            "Executing functions from SPMD backend requires a queue"
+        )
     
     def _onedal_score(self, X, y, sample_weight=None, queue=None):
         raise RuntimeError(

--- a/sklearnex/spmd/linear_model/logistic_regression.py
+++ b/sklearnex/spmd/linear_model/logistic_regression.py
@@ -32,7 +32,7 @@ class LogisticRegression(LogisticRegression_Batch):
     def _error_out_on_incompatible_devices(self, X, method_name: str) -> None:
         # custom function in LogisticRegression which will trigger for cpu data
         raise RuntimeError("Executing functions from SPMD backend requires a queue")
-    
+
     def _onedal_score(self, X, y, sample_weight=None, queue=None):
         raise RuntimeError(
             "score method is not supported for LogisticRegression SPMD estimator."

--- a/sklearnex/spmd/linear_model/logistic_regression.py
+++ b/sklearnex/spmd/linear_model/logistic_regression.py
@@ -26,19 +26,14 @@ class LogisticRegression(LogisticRegression_Batch):
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
         if queue is None or queue.sycl_device.is_cpu:
             # We don't use onedal backend for CPU, so we need an additional check here
-            raise RuntimeError(
-                "Executing functions from SPMD backend requires a queue"
-            )
+            raise RuntimeError("Executing functions from SPMD backend requires a queue")
         return super()._onedal_fit(X, y, sample_weight=sample_weight, queue=queue)
 
     def _error_out_on_incompatible_devices(self, X, method_name: str) -> None:
         # custom function in LogisticRegression which will trigger for cpu data
-        raise RuntimeError(
-            "Executing functions from SPMD backend requires a queue"
-        )
+        raise RuntimeError("Executing functions from SPMD backend requires a queue")
     
     def _onedal_score(self, X, y, sample_weight=None, queue=None):
         raise RuntimeError(
             "score method is not supported for LogisticRegression SPMD estimator."
         )
-

--- a/sklearnex/spmd/linear_model/logistic_regression.py
+++ b/sklearnex/spmd/linear_model/logistic_regression.py
@@ -22,3 +22,24 @@ from ...linear_model import LogisticRegression as LogisticRegression_Batch
 class LogisticRegression(LogisticRegression_Batch):
     __doc__ = LogisticRegression_Batch.__doc__
     _onedal_LogisticRegression = staticmethod(onedal_LogisticRegression)
+
+    def _onedal_fit(self, X, y, sample_weight=None, queue=None):
+        if queue is None or queue.sycl_device.is_cpu:
+            # We don't use onedal backend for CPU, so we need an additional check here
+            raise RuntimeError(
+                "Executing functions from SPMD backend requires a queue"
+            )
+        return super()._onedal_fit(X, y, sample_weight=sample_weight, queue=queue)
+
+    def _onedal_predict(self, X, queue=None):
+        if queue is None or queue.sycl_device.is_cpu:
+            raise RuntimeError(
+                "Executing functions from SPMD backend requires a queue"
+            )
+        return super()._onedal_predict(X, queue=queue)
+    
+    def _onedal_score(self, X, y, sample_weight=None, queue=None):
+        raise RuntimeError(
+            "score method is not supported for LogisticRegression SPMD estimator."
+        )
+


### PR DESCRIPTION
## Description

Rather than checking for the module, use inheritance and `super` to do the same thing (which is more recommended, separates spmd code and is easier to read and manage).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
