### PR TITLE
MAINT: Skip RF float32 test on GPU that fails due to tolerances

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -636,6 +636,9 @@ gpu:
   - tests/test_common.py::test_estimators[RandomForestClassifier(n_estimators=5)-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[ExtraTreesClassifier(n_estimators=5)-check_class_weight_classifiers]
 
+  # Fails for float32 due to small numeric tolerances in the order of 1e-6
+  - ensemble/tests/test_forest.py::test_memory_layout[float32
+
   # --------------------------------------------------------
   # The following tests fail at collection time, so they cannot be deselected with --deselect and must be ignored with --ignore.
 ignored_tests:


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Skips a test that will start failing due to small floating point differences after this fix:
https://github.com/uxlfoundation/oneDAL/pull/3649#issuecomment-4590964782

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

</details>
