### PR TITLE
[fix] add numpy 2.0 guard to tests evaluating array API mixed namespace support

### DIFF
--- a/sklearnex/basic_statistics/tests/test_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_basic_statistics.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
+from daal4py.sklearn._utils import _package_check_version, daal_check_version, sklearn_check_version
 from onedal.basic_statistics.tests.utils import options_and_tests
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
@@ -404,8 +404,8 @@ def test_results_have_underscores(underscore_first):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Test for functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Test for functionality introduced in later scikit-learn versions with numpy Array API support.",
 )
 @pytest.mark.parametrize(
     "X_xp",

--- a/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/tests/test_incremental_basic_statistics.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn._utils import _package_check_version, sklearn_check_version
 from onedal.basic_statistics.tests.utils import options_and_tests
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
@@ -455,7 +455,7 @@ def test_results_have_underscores(underscore_first):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
     reason="Test for functionality introduced in later scikit-learn versions.",
 )
 @pytest.mark.parametrize(

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -22,7 +22,7 @@ from numpy.testing import assert_allclose
 from sklearn.base import is_regressor
 from sklearn.datasets import make_classification, make_regression
 
-from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
+from daal4py.sklearn._utils import _package_check_version, daal_check_version, sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
     _as_numpy,
     _convert_to_dataframe,
@@ -210,7 +210,7 @@ def test_classifiers_work_on_single_class_non_numeric():
 # TODO: add 'sample_weights' to this test once oneDAL supports the
 # new scikit-learn methodology and sklearnex doesn't fall back.
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
+    not (sklearn_check_version("1.9")  and _package_check_version("2.0", np.__version__),
     reason="Functionality introduced in later scikit-learn versions.",
 )
 @pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])
@@ -275,8 +275,8 @@ def test_rf_mixed_array_namespaces(X_xp, y_xp, class_weight, n_classes, with_arr
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.skipif(
     not is_sycl_device_available("gpu"), reason="Test checks GPU-specific functionality."

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -210,7 +210,7 @@ def test_classifiers_work_on_single_class_non_numeric():
 # TODO: add 'sample_weights' to this test once oneDAL supports the
 # new scikit-learn methodology and sklearnex doesn't fall back.
 @pytest.mark.skipif(
-    not (sklearn_check_version("1.9")  and _package_check_version("2.0", np.__version__),
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
     reason="Functionality introduced in later scikit-learn versions.",
 )
 @pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])

--- a/sklearnex/linear_model/tests/test_mixed_inputs.py
+++ b/sklearnex/linear_model/tests/test_mixed_inputs.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn._utils import _package_check_version, sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
     dpnp_available,
     torch_available,
@@ -117,8 +117,8 @@ def _check_attributes_and_output(model, X, y, X_xp):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])
 @pytest.mark.parametrize("y_xp", [np, pd, array_api_strict])
@@ -179,8 +179,8 @@ def test_error_on_incompatible_namespaces(
     reason="Test checks GPU-specific functionality.",
 )
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.
 )
 @pytest.mark.parametrize(
     "X_xp, X_device",

--- a/sklearnex/neighbors/tests/test_neighbors.py
+++ b/sklearnex/neighbors/tests/test_neighbors.py
@@ -30,7 +30,7 @@ if hasattr(sp, "csr_array"):
 else:
     CSR_CTOR = sp.csr_matrix
 
-from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn._utils import _package_check_version, sklearn_check_version
 from onedal.tests.utils._dataframes_support import (
     _as_numpy,
     _convert_to_dataframe,

--- a/sklearnex/neighbors/tests/test_neighbors.py
+++ b/sklearnex/neighbors/tests/test_neighbors.py
@@ -242,8 +242,8 @@ def test_error_on_incompatible_namespaces(weights, with_array_api):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])
 @pytest.mark.parametrize("y_xp", [np, pd, array_api_strict])
@@ -301,8 +301,8 @@ def test_mixed_array_namespaces(X_xp, y_xp, weights, n_classes, with_array_api):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.skipif(
     not is_sycl_device_available("gpu"), reason="Test checks GPU-specific functionality."

--- a/sklearnex/svm/tests/test_svm.py
+++ b/sklearnex/svm/tests/test_svm.py
@@ -441,8 +441,8 @@ def test_dense_predict_on_sparse_fit_works(estimator, array_api):
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__)),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.parametrize("X_xp", [np, pd, array_api_strict])
 @pytest.mark.parametrize("y_xp", [np, pd, array_api_strict])
@@ -516,8 +516,8 @@ def test_svm_mixed_array_namespaces(
 # in which 'X' is on a CPU device. If GPU support gets added in the future,
 # it should also test cases where 'X' is on GPU.
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions using numpy array API support.",
 )
 @pytest.mark.skipif(
     not is_sycl_device_available("gpu"), reason="Test checks GPU-specific functionality."
@@ -580,8 +580,8 @@ def test_svr_mixed_devices(
 
 
 @pytest.mark.skipif(
-    not sklearn_check_version("1.9"),
-    reason="Functionality introduced in later scikit-learn versions.",
+    not (sklearn_check_version("1.9") and _package_check_version("2.0", np.__version__),
+    reason="Functionality introduced in later scikit-learn versions with numpy array API support.",
 )
 @pytest.mark.skipif(
     not is_sycl_device_available("gpu"), reason="Test checks GPU-specific functionality."


### PR DESCRIPTION
## Description

to be added

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
