### PR TITLE
[enhancement] enable `assume_finite` sklearn config support in sklearnex via `assert_all_finite`

### DIFF
--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -242,7 +242,7 @@ def test_sklearnex_assume_finite_config():
     with config_context(assume_finite=True):
         est = DummyEstimator()
         # force onedal track via 32769 datapoints
-        data = np.empty(2**15 + 1)
-        data.fill(np.inf).reshape((-1, 1))
+        data = np.empty((2**15 + 1, 1))
+        data.fill(np.inf)
         # if it still triggers an exception, test will fail
         validate_data(est, data)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -238,10 +238,11 @@ def test_validate_data_output(dtype, dataframe, queue):
             assert second is None or isinstance(second, np.ndarray)
 
 
-def test_assert_all_finite_assume_finite_config():
+def test_sklearnex_assume_finite_config():
     with config_context(assume_finite=True):
+        est = DummyEstimator()
         # force onedal track via 32769 datapoints
         data = np.empty(2**15+1)
         data.fill(np.inf)
-        # if it still triggers a failure, test will fail
-        assert_all_finite(data)
+        # if it still triggers an exception, test will fail
+        validate_data(est, data)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -236,3 +236,12 @@ def test_validate_data_output(dtype, dataframe, queue):
             # array_api_strict from sklearn < 1.2 and pandas will convert to numpy arrays
             assert isinstance(first, np.ndarray)
             assert second is None or isinstance(second, np.ndarray)
+
+
+def test_assert_all_finite_assume_finite_config():
+    with config_context(assume_finite=True):
+        # force onedal track via 32769 datapoints
+        data = np.emtpy(2**15+1)
+        data.fill(np.inf)
+        # if it still triggers a failure, test will fail
+        assert_all_finite(data)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -242,7 +242,7 @@ def test_sklearnex_assume_finite_config():
     with config_context(assume_finite=True):
         est = DummyEstimator()
         # force onedal track via 32769 datapoints
-        data = np.empty(2**15+1)
+        data = np.empty(2**15 + 1)
         data.fill(np.inf)
         # if it still triggers an exception, test will fail
         validate_data(est, data)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -243,6 +243,6 @@ def test_sklearnex_assume_finite_config():
         est = DummyEstimator()
         # force onedal track via 32769 datapoints
         data = np.empty(2**15 + 1)
-        data.fill(np.inf)
+        data.fill(np.inf).reshape((-1, 1))
         # if it still triggers an exception, test will fail
         validate_data(est, data)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -241,7 +241,7 @@ def test_validate_data_output(dtype, dataframe, queue):
 def test_assert_all_finite_assume_finite_config():
     with config_context(assume_finite=True):
         # force onedal track via 32769 datapoints
-        data = np.emtpy(2**15+1)
+        data = np.empty(2**15+1)
         data.fill(np.inf)
         # if it still triggers a failure, test will fail
         assert_all_finite(data)

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -103,7 +103,7 @@ def _sklearnex_assert_all_finite(
         else:
             _sklearn_assert_all_finite(X, allow_nan=allow_nan)
     else:
-        # only set on onedal branch as it is already exists in sklearn's
+        # only check on onedal branch as it is already exists in sklearn's
         if _get_config()["assume_finite"]:
             return
         

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -36,8 +36,8 @@ if sklearn_check_version("1.9"):
     from sklearn.utils.validation import _check_estimator_name
     from sklearn.utils._array_api import get_namespace_and_device, move_to
 
+from .._config import get_config as _get_config
 from ._array_api import get_namespace
-from ._config import get_config as _get_config
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data as _sklearn_validate_data

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -37,6 +37,7 @@ if sklearn_check_version("1.9"):
     from sklearn.utils._array_api import get_namespace_and_device, move_to
 
 from ._array_api import get_namespace
+from ._config import get_config as _get_config
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data as _sklearn_validate_data
@@ -102,6 +103,10 @@ def _sklearnex_assert_all_finite(
         else:
             _sklearn_assert_all_finite(X, allow_nan=allow_nan)
     else:
+        # only set on onedal branch as it is already exists in sklearn's
+        if _get_config()["assume_finite"]:
+            return
+        
         all_finite = check_all_finite(
             X,
             allow_nan=allow_nan,

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -106,7 +106,7 @@ def _sklearnex_assert_all_finite(
         # only check on onedal branch as it is already exists in sklearn's
         if _get_config()["assume_finite"]:
             return
-        
+
         all_finite = check_all_finite(
             X,
             allow_nan=allow_nan,


### PR DESCRIPTION
## Description

Available since sklearn 0.19 and brought up in #3236, this will allow for sklearnex estimators using `assert_all_finite` to respect the setting of the config.

Test added to verify.

Already supported in daal4py's version.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
