### PR TITLE
[maintenance] clean up `onedal.neighbors.*.fit` to conform to codebase norms

### DIFF
--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -200,10 +200,6 @@ class KNeighborsClassifier(NeighborsBase):
         return result
 
     @supports_queue
-    def fit(self, X, y, queue=None):
-        return self._fit(X, y)
-
-    @supports_queue
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
         return self._kneighbors(X, n_neighbors, return_distance)
 

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -117,7 +117,7 @@ class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
         self._fit_method = super()._parse_auto_method(
             self.algorithm, self.n_samples_fit_, self.n_features_in_
         )
-        
+
         return self
 
     def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
@@ -189,7 +189,7 @@ class KNeighborsClassifier(NeighborsBase):
         self._onedal_model = self.train(params, X_table, y_table).model
         # model contains no attributes which need to be converted
         return self
-    
+
     def _onedal_predict(self, model, X, params):
         X = to_table(X, queue=QM.get_global_queue())
         if "responses" not in params["result_option"]:
@@ -250,7 +250,7 @@ class KNeighborsRegressor(NeighborsBase):
         else:
             self._onedal_model = self.train_search(params, X_table).model
         return self
-    
+
     def _onedal_predict(self, model, X, params):
         assert self._onedal_model is not None, "Model is not trained"
 

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -24,7 +24,7 @@ from ..common._estimator_checks import _check_is_fitted
 from ..datatypes import from_table, to_table
 
 
-class NeighborsBase(metaclass=ABCMeta):
+class NeighborsCommonBase(metaclass=ABCMeta):
     def __init__(self):
         self.requires_y = False
         self.n_neighbors = None

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -183,7 +183,7 @@ class KNeighborsClassifier(NeighborsBase):
     @supports_queue
     def fit(self, X, y, queue=None):
         # prepare for fitting using common fit routines
-        super.fit(X, y)
+        super().fit(X, y)
         X_table, y_table = to_table(X, y, queue=queue)
         params = self._get_onedal_params(X_table, y)
         self._onedal_model = self.train(params, X_table, y_table).model

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -24,7 +24,7 @@ from ..common._estimator_checks import _check_is_fitted
 from ..datatypes import from_table, to_table
 
 
-class NeighborsCommonBase(metaclass=ABCMeta):
+class NeighborsBase(metaclass=ABCMeta):
     def __init__(self):
         self.requires_y = False
         self.n_neighbors = None
@@ -58,9 +58,6 @@ class NeighborsCommonBase(metaclass=ABCMeta):
 
     @abstractmethod
     def infer(self, *args, **kwargs): ...
-
-    @abstractmethod
-    def _onedal_fit(self, X, y): ...
 
     def _get_onedal_params(self, X, y=None, n_neighbors=None):
         class_count = 0 if self.classes_ is None else self.classes_.shape[0]
@@ -102,7 +99,7 @@ class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
         self.p = p
         self.metric_params = metric_params
 
-    def _fit(self, X, y):
+    def fit(self, X, y):
         self._onedal_model = None
         self._tree = None
         if not hasattr(self, "_shape"):
@@ -120,13 +117,8 @@ class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
         self._fit_method = super()._parse_auto_method(
             self.algorithm, self.n_samples_fit_, self.n_features_in_
         )
-
-        result = self._onedal_fit(X, y)
-
-        self._onedal_model = result
-        result = self
-
-        return result
+        
+        return self
 
     def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         """Raw kneighbors: calls C++ backend and returns from_table results.
@@ -188,13 +180,16 @@ class KNeighborsClassifier(NeighborsBase):
     @bind_default_backend("neighbors.classification")
     def infer(self, *args, **kwargs): ...
 
-    def _onedal_fit(self, X, y):
-        # global queue is set as per user configuration (`target_offload`) or from data prior to calling this internal function
-        queue = QM.get_global_queue()
+    @supports_queue
+    def fit(self, X, y, queue=None):
+        # prepare for fitting using common fit routines
+        super.fit(X, y)
         X_table, y_table = to_table(X, y, queue=queue)
         params = self._get_onedal_params(X_table, y)
-        return self.train(params, X_table, y_table).model
-
+        self._onedal_model = self.train(params, X_table, y_table).model
+        # model contains no attributes which need to be converted
+        return self
+    
     def _onedal_predict(self, model, X, params):
         X = to_table(X, queue=QM.get_global_queue())
         if "responses" not in params["result_option"]:
@@ -247,17 +242,19 @@ class KNeighborsRegressor(NeighborsBase):
     @bind_default_backend("neighbors.regression")
     def infer(self, *args, **kwargs): ...
 
-    def _onedal_fit(self, X, y):
-        queue = QM.get_global_queue()
+    @supports_queue
+    def fit(self, X, y, queue=None):
+        super().fit(X, y)
         gpu_device = queue is not None and getattr(queue.sycl_device, "is_gpu", False)
         X_table, y_table = to_table(X, y, queue=queue)
         params = self._get_onedal_params(X_table, y)
 
         if gpu_device:
-            return self.train(params, X_table, y_table).model
+            self._onedal_model = self.train(params, X_table, y_table).model
         else:
-            return self.train_search(params, X_table).model
-
+            self._onedal_model = self.train_search(params, X_table).model
+        return self
+    
     def _onedal_predict(self, model, X, params):
         assert self._onedal_model is not None, "Model is not trained"
 
@@ -273,10 +270,6 @@ class KNeighborsRegressor(NeighborsBase):
             return self.infer(params, self._onedal_model, X)
         else:
             return self.infer_search(params, self._onedal_model, X)
-
-    @supports_queue
-    def fit(self, X, y, queue=None):
-        return self._fit(X, y)
 
     @supports_queue
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
@@ -329,21 +322,19 @@ class NearestNeighbors(NeighborsBase):
     @bind_default_backend("neighbors.search")
     def infer(self, *arg, **kwargs): ...
 
-    def _onedal_fit(self, X, y):
-        queue = QM.get_global_queue()
+    @supports_queue
+    def fit(self, X, y=None, queue=None):
+        super().fit(X, y)
         X_table, _ = to_table(X, y, queue=queue)
         params = self._get_onedal_params(X_table, y)
-        return self.train(params, X_table).model
+        self._onedal_model = self.train(params, X_table).model
+        return self
 
     def _onedal_predict(self, model, X, params):
         X = to_table(X, queue=QM.get_global_queue())
 
         params["fptype"] = X.dtype
         return self.infer(params, model, X)
-
-    @supports_queue
-    def fit(self, X, y=None, queue=None):
-        return self._fit(X, y)
 
     @supports_queue
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):


### PR DESCRIPTION
## Description
---
Remove some stuff that can be handled by inheritance, use `supports_queue` wrapper, delete the `_onedal_fit` function, remove some unnecessary assignments of variables.

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
