### PR TITLE
[CI,fix] lockstep scikit-learn version in `meta.yml` testing with `requirements-test.txt`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,9 +67,8 @@
       "customType": "regex",
       "fileMatch": ["(^|/)meta\\.ya?ml$"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*[\"']\\S+\\s+(?<currentValue><=?.*?)[\"']"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*[\"']\\S+\\s+<=(?<currentValue>[^\"']+)[\"']"
       ],
-      "rangeStrategy": "bump"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,6 +62,14 @@
       "matchStrings": ["pre-commit==(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "pre-commit",
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)meta\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*[\"']\\S+\\s+(?<currentValue><=?.*?)[\"']"
+      ],
+      "rangeStrategy": "bump"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,7 +65,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)meta\\.ya?ml$"],
+      "managerFilePatterns": ["(^|/)meta\\.ya?ml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*[\"']\\S+\\s+<=(?<currentValue>[^\"']+)[\"']"
       ],

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -69,7 +69,7 @@ requirements:
     - python
     - numpy
     # renovate: datasource=conda depName=conda-forge/scikit-learn
-    - "scikit-learn <= 1.8.0"
+    - "scikit-learn <=1.8.0"
     # dal-devel has run_exports on conda-forge, so no need to add it.
     - mpi * impi  # [not win]
     - packaging

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -68,7 +68,8 @@ requirements:
   run:
     - python
     - numpy
-    - scikit-learn
+    # renovate: datasource=conda depName=conda-forge/scikit-learn
+    - "scikit-learn <= 1.8.0"
     # dal-devel has run_exports on conda-forge, so no need to add it.
     - mpi * impi  # [not win]
     - packaging

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -68,14 +68,19 @@ requirements:
   run:
     - python
     - numpy
-    # renovate: datasource=conda depName=conda-forge/scikit-learn
-    - "scikit-learn <=1.8.0"
+    - scikit-learn
     # dal-devel has run_exports on conda-forge, so no need to add it.
     - mpi * impi  # [not win]
     - packaging
 
 test:
   requires:
+    # for QA we control the test version ceiling, which follows repository
+    # guidelines where sklearn support may exist but is not verified
+    # outside certain versions. Renovate is used to lockstep with
+    # requirements-test.txt
+    # renovate: datasource=conda depName=conda-forge/scikit-learn
+    - "scikit-learn <=1.8.0"
     - pyyaml
     - mpi * impi  # [not win]
     # DPC part of sklearnex is optional


### PR DESCRIPTION
## Description

Ideally should be merged before #3225 (though please note that current CI failures for WindowsCondaRecipe do not occur in that PR because its still using 1.8 from conda-forge.

It forces a sklearn version for testing to be below a certain value, this value matches the max value in `requirements-test.txt` and is then tracked by renovate.

We need to really consider how we control this meta.yml because it has been high maintenance for a long time, as versions are controlled in a very limited way. This is pretty frustrating, but should return CI to green by downgrading sklearn to 1.8 until it is properly upgraded in #3225.

NOTE: the method for using renovate follows the commentary approach, different than in other circumstances.  This simplifies future work in control, as the same renovate check can be used elsewhere.


---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
