### PR TITLE
[maintenance] Move `support_input_format`,`support_sycl_format` from `onedal._device_offload` to `sklearnex._device_offload`

### DIFF
--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -20,10 +20,8 @@ from operator import xor
 
 import numpy as np
 
-from .datatypes import copy_to_dpnp, dlpack_to_numpy
+from .datatypes import dlpack_to_numpy
 from .utils import _sycl_queue_manager as QM
-from .utils._array_api import _asarray, _get_sycl_namespace, _is_numpy_namespace
-from .utils._third_party import is_dpnp_ndarray
 
 
 def supports_queue(func):

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -89,68 +89,6 @@ def _get_host_inputs(*args, **kwargs):
     return hostargs, hostkwargs
 
 
-def support_input_format(func):
-    """Transform input and output function arrays to/from host.
-
-    Converts and moves the output arrays of the decorated function
-    to match the input array type and device.
-    Puts SYCLQueue from data to decorated function arguments.
-
-    Parameters
-    ----------
-    func : callable
-       Function or method which has array data as input.
-
-    Returns
-    -------
-    wrapper_impl : callable
-        Wrapped function or method which will return matching format.
-    """
-
-    def invoke_func(self_or_None, *args, **kwargs):
-        if self_or_None is None:
-            return func(*args, **kwargs)
-        else:
-            return func(self_or_None, *args, **kwargs)
-
-    @wraps(func)
-    def wrapper_impl(*args, **kwargs):
-        # remove self from args if it is a class method
-        if inspect.isfunction(func) and "." in func.__qualname__:
-            self = args[0]
-            args = args[1:]
-        else:
-            self = None
-
-        if "queue" not in kwargs and "queue" in inspect.signature(func).parameters:
-            if usm_iface := getattr(args[0], "__sycl_usm_array_interface__", None):
-                kwargs["queue"] = usm_iface["syclobj"]
-
-        if kwargs.get("queue") is not None:
-            # Device path — function accepts queue, pass device data directly
-            result = invoke_func(self, *args, **kwargs)
-        else:
-            # Host path — sklearn function or host data, transfer to host
-            if len(args) == 0 and len(kwargs) == 0:
-                return invoke_func(self, *args, **kwargs)
-
-            with QM.manage_global_queue(None, *args) as queue:
-                hostargs, hostkwargs = _get_host_inputs(*args, **kwargs)
-                result = invoke_func(self, *hostargs, **hostkwargs)
-                if queue and hasattr(args[0], "__sycl_usm_array_interface__"):
-                    return copy_to_dpnp(queue, result)
-
-        data = (*args, *kwargs.values())[0]
-        if get_config().get("transform_output") in ("default", None):
-            input_array_api = getattr(data, "__array_namespace__", lambda: None)()
-            if input_array_api and not _is_numpy_namespace(input_array_api):
-                input_array_api_device = data.device
-                result = _asarray(result, input_array_api, device=input_array_api_device)
-        return result
-
-    return wrapper_impl
-
-
 def support_sycl_format(func):
     # This wrapper enables scikit-learn functions and methods to work with
     # all sycl data frameworks as they no longer support numpy implicit

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -86,27 +86,3 @@ def _get_host_inputs(*args, **kwargs):
     _, hostvalues = _transfer_to_host(*kwargs.values())
     hostkwargs = dict(zip(kwargs.keys(), hostvalues))
     return hostargs, hostkwargs
-
-
-def support_sycl_format(func):
-    # This wrapper enables scikit-learn functions and methods to work with
-    # all sycl data frameworks as they no longer support numpy implicit
-    # conversion and must be manually converted. This is only necessary
-    # when array API is supported but not active.
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if (
-            not get_config().get("array_api_dispatch", False)
-            and _get_sycl_namespace(*args)[2]
-        ):
-            with QM.manage_global_queue(kwargs.get("queue"), *args):
-                if inspect.isfunction(func) and "." in func.__qualname__:
-                    self, (args, kwargs) = args[0], _get_host_inputs(*args[1:], **kwargs)
-                    return func(self, *args, **kwargs)
-                else:
-                    args, kwargs = _get_host_inputs(*args, **kwargs)
-                    return func(*args, **kwargs)
-        return func(*args, **kwargs)
-
-    return wrapper

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -19,7 +19,6 @@ from functools import wraps
 from operator import xor
 
 import numpy as np
