### PR TITLE
[maintenance] increase robustness in extension module searching in the `onedal` module

### DIFF
--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import pathlib as _pathlib
+import importlib
 import platform
 
 from daal4py.sklearn._utils import daal_check_version
@@ -64,7 +64,8 @@ class Backend:
 
 def _backend_binary_present(prefix: str) -> bool:
     """Return True if a backend extension binary with the given prefix exists."""
-    return any(_pathlib.Path(__file__).parent.glob(f"{prefix}*"))
+    spec = importlib.util.find_spec(f"{__package__}.{prefix}")
+    return spec is not None and spec.origin is not None
 
 
 if "Windows" in platform.system():


### PR DESCRIPTION
## Description

Use native python functionality to verify the existence of a extension module (instead of pathlib) as it is more exact. I had considered swapping logic to `ModuleNotFound` but it turns out windows/linux are inconsistent with respect to libraries and the use of that specific error (which hits this catch exactly).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
