### PR TITLE
[CI] Make test deselection logic more extensible

### DIFF
--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -73,14 +73,13 @@ def filter_by_version_and_platform(entry, sk_ver):
     return None
 
 
-def create_pytest_switches(
-    filename, absolute, reduced, public, gpu, preview, base_dir=None
-):
+def create_pytest_switches(filename, absolute, **kwargs):
     pytest_switches = []
     if os.path.exists(filename):
         with open(filename, "r") as fh:
             dt = yaml_load(fh, Loader=FullLoader)
 
+        base_dir = kwargs.pop("base_dir")
         sklearn_dir = os.path.dirname(sklearn.__file__)
 
         if absolute:
@@ -94,34 +93,14 @@ def create_pytest_switches(
             filter_by_version_and_platform(test_name, sklearn_version)
             for test_name in dt.get("deselected_tests", [])
         ]
-        if reduced:
-            filtered_deselection.extend(
-                [
-                    filter_by_version_and_platform(test_name, sklearn_version)
-                    for test_name in dt.get("reduced_tests", [])
-                ]
-            )
-        if public:
-            filtered_deselection.extend(
-                [
-                    filter_by_version_and_platform(test_name, sklearn_version)
-                    for test_name in dt.get("public", [])
-                ]
-            )
-        if gpu:
-            filtered_deselection.extend(
-                [
-                    filter_by_version_and_platform(test_name, sklearn_version)
-                    for test_name in dt.get("gpu", [])
-                ]
-            )
-        if preview:
-            filtered_deselection.extend(
-                [
-                    filter_by_version_and_platform(test_name, sklearn_version)
-                    for test_name in dt.get("preview", [])
-                ]
-            )
+        for group, flagged in kwargs.items():
+            if flagged:
+                filtered_deselection.extend(
+                    [
+                        filter_by_version_and_platform(test_name, sklearn_version)
+                        for test_name in dt.get(group, [])
+                    ]
+                )
         pytest_switches = []
         for test_name in filtered_deselection:
             if test_name:
@@ -159,11 +138,11 @@ if __name__ == "__main__":
                 create_pytest_switches(
                     fn,
                     args.absolute,
-                    args.reduced,
-                    args.public,
-                    args.gpu,
-                    args.preview,
-                    args.base_dir,
+                    reduced_tests = args.reduced,
+                    public = args.public,
+                    gpu = args.gpu,
+                    preview = args.preview,
+                    base_dir = args.base_dir,
                 )
             )
         )

--- a/.circleci/deselect_tests.py
+++ b/.circleci/deselect_tests.py
@@ -138,11 +138,11 @@ if __name__ == "__main__":
                 create_pytest_switches(
                     fn,
                     args.absolute,
-                    reduced_tests = args.reduced,
-                    public = args.public,
-                    gpu = args.gpu,
-                    preview = args.preview,
-                    base_dir = args.base_dir,
+                    reduced_tests=args.reduced,
+                    public=args.public,
+                    gpu=args.gpu,
+                    preview=args.preview,
+                    base_dir=args.base_dir,
                 )
             )
         )


### PR DESCRIPTION
## Description

Just removing some ugly logic. This should make extensibility easier rather than a large if statement addition, just defining a new kwarg with the matchin yaml section name (all around the argparse instead).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