-from sklearn import get_config
 
 from .datatypes import copy_to_dpnp, dlpack_to_numpy
 from .utils import _sycl_queue_manager as QM

--- a/onedal/_device_offload.py
+++ b/onedal/_device_offload.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import inspect
 from functools import wraps
 from operator import xor
 

--- a/onedal/spmd/decomposition/pca.py
+++ b/onedal/spmd/decomposition/pca.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from ..._device_offload import support_input_format
 from ...common._backend import bind_spmd_backend
 from ...decomposition.pca import PCA as PCABatch
 

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -241,3 +241,65 @@ def wrap_output_data(func: Callable) -> Callable:
         return result
 
     return wrapper
+
+
+def support_input_format(func):
+    """Transform input and output function arrays to/from host.
+
+    Converts and moves the output arrays of the decorated function
+    to match the input array type and device.
+    Puts SYCLQueue from data to decorated function arguments.
+
+    Parameters
+    ----------
+    func : callable
+       Function or method which has array data as input.
+
+    Returns
+    -------
+    wrapper_impl : callable
+        Wrapped function or method which will return matching format.
+    """
+
+    def invoke_func(self_or_None, *args, **kwargs):
+        if self_or_None is None:
+            return func(*args, **kwargs)
+        else:
+            return func(self_or_None, *args, **kwargs)
+
+    @wraps(func)
+    def wrapper_impl(*args, **kwargs):
+        # remove self from args if it is a class method
+        if inspect.isfunction(func) and "." in func.__qualname__:
+            self = args[0]
+            args = args[1:]
+        else:
+            self = None
+
+        if "queue" not in kwargs and "queue" in inspect.signature(func).parameters:
+            if usm_iface := getattr(args[0], "__sycl_usm_array_interface__", None):
+                kwargs["queue"] = usm_iface["syclobj"]
+
+        if kwargs.get("queue") is not None:
+            # Device path — function accepts queue, pass device data directly
+            result = invoke_func(self, *args, **kwargs)
+        else:
+            # Host path — sklearn function or host data, transfer to host
+            if len(args) == 0 and len(kwargs) == 0:
+                return invoke_func(self, *args, **kwargs)
+
+            with QM.manage_global_queue(None, *args) as queue:
+                hostargs, hostkwargs = _get_host_inputs(*args, **kwargs)
+                result = invoke_func(self, *hostargs, **hostkwargs)
+                if queue and hasattr(args[0], "__sycl_usm_array_interface__"):
+                    return copy_to_dpnp(queue, result)
+
+        data = (*args, *kwargs.values())[0]
+        if get_config().get("transform_output") in ("default", None):
+            input_array_api = getattr(data, "__array_namespace__", lambda: None)()
+            if input_array_api and not _is_numpy_namespace(input_array_api):
+                input_array_api_device = data.device
+                result = _asarray(result, input_array_api, device=input_array_api_device)
+        return result
+
+    return wrapper_impl

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -20,7 +20,7 @@ from functools import wraps
 from typing import Any, Union
 
 from daal4py.sklearn._utils import sklearn_check_version
-from onedal._device_offload import _transfer_to_host
+from onedal._device_offload import _get_host_inputs, _transfer_to_host
 from onedal.datatypes import copy_to_dpnp
 from onedal.utils import _sycl_queue_manager as QM
 from onedal.utils._array_api import _asarray, _get_sycl_namespace, _is_numpy_namespace

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -22,7 +22,7 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal._device_offload import _transfer_to_host
 from onedal.datatypes import copy_to_dpnp
 from onedal.utils import _sycl_queue_manager as QM
-from onedal.utils._array_api import _asarray, _is_numpy_namespace
+from onedal.utils._array_api import _asarray, _get_sycl_namespace, _is_numpy_namespace
 from onedal.utils._third_party import is_dpnp_ndarray
 
 from ._config import get_config

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -303,3 +303,27 @@ def support_input_format(func):
         return result
 
     return wrapper_impl
