### PR TITLE
[maintenance] Remove unnecessary inheritance in `onedal.neighbors` Estimators

### DIFF
--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -24,15 +24,26 @@ from ..common._estimator_checks import _check_is_fitted
 from ..datatypes import from_table, to_table
 
 
-class NeighborsCommonBase(metaclass=ABCMeta):
-    def __init__(self):
+class NeighborsBase(metaclass=ABCMeta):
+    def __init__(
+        self,
+        n_neighbors=None,
+        radius=None,
+        algorithm="auto",
+        metric="minkowski",
+        p=2,
+        metric_params=None,
+    ):
+        self.n_neighbors = n_neighbors
+        self.radius = radius
+        self.algorithm = algorithm
+        self.metric = metric
+        self.p = p
+        self.metric_params = metric_params
         self.requires_y = False
-        self.n_neighbors = None
-        self.metric = None
         self.classes_ = None
         self.effective_metric_ = None
         self._fit_method = None
-        self.radius = None
         self.effective_metric_params_ = None
         self._onedal_model = None
 
@@ -83,24 +94,6 @@ class NeighborsCommonBase(metaclass=ABCMeta):
             "metric_params": self.effective_metric_params_,
             "result_option": "indices|distances" if y is None else "responses",
         }
-
-
-class NeighborsBase(NeighborsCommonBase, metaclass=ABCMeta):
-    def __init__(
-        self,
-        n_neighbors=None,
-        radius=None,
-        algorithm="auto",
-        metric="minkowski",
-        p=2,
-        metric_params=None,
-    ):
-        self.n_neighbors = n_neighbors
-        self.radius = radius
-        self.algorithm = algorithm
-        self.metric = metric
-        self.p = p
-        self.metric_params = metric_params
 
     def _fit(self, X, y):
         self._onedal_model = None
@@ -165,7 +158,6 @@ class KNeighborsClassifier(NeighborsBase):
         p=2,
         metric="minkowski",
         metric_params=None,
-        **kwargs,
     ):
         super().__init__(
             n_neighbors=n_neighbors,
@@ -173,7 +165,6 @@ class KNeighborsClassifier(NeighborsBase):
             metric=metric,
             p=p,
             metric_params=metric_params,
-            **kwargs,
         )
         self.weights = weights
 
@@ -223,7 +214,6 @@ class KNeighborsRegressor(NeighborsBase):
         p=2,
         metric="minkowski",
         metric_params=None,
-        **kwargs,
     ):
         super().__init__(
             n_neighbors=n_neighbors,
@@ -231,7 +221,6 @@ class KNeighborsRegressor(NeighborsBase):
             metric=metric,
             p=p,
             metric_params=metric_params,
-            **kwargs,
         )
         self.weights = weights
 
@@ -311,7 +300,6 @@ class NearestNeighbors(NeighborsBase):
         p=2,
         metric="minkowski",
         metric_params=None,
-        **kwargs,
     ):
         super().__init__(
             n_neighbors=n_neighbors,
@@ -319,7 +307,6 @@ class NearestNeighbors(NeighborsBase):
             metric=metric,
             p=p,
             metric_params=metric_params,
-            **kwargs,
         )
         self.requires_y = False
 

--- a/onedal/neighbors/neighbors.py
+++ b/onedal/neighbors/neighbors.py
@@ -110,7 +110,7 @@ class NeighborsBase(metaclass=ABCMeta):
         self.n_samples_fit_ = X.shape[0]
         self.n_features_in_ = X.shape[1]
         self._fit_X = X
-        self._fit_method = super()._parse_auto_method(
+        self._fit_method = self._parse_auto_method(
             self.algorithm, self.n_samples_fit_, self.n_features_in_
         )
 
@@ -138,7 +138,7 @@ class NeighborsBase(metaclass=ABCMeta):
         if X is None:
             X = self._fit_X
 
-        params = super()._get_onedal_params(X, n_neighbors=n_neighbors)
+        params = self._get_onedal_params(X, n_neighbors=n_neighbors)
         prediction_results = self._onedal_predict(self._onedal_model, X, params)
         distances = from_table(prediction_results.distances, like=X)
         indices = from_table(prediction_results.indices, like=X)


### PR DESCRIPTION
## Description

Delete the `NeighborsCommonBase` object and remove `**kwargs` catchall. The parameters should be explicit.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
