### PR TITLE
[maintenance] re-enable dpnp array API sklearn fallback

### DIFF
--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -147,13 +147,12 @@ def dispatch(
                 patching_status.write_log(transferred_to_host=False)
                 return branches["sklearn"](obj, *args, **kwargs)
 
-        # move data to host because of multiple reasons: array_api fallback to host,
-        # non array_api supporting oneDAL code, issues with usm support in sklearn.
-        has_usm_data_for_args, hostargs = _transfer_to_host(*args)
-        has_usm_data_for_kwargs, hostvalues = _transfer_to_host(*kwargs.values())
+        # move data to host because of multiple reasons: array_api fallback to host
+        # and non array_api supporting oneDAL code
+        _, hostargs = _transfer_to_host(*args)
+        _, hostvalues = _transfer_to_host(*kwargs.values())
 
         hostkwargs = dict(zip(kwargs.keys(), hostvalues))
-        has_usm_data = has_usm_data_for_args or has_usm_data_for_kwargs
 
         while backend is None:
             backend, patching_status = _get_backend(obj, method_name, *hostargs)
@@ -163,8 +162,7 @@ def dispatch(
             patching_status.write_log(queue=queue, transferred_to_host=False)
             return branches["onedal"](obj, *hostargs, **hostkwargs, queue=queue)
         else:
-            if sklearn_array_api and not has_usm_data:
-                # dpnp fallback is not handled properly yet.
+            if sklearn_array_api:
                 patching_status.write_log(transferred_to_host=False)
                 return branches["sklearn"](obj, *args, **kwargs)
             else:


### PR DESCRIPTION
## Description

There is a check for usm_ndarray support which influences the use of sklearn array API fallbacks, I assume that the necessary work has been done on dpnp-side in order to re-enable this code pathway.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
