### PR TITLE
[FIX] Correct usage of the `allow_fallback_to_host` configuration option

### DIFF
--- a/.circleci/run_xpu_tests.py
+++ b/.circleci/run_xpu_tests.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     with config_context(allow_sklearn_after_onedal=False):
 
         if args.device == "gpu":
-            with config_context(target_offload=args.device, allow_fallback_to_host=False):
+            with config_context(target_offload=args.device, allow_fallback_to_host=True):
                 pytest.main(
                     pytest_params + ["--pyargs", "sklearn"] + yml_deselected_tests
                 )

--- a/onedal/utils/_sycl_queue_manager.py
+++ b/onedal/utils/_sycl_queue_manager.py
@@ -83,6 +83,9 @@ def remove_global_queue():
     __globals.queue = None
 
 
+is_cpu_device = lambda: (get_global_queue() := queue) is None or getattr(queue.sycl_device, "is_cpu", True)
+is_gpu_device = lambda: (get_global_queue() := queue) is not None and getattr(queue.sycl_device, "is_gpu", False)
+
 def update_global_queue(queue):
     """Update the global queue.
 

--- a/onedal/utils/_sycl_queue_manager.py
+++ b/onedal/utils/_sycl_queue_manager.py
@@ -83,8 +83,15 @@ def remove_global_queue():
     __globals.queue = None
 
 
-is_cpu_device = lambda: (get_global_queue() := queue) is None or getattr(queue.sycl_device, "is_cpu", True)
-is_gpu_device = lambda: (get_global_queue() := queue) is not None and getattr(queue.sycl_device, "is_gpu", False)
+def is_cpu_device():
+    queue = get_global_queue()
+    return queue is None or getattr(queue.sycl_device, "is_cpu", True)
+
+
+def is_gpu_device():
+    queue = get_global_queue()
+    return queue is not None and getattr(queue.sycl_device, "is_gpu", False)
+
 
 def update_global_queue(queue):
     """Update the global queue.

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -167,6 +167,11 @@ def dispatch(
                 # dpnp fallback is not handled properly yet.
                 patching_status.write_log(transferred_to_host=False)
                 return branches["sklearn"](obj, *args, **kwargs)
+            elif QM.get_global_queue() is not None and not get_config()["allow_fallback_to_host"]:
+                # In spirit of the documentation, if there is a transfer to host which runs then
+                # scikit-learn without array API then it must be done on CPU. This is then controlled
+                # by the `allow_fallback_to_host` configuration option.
+                    raise RuntimeError("Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option")
             else:
                 patching_status.write_log()
                 return branches["sklearn"](obj, *hostargs, **hostkwargs)

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -41,15 +41,12 @@ def _get_backend(
     It is assumed that the queue (which determined what hardware to possibly use for
     oneDAL) has been previously and extensively collected (i.e. the data has already
     been checked using onedal's SyclQueueManager for queues)."""
-    queue = QM.get_global_queue()
-    cpu_device = queue is None or getattr(queue.sycl_device, "is_cpu", True)
-    gpu_device = queue is not None and getattr(queue.sycl_device, "is_gpu", False)
 
-    if cpu_device:
+    if QM.is_cpu_device():
         patching_status = obj._onedal_cpu_supported(method_name, *data)
         return patching_status.get_status(), patching_status
 
-    if gpu_device:
+    if QM.is_gpu_device():
         patching_status = obj._onedal_gpu_supported(method_name, *data)
         if not patching_status.get_status() and get_config()["allow_fallback_to_host"]:
             QM.fallback_to_host()
@@ -167,11 +164,11 @@ def dispatch(
                 # dpnp fallback is not handled properly yet.
                 patching_status.write_log(transferred_to_host=False)
                 return branches["sklearn"](obj, *args, **kwargs)
-            elif QM.get_global_queue() is not None and not get_config()["allow_fallback_to_host"]:
+            elif not QM.is_cpu_device() and not get_config()["allow_fallback_to_host"]:
                 # In spirit of the documentation, if there is a transfer to host which runs then
                 # scikit-learn without array API then it must be done on CPU. This is then controlled
                 # by the `allow_fallback_to_host` configuration option.
-                    raise RuntimeError("Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option")
+                raise RuntimeError("Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option")
             else:
                 patching_status.write_log()
                 return branches["sklearn"](obj, *hostargs, **hostkwargs)

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -168,7 +168,9 @@ def dispatch(
                 # In spirit of the documentation, if there is a transfer to host which runs then
                 # scikit-learn without array API then it must be done on CPU. This is then controlled
                 # by the `allow_fallback_to_host` configuration option.
-                raise RuntimeError("Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option")
+                raise RuntimeError(
+                    "Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option"
+                )
             else:
                 patching_status.write_log()
                 return branches["sklearn"](obj, *hostargs, **hostkwargs)

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -225,7 +225,7 @@ def test_fallback_to_host(sklearn_fallback, caplog):
             assert (
                 f": running accelerated version on {'CPU' if fallback else 'GPU'}"
                 in caplog.messages[start:]
-                or sklearn_fallback
+                or (sklearn_fallback and not fallback)
             )
             start = len(caplog.messages)
 

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -164,8 +164,8 @@ def test_host_backend_target_offload(target):
 @pytest.mark.skipif(
     not is_sycl_device_available(["gpu"]), reason="Requires a gpu for fallback testing"
 )
-@pytest.mark.parmetrize("sklearn_fallback", [True, False])
-def test_fallback_to_host(caplog, sklearn_fallback):
+@pytest.mark.parametrize("sklearn_fallback", [True, False])
+def test_fallback_to_host(sklearn_fallback, caplog):
     # force a fallback to cpu with direct use of dispatch and PatchingConditionsChain
     # it should complete with allow_fallback_to_host. The queue should be preserved
     # and properly used in the second round on gpu
@@ -181,17 +181,14 @@ def test_fallback_to_host(caplog, sklearn_fallback):
     class _Estimator:
         def _onedal_gpu_supported(self, method_name, *data):
             patching_status = PatchingConditionsChain("")
-            patching_status.and_condition(data[0] == "gpu", "")
+            patching_status.and_conditions(
+                [(data[0] == "gpu", ""), (not sklearn_fallback, "")]
+            )
             return patching_status
 
         def _onedal_cpu_supported(self, method_name, *data):
             patching_status = PatchingConditionsChain("")
-            # use onedal if not using sklearn_fallback
-            patching_status.and_condition(not sklearn_fallback, "")
             return patching_status
-
-        def _sklearn_test(self, *args):
-            self._onedal_test(*args)
 
         def _onedal_test(self, *args, queue=None):
             if args[0] == "cpu":
@@ -210,12 +207,16 @@ def test_fallback_to_host(caplog, sklearn_fallback):
         # True == with cpu (eventually), False == with gpu
         for fallback in [True, False]:
             err_msg = "Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option"
-            sklearn_ctx = nullcontext() if sklearn_fallback else pytest.raises(RuntimeError, match=err_msg)
+            sklearn_ctx = (
+                nullcontext()
+                if fallback or not sklearn_fallback
+                else pytest.raises(RuntimeError, match=err_msg)
+            )
             with sklearnex.config_context(allow_fallback_to_host=fallback), sklearn_ctx:
                 dispatch(
                     est,
                     "test",
-                    {"onedal": _Estimator._onedal_test, "sklearn": _Estimator._sklearn_test},
+                    {"onedal": _Estimator._onedal_test, "sklearn": None},
                     "cpu" if fallback else "gpu",
                 )
 
@@ -224,6 +225,7 @@ def test_fallback_to_host(caplog, sklearn_fallback):
             assert (
                 f": running accelerated version on {'CPU' if fallback else 'GPU'}"
                 in caplog.messages[start:]
+                or sklearn_fallback
             )
             start = len(caplog.messages)
 

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -160,10 +160,12 @@ def test_host_backend_target_offload(target):
             est.fit(np.eye(5, 8))
 
 
+@pytest.mark.allow_sklearn_fallback
 @pytest.mark.skipif(
     not is_sycl_device_available(["gpu"]), reason="Requires a gpu for fallback testing"
 )
-def test_fallback_to_host(caplog):
+@pytest.mark.parmetrize("sklearn_fallback", [True, False])
+def test_fallback_to_host(caplog, sklearn_fallback):
     # force a fallback to cpu with direct use of dispatch and PatchingConditionsChain
     # it should complete with allow_fallback_to_host. The queue should be preserved
     # and properly used in the second round on gpu
@@ -184,7 +186,12 @@ def test_fallback_to_host(caplog):
 
         def _onedal_cpu_supported(self, method_name, *data):
             patching_status = PatchingConditionsChain("")
+            # use onedal if not using sklearn_fallback
+            patching_status.and_condition(not sklearn_fallback, "")
             return patching_status
+
+        def _sklearn_test(self, *args):
+            self._onedal_test(*args)
 
         def _onedal_test(self, *args, queue=None):
             if args[0] == "cpu":
@@ -202,11 +209,13 @@ def test_fallback_to_host(caplog):
     ):
         # True == with cpu (eventually), False == with gpu
         for fallback in [True, False]:
-            with sklearnex.config_context(allow_fallback_to_host=fallback):
+            err_msg = ""
+            sklearn_ctx = nullcontext() if sklearn_fallback else pytest.raises(RuntimeError, match=err_msg)
+            with sklearnex.config_context(allow_fallback_to_host=fallback), sklearn_ctx:
                 dispatch(
                     est,
                     "test",
-                    {"onedal": _Estimator._onedal_test, "sklearn": None},
+                    {"onedal": _Estimator._onedal_test, "sklearn": _Estimator._sklearn_test},
                     "cpu" if fallback else "gpu",
                 )
 

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -209,7 +209,7 @@ def test_fallback_to_host(caplog, sklearn_fallback):
     ):
         # True == with cpu (eventually), False == with gpu
         for fallback in [True, False]:
-            err_msg = ""
+            err_msg = "Fallback to scikit-learn on host, device operation may be supported via the `array_api_dispatch` configuration option"
             sklearn_ctx = nullcontext() if sklearn_fallback else pytest.raises(RuntimeError, match=err_msg)
             with sklearnex.config_context(allow_fallback_to_host=fallback), sklearn_ctx:
                 dispatch(


### PR DESCRIPTION
## Description

Address issues brought up in #3220 and by @david-cortes-intel where newer refactor of `sklearnex._device_offload.dispatcher` occurring in the array API support commit (#2096) disabled an error upon falling back to scikit-learn when using GPU data. It was the case that this option was broken since #2168, but was untested and the new tests introduced in #2096 did not encompass the fallback to sklearn. This did not reflect the initial implementation which occurred in #772.  This PR adds an additional check and expands test to cover this scenario, it only occurs after all oneDAL checks have been exhausted so it has no performance impact on oneDAL acceleration.  This should only happen in the case that `array_api_dispatch` is False, and `allow_fallback_to_host` is False.  In the case that `array_api_dispatch` is `True` and `allow_fallback_to_host` is `True`, it will prioritize oneDAL `cpu` acceleration over sklearn's array API support.

Additionally, new functions are added to the sycl_queue_manager which should simplify device checks.

NOTE: This PR will stay in draft as it should wreak havoc on private CI sklearn conformance testing, and changes for that are oncoming.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
