### PR TITLE
[CI] Remove MacOS deselections from `deselected_tests.yml`

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -244,7 +244,6 @@ deselected_tests:
 
   # OOB scores in scikit-learn and oneDAL are different because of different random number generators
   - ensemble/tests/test_forest.py::test_forest_regressor_oob[True-X0-y0-0.7-array-ExtraTreesRegressor] >=1.3
-  - ensemble/tests/test_forest.py::test_importances[ExtraTreesRegressor-squared_error-float64] >=0.23 darwin
   - ensemble/tests/test_forest.py::test_forest_regressor_oob[X0-y0-0.7-array-ExtraTreesRegressor]
   - ensemble/tests/test_forest.py::test_warm_start_oob
   - ensemble/tests/test_forest.py::test_distribution


### PR DESCRIPTION
## Description

Common operation of Mac OS variants stopped years ago. Remove deselections related to Mac, as they are unverified and very stale. In this singular case, there exists a more expansive deselection of the same test, making it redundant.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
