### PR TITLE
[maintenance] delete `support_input_format` from `onedal.spmd` estimators

### DIFF
--- a/onedal/spmd/basic_statistics/basic_statistics.py
+++ b/onedal/spmd/basic_statistics/basic_statistics.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format
 from ...basic_statistics import BasicStatistics as BasicStatistics_Batch
 from ...common._backend import bind_spmd_backend
 
@@ -22,7 +21,3 @@ from ...common._backend import bind_spmd_backend
 class BasicStatistics(BasicStatistics_Batch):
     @bind_spmd_backend("basic_statistics")
     def compute(self, data, weights=None): ...
-
-    @support_input_format
-    def fit(self, data, sample_weight=None, queue=None):
-        return super().fit(data, sample_weight, queue=queue)

--- a/onedal/spmd/cluster/kmeans.py
+++ b/onedal/spmd/cluster/kmeans.py
@@ -16,7 +16,7 @@
 
 import numpy as np
 
-from ..._device_offload import support_input_format, supports_queue
+from ..._device_offload import supports_queue
 from ...cluster import KMeans as KMeans_Batch
 from ...cluster import KMeansInit as KMeansInit_Batch
 from ...common._backend import bind_spmd_backend
@@ -59,15 +59,3 @@ class KMeans(KMeans_Batch):
 
     @bind_spmd_backend("kmeans.clustering")
     def infer(self, params, model, centroids_table): ...
-
-    @support_input_format
-    def fit(self, X, y=None, queue=None):
-        return super().fit(X, y, queue=queue)
-
-    @support_input_format
-    def predict(self, X, queue=None):
-        return super().predict(X, queue=queue)
-
-    @support_input_format
-    def fit_predict(self, X, y=None, queue=None):
-        return super().fit_predict(X, queue=queue)

--- a/onedal/spmd/covariance/covariance.py
+++ b/onedal/spmd/covariance/covariance.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format
 from ...common._backend import bind_spmd_backend
 from ...covariance import EmpiricalCovariance as EmpiricalCovariance_Batch
 
@@ -26,7 +25,3 @@ class EmpiricalCovariance(EmpiricalCovariance_Batch):
 
     @bind_spmd_backend("covariance")
     def finalize_compute(self, params, partial_result): ...
-
-    @support_input_format
-    def fit(self, X, y=None, queue=None):
-        return super().fit(X, queue=queue)

--- a/onedal/spmd/decomposition/pca.py
+++ b/onedal/spmd/decomposition/pca.py
@@ -26,7 +26,3 @@ class PCA(PCABatch):
 
     @bind_spmd_backend("decomposition.dim_reduction")
     def finalize_train(self, *args, **kwargs): ...
-
-    @support_input_format
-    def fit(self, X, y=None, queue=None):
-        return super().fit(X, queue=queue)

--- a/onedal/spmd/linear_model/linear_model.py
+++ b/onedal/spmd/linear_model/linear_model.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format
 from ...common._backend import bind_spmd_backend
 from ...linear_model import LinearRegression as LinearRegression_Batch
 
@@ -29,11 +28,3 @@ class LinearRegression(LinearRegression_Batch):
 
     @bind_spmd_backend("linear_model.regression")
     def infer(self, params, model, X): ...
-
-    @support_input_format
-    def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue=queue)
-
-    @support_input_format
-    def predict(self, X, queue=None):
-        return super().predict(X, queue=queue)

--- a/onedal/spmd/linear_model/logistic_regression.py
+++ b/onedal/spmd/linear_model/logistic_regression.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format
 from ...common._backend import bind_spmd_backend
 from ...linear_model import LogisticRegression as LogisticRegression_Batch
 
@@ -26,15 +25,3 @@ class LogisticRegression(LogisticRegression_Batch):
 
     @bind_spmd_backend("logistic_regression.classification")
     def infer(self, params, X, model): ...
-
-    @support_input_format
-    def fit(self, X, y, queue=None):
-        return super().fit(X, y, queue=queue)
-
-    @support_input_format
-    def predict(self, X, queue=None, classes=None):
-        return super().predict(X, queue=queue, classes=classes)
-
-    @support_input_format
-    def predict_proba(self, X, queue=None):
-        return super().predict_proba(X, queue=queue)

--- a/onedal/spmd/neighbors/neighbors.py
+++ b/onedal/spmd/neighbors/neighbors.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format, supports_queue
+from ..._device_offload import supports_queue
 from ...common._backend import bind_spmd_backend
 from ...neighbors import KNeighborsClassifier as KNeighborsClassifier_Batch
 from ...neighbors import KNeighborsRegressor as KNeighborsRegressor_Batch
@@ -29,13 +29,11 @@ class KNeighborsClassifier(KNeighborsClassifier_Batch):
     @bind_spmd_backend("neighbors.classification")
     def infer(self, *args, **kwargs): ...
 
-    @support_input_format
     def fit(self, X, y, queue=None):
         # Store queue to use during inference if not provided (if X is none in kneighbors)
         self.spmd_queue_ = queue
         return super().fit(X, y, queue=queue)
 
-    @support_input_format
     @supports_queue
     def predict(self, X, queue=None):
         # SPMD classification: call the SPMD backend's inference directly
@@ -59,11 +57,9 @@ class KNeighborsClassifier(KNeighborsClassifier_Batch):
         responses = from_table(result.responses, like=X)
         return responses[:, 0]
 
-    @support_input_format
     def predict_proba(self, X, queue=None):
         raise NotImplementedError("predict_proba not supported in distributed mode.")
 
-    @support_input_format
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
         if queue is None:
             queue = getattr(self, "spmd_queue_", None)
@@ -86,7 +82,6 @@ class KNeighborsRegressor(KNeighborsRegressor_Batch):
     @bind_spmd_backend("neighbors.regression")
     def infer(self, *args, **kwargs): ...
 
-    @support_input_format
     @supports_queue
     def fit(self, X, y, queue=None):
         # Store queue to use during inference if not provided (if X is none in kneighbors)
@@ -99,7 +94,6 @@ class KNeighborsRegressor(KNeighborsRegressor_Batch):
                 "CPU. Consider running on it on GPU."
             )
 
-    @support_input_format
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
         if queue is None:
             queue = getattr(self, "spmd_queue_", None)
@@ -107,7 +101,6 @@ class KNeighborsRegressor(KNeighborsRegressor_Batch):
             X, n_neighbors=n_neighbors, return_distance=return_distance, queue=queue
         )
 
-    @support_input_format
     @supports_queue
     def predict(self, X, queue=None):
         # SPMD regression: call the SPMD backend's inference directly
@@ -146,13 +139,11 @@ class NearestNeighbors(NearestNeighbors_Batch):
     @bind_spmd_backend("neighbors.search")
     def infer(self, *args, **kwargs): ...
 
-    @support_input_format
     def fit(self, X, y=None, queue=None):
         # Store queue to use during inference if not provided (if X is none in kneighbors)
         self.spmd_queue_ = queue
         return super().fit(X, y, queue=queue)
 
-    @support_input_format
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True, queue=None):
         if queue is None:
             queue = getattr(self, "spmd_queue_", None)


### PR DESCRIPTION
## Description

The use of this wrapper (in `onedal._device_offload`) was to enable direct use of `onedal.spmd` estimators as `sklearnex.spmd` estimators. With the completion of the initial array API rollout, each of the `onedal.spmd` estimators has an equivalent `sklearnex.spmd` estimator based off of the `sklearnex` estimator instead. These `sklearnex` inherited estimators use `support_input_format` where necessary.

cc @ethanglaser (as I am not a pro on the spmd-side but I believe this to be true).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
