### PR TITLE
[maintenance] delete unused `onedal.utils.validation._is_multilabel`  function

### DIFF
--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -29,7 +29,7 @@ from daal4py.sklearn.utils.validation import (
 from .. import _default_backend as backend
 from ..common._backend import BackendFunction
 from ..datatypes import to_table
-from ..onedal.utils import _sycl_queue_manager as QM
+from ..utils import _sycl_queue_manager as QM
 
 class DataConversionWarning(UserWarning):
     """Warning used to notify implicit data conversions happening in the code."""

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -55,39 +55,6 @@ def _is_arraylike_not_scalar(array):
     return _is_arraylike(array) and not np.isscalar(array)
 
 
-def _is_integral_float(y):
-    return y.dtype.kind == "f" and np.all(y.astype(int) == y)
-
-
-def _is_multilabel(y):
-    if hasattr(y, "__array__") or isinstance(y, Sequence):
-        # DeprecationWarning will be replaced by ValueError, see NEP 34
-        # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", VisibleDeprecationWarning)
-            try:
-                y = np.asarray(y)
-            except VisibleDeprecationWarning:
-                # dtype=object should be provided explicitly for ragged arrays,
-                # see NEP 34
-                y = np.array(y, dtype=object)
-
-    if not (hasattr(y, "shape") and y.ndim == 2 and y.shape[1] > 1):
-        return False
-
-    if sp.issparse(y):
-        if isinstance(y, (sp.dok_matrix, sp.lil_matrix)):
-            y = y.tocsr()
-        return (
-            len(y.data) == 0
-            or np.unique(y.data).size == 1
-            and (y.dtype.kind in "biu" or _is_integral_float(np.unique(y.data)))
-        )
-    labels = np.unique(y)
-
-    return len(labels) < 3 and (y.dtype.kind in "biu" or _is_integral_float(labels))
-
-
 def _check_n_features(self, X, reset):
     try:
         n_features = _num_features(X)

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -16,21 +16,12 @@
 
 import inspect
 import warnings
-from collections.abc import Sequence
-from numbers import Integral
 
 import numpy as np
 from scipy import sparse as sp
 
 from onedal.common._backend import BackendFunction
 from onedal.utils import _sycl_queue_manager as QM
-
-if np.lib.NumpyVersion(np.__version__) >= np.lib.NumpyVersion("2.0.0a0"):
-    # numpy_version >= 2.0
-    from numpy.exceptions import VisibleDeprecationWarning
-else:
-    # numpy_version < 2.0
-    from numpy import VisibleDeprecationWarning
 
 from sklearn.preprocessing import LabelEncoder
 

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -16,6 +16,7 @@
 
 import inspect
 import warnings
+from numbers import Integral
 
 import numpy as np
 from scipy import sparse as sp

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -20,7 +20,6 @@ from numbers import Integral
 
 import numpy as np
 from scipy import sparse as sp
-
 from sklearn.preprocessing import LabelEncoder
 
 from daal4py.sklearn.utils.validation import (
@@ -31,6 +30,7 @@ from .. import _default_backend as backend
 from ..common._backend import BackendFunction
 from ..datatypes import to_table
 from ..utils import _sycl_queue_manager as QM
+
 
 class DataConversionWarning(UserWarning):
     """Warning used to notify implicit data conversions happening in the code."""

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -20,17 +20,16 @@ import warnings
 import numpy as np
 from scipy import sparse as sp
 
-from onedal.common._backend import BackendFunction
-from onedal.utils import _sycl_queue_manager as QM
-
 from sklearn.preprocessing import LabelEncoder
 
 from daal4py.sklearn.utils.validation import (
     _assert_all_finite as _daal4py_assert_all_finite,
 )
-from onedal import _default_backend as backend
-from onedal.datatypes import to_table
 
+from .. import _default_backend as backend
+from ..common._backend import BackendFunction
+from ..datatypes import to_table
+from ..onedal.utils import _sycl_queue_manager as QM
 
 class DataConversionWarning(UserWarning):
     """Warning used to notify implicit data conversions happening in the code."""


### PR DESCRIPTION
## Description

Further remove unused code.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