+
+
+def support_sycl_format(func):
+    # This wrapper enables scikit-learn functions and methods to work with
+    # all sycl data frameworks as they no longer support numpy implicit
+    # conversion and must be manually converted. This is only necessary
+    # when array API is supported but not active.
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if (
+            not get_config().get("array_api_dispatch", False)
+            and _get_sycl_namespace(*args)[2]
+        ):
+            with QM.manage_global_queue(kwargs.get("queue"), *args):
+                if inspect.isfunction(func) and "." in func.__qualname__:
+                    self, (args, kwargs) = args[0], _get_host_inputs(*args[1:], **kwargs)
+                    return func(self, *args, **kwargs)
+                else:
+                    args, kwargs = _get_host_inputs(*args, **kwargs)
+                    return func(*args, **kwargs)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import inspect
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, Union

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -33,7 +33,12 @@ from onedal.covariance import (
 from onedal.utils._array_api import _is_numpy_namespace
 
 from .._config import config_context
-from .._device_offload import dispatch, support_input_format, support_sycl_format, wrap_output_data
+from .._device_offload import (
+    dispatch,
+    support_input_format,
+    support_sycl_format,
+    wrap_output_data,
+)
 from .._utils import PatchingConditionsChain, _add_inc_serialization_note
 from ..base import oneDALEstimator
 from ..utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -27,14 +27,13 @@ from sklearn.utils.validation import _num_features, check_is_fitted
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from daal4py.sklearn.metrics import pairwise_distances
-from onedal._device_offload import support_sycl_format
 from onedal.covariance import (
     IncrementalEmpiricalCovariance as onedal_IncrementalEmpiricalCovariance,
 )
 from onedal.utils._array_api import _is_numpy_namespace
 
 from .._config import config_context
-from .._device_offload import dispatch, support_input_format, wrap_output_data
+from .._device_offload import dispatch, support_input_format, support_sycl_format, wrap_output_data
 from .._utils import PatchingConditionsChain, _add_inc_serialization_note
 from ..base import oneDALEstimator
 from ..utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -27,14 +27,14 @@ from sklearn.utils.validation import _num_features, check_is_fitted
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 from daal4py.sklearn.metrics import pairwise_distances
-from onedal._device_offload import support_input_format, support_sycl_format
+from onedal._device_offload import support_sycl_format
 from onedal.covariance import (
     IncrementalEmpiricalCovariance as onedal_IncrementalEmpiricalCovariance,
 )
 from onedal.utils._array_api import _is_numpy_namespace
 
 from .._config import config_context
-from .._device_offload import dispatch, wrap_output_data
+from .._device_offload import dispatch, support_input_format, wrap_output_data
 from .._utils import PatchingConditionsChain, _add_inc_serialization_note
 from ..base import oneDALEstimator
 from ..utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -31,7 +31,7 @@ if daal_check_version((2024, "P", 100)):
     from daal4py.sklearn._utils import sklearn_check_version
     from onedal._device_offload import _transfer_to_host
 
-    from .._device_offload import dispatch, wrap_output_data
+    from .._device_offload import dispatch, support_sycl_format, wrap_output_data
     from .._utils import PatchingConditionsChain, register_hyperparameters
     from ..base import oneDALEstimator
     from ..utils._array_api import enable_array_api, get_namespace
@@ -45,7 +45,6 @@ if daal_check_version((2024, "P", 100)):
 
     from sklearn.decomposition import PCA as _sklearn_PCA
 
-    from onedal._device_offload import support_sycl_format
     from onedal.decomposition import PCA as onedal_PCA
     from onedal.utils._array_api import _is_numpy_namespace
     from onedal.utils.validation import _num_features, _num_samples

--- a/sklearnex/dummy/_dummy.py
+++ b/sklearnex/dummy/_dummy.py
@@ -26,10 +26,9 @@ from sklearn.utils.validation import check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, is_sparse, sklearn_check_version
-from onedal._device_offload import support_input_format
 from onedal.dummy import DummyEstimator as onedal_DummyEstimator
 
-from .._device_offload import dispatch
+from .._device_offload import dispatch, support_input_format
 from .._utils import PatchingConditionsChain
 from ..base import oneDALEstimator
 from ..utils._array_api import enable_array_api, get_namespace

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -50,7 +50,6 @@ from daal4py.sklearn._utils import (
     is_sparse,
     sklearn_check_version,
 )
-from onedal._device_offload import support_input_format
 from onedal.ensemble import ExtraTreesClassifier as onedal_ExtraTreesClassifier
 from onedal.ensemble import ExtraTreesRegressor as onedal_ExtraTreesRegressor
 from onedal.ensemble import RandomForestClassifier as onedal_RandomForestClassifier
@@ -58,7 +57,7 @@ from onedal.ensemble import RandomForestRegressor as onedal_RandomForestRegresso
 from onedal.primitives import get_tree_state_cls, get_tree_state_reg
 from onedal.utils.validation import _num_features
 
-from .._device_offload import dispatch, wrap_output_data
+from .._device_offload import dispatch, support_input_format, wrap_output_data
 from .._utils import PatchingConditionsChain, register_hyperparameters
 from ..base import oneDALEstimator
 from ..utils._array_api import enable_array_api, get_namespace

--- a/sklearnex/linear_model/ridge.py
+++ b/sklearnex/linear_model/ridge.py
@@ -415,7 +415,8 @@ if daal_check_version((2024, "P", 600)):
 
 else:
     from daal4py.sklearn.linear_model import Ridge
-    from onedal._device_offload import support_input_format
+    
+    from .._device_offload import support_input_format
 
     Ridge.fit = support_input_format(Ridge.fit)
     Ridge.predict = support_input_format(Ridge.predict)

--- a/sklearnex/linear_model/ridge.py
+++ b/sklearnex/linear_model/ridge.py
@@ -415,7 +415,7 @@ if daal_check_version((2024, "P", 600)):
 
 else:
     from daal4py.sklearn.linear_model import Ridge
-    
+
     from .._device_offload import support_input_format
 
     Ridge.fit = support_input_format(Ridge.fit)

--- a/sklearnex/model_selection/split.py
+++ b/sklearnex/model_selection/split.py
@@ -16,7 +16,8 @@
 
 from daal4py.sklearn._utils import sklearn_check_version
 from daal4py.sklearn.model_selection import train_test_split
-from onedal._device_offload import support_input_format
+
+from .._device_offload import support_input_format
 
 # Needed due to some issues with array API support on the scikit-learn side
 # for the internal safe indexer tool which daal4py uses. Note that this will

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -25,13 +25,12 @@ from sklearn.utils.validation import check_array, check_is_fitted
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, is_sparse, sklearn_check_version
 from daal4py.sklearn.metrics import pairwise_distances
-from onedal._device_offload import support_sycl_format
 from onedal.covariance import EmpiricalCovariance as onedal_EmpiricalCovariance
 from onedal.utils._array_api import _is_numpy_namespace
 from onedal.utils.validation import _num_features
 from sklearnex import config_context
 
-from ..._device_offload import dispatch, support_input_format, wrap_output_data
+from ..._device_offload import dispatch, support_input_format, support_sycl_format, wrap_output_data
 from ..._utils import PatchingConditionsChain, register_hyperparameters
 from ...base import oneDALEstimator
 from ...utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -30,7 +30,12 @@ from onedal.utils._array_api import _is_numpy_namespace
 from onedal.utils.validation import _num_features
 from sklearnex import config_context
 
-from ..._device_offload import dispatch, support_input_format, support_sycl_format, wrap_output_data
+from ..._device_offload import (
+    dispatch,
+    support_input_format,
+    support_sycl_format,
+    wrap_output_data,
+)
 from ..._utils import PatchingConditionsChain, register_hyperparameters
 from ...base import oneDALEstimator
 from ...utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -25,13 +25,13 @@ from sklearn.utils.validation import check_array, check_is_fitted
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import daal_check_version, is_sparse, sklearn_check_version
 from daal4py.sklearn.metrics import pairwise_distances
-from onedal._device_offload import support_input_format, support_sycl_format
+from onedal._device_offload import support_sycl_format
 from onedal.covariance import EmpiricalCovariance as onedal_EmpiricalCovariance
 from onedal.utils._array_api import _is_numpy_namespace
 from onedal.utils.validation import _num_features
 from sklearnex import config_context
 
-from ..._device_offload import dispatch, wrap_output_data
+from ..._device_offload import dispatch, support_input_format, wrap_output_data
 from ..._utils import PatchingConditionsChain, register_hyperparameters
 from ...base import oneDALEstimator
 from ...utils._array_api import _pinvh, enable_array_api, get_namespace, log_likelihood


### PR DESCRIPTION
## Description

This removes a sklearn dependency in the `onedal` module, as the `onedal` module no longer uses the `support_input_format` or `support_sycl_format` functions (as of #3247) and thus should not be there.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
