### PR TITLE
[maintenance] Remove onedal/sklearnex functionality mixing in `KNeighborsClassifier.predict` using `from_table`

### DIFF
--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -196,7 +196,7 @@ class KNeighborsClassifier(NeighborsBase):
         return self.train(params, X_table, y_table).model
 
     @supports_queue
-    def predict(self, X, params, queue=None):
+    def predict(self, X, queue=None):
         X_table = to_table(X, queue=queue)
         # pass Y as non-None to trigger 'responses'
         params = self._get_onedal_params(X_table, 0)

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -202,7 +202,7 @@ class KNeighborsClassifier(NeighborsBase):
         params["fptype"] = X.dtype
         result = self.infer(params, model, X)
 
-        return result
+        return from_table(result.responses, like=X)
 
     @supports_queue
     def fit(self, X, y, queue=None):

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -195,12 +195,12 @@ class KNeighborsClassifier(NeighborsBase):
         params = self._get_onedal_params(X_table, y)
         return self.train(params, X_table, y_table).model
 
-    def _onedal_predict(self, model, X, params):
-        X = to_table(X, queue=QM.get_global_queue())
-        if "responses" not in params["result_option"]:
-            params["result_option"] += "|responses"
-        params["fptype"] = X.dtype
-        result = self.infer(params, model, X)
+    @supports_queue
+    def predict(self, X, params, queue=None):
+        X_table = to_table(X, queue=queue)
+        # pass Y as non-None to trigger 'responses'
+        params = self._get_onedal_params(X_table, 0)
+        result = self.infer(params, self._onedal_model, X)
 
         return from_table(result.responses, like=X)
 

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -210,7 +210,21 @@ class KNeighborsClassifier(NeighborsBase):
 
     @supports_queue
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
-        return self._kneighbors(X, n_neighbors, return_distance)
+        _check_is_fitted(self)
+
+        if n_neighbors is None:
+            n_neighbors = self.n_neighbors
+
+        if X is None:
+            X = self._fit_X
+
+        X_table = to_table(X)
+        params = self._get_onedal_params(X, n_neighbors=n_neighbors)
+        prediction_results = self.infer(self._onedal_model, X_table, params)
+        distances = from_table(prediction_results.distances, like=X)
+        indices = from_table(prediction_results.indices, like=X)
+
+        return distances, indices if return_distance else indices
 
 
 class KNeighborsRegressor(NeighborsBase):

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -23,7 +23,6 @@ from sklearn.utils.validation import check_is_fitted
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
 from daal4py.sklearn.utils.validation import get_requires_y_tag
-from onedal.datatypes import from_table
 from onedal.neighbors import KNeighborsClassifier as onedal_KNeighborsClassifier
 from onedal.utils._array_api import _is_numpy_namespace
 from onedal.utils.validation import _check_classification_targets
@@ -274,12 +273,10 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             if sklearn_check_version("1.9"):
                 check_same_namespace(X, self, attribute="_fit_X", method="predict")
 
-        params = self._onedal_estimator._get_onedal_params(X)
-        params["result_option"] = "responses"
         result = self._onedal_estimator._onedal_predict(
             self._onedal_estimator._onedal_model, X, params
         )
-        responses = from_table(result.responses, like=X)
+        responses = self._onedal_estimator.responses
         if sklearn_check_version("1.9"):
             xp, _, device = get_namespace_and_device(self.classes_)
             responses = move_to(responses, xp=xp, device=device)

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -273,7 +273,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             if sklearn_check_version("1.9"):
                 check_same_namespace(X, self, attribute="_fit_X", method="predict")
 
-        responses = self._onedal_estimator.predict(X, params)
+        responses = self._onedal_estimator.predict(X)
 
         if sklearn_check_version("1.9"):
             xp, _, device = get_namespace_and_device(self.classes_)

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -273,10 +273,8 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             if sklearn_check_version("1.9"):
                 check_same_namespace(X, self, attribute="_fit_X", method="predict")
 
-        result = self._onedal_estimator._onedal_predict(
-            self._onedal_estimator._onedal_model, X, params
-        )
-        responses = self._onedal_estimator.responses
+        responses = self._onedal_estimator.predict(X, params)
+
         if sklearn_check_version("1.9"):
             xp, _, device = get_namespace_and_device(self.classes_)
             responses = move_to(responses, xp=xp, device=device)


### PR DESCRIPTION
## Description

`KNeighborsClassifier` uses the onedal `from_table` functionality and internal parameter setting functionality in a way which is different from the rest of the codebase.  This makes it similar to all other uses in the codebase.  This is not a final solution, as a refactoring of the `_get_onedal_params` needs to be done, and therefore includes a temporary (but limited) solution.

Follow up: evaluate how to use a _create_model function in the classifier, as a `model` is available for this specific estimator (allowing for the definition of a `_create_model` function).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
