### PR TITLE
[CI, Fix] Upgrade VC compiler from 2022 to 2026 on github actions `windows-2025` CI runners

### DIFF
--- a/.github/scripts/activate_components.bat
+++ b/.github/scripts/activate_components.bat
@@ -18,6 +18,8 @@ rem ============================================================================
 rem %1 - dpcpp activate flag
 
 rem prepare vc
+rem The Visual Studio installation is dependent on the github-actions runner
+rem version changes can be found in "C:\Program Files\Microsoft Visual Studio"
 call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 rem prepare only TBB from oneAPI if a parameter is given.
 IF "%1"=="" (call .\oneapi\setvars.bat) ELSE (call .\oneapi\tbb\latest\env\vars.bat)

--- a/.github/scripts/activate_components.bat
+++ b/.github/scripts/activate_components.bat
@@ -18,7 +18,7 @@ rem ============================================================================
 rem %1 - dpcpp activate flag
 
 rem prepare vc
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
+call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 rem prepare only TBB from oneAPI if a parameter is given.
 IF "%1"=="" (call .\oneapi\setvars.bat) ELSE (call .\oneapi\tbb\latest\env\vars.bat)
 rem prepare oneDAL


### PR DESCRIPTION
## Description

2022 is no longer default on windows-2025 runners, which was removed and is causing CI failures. This upgrades the compiler to 2026 (18) in order to get CI operational.

Follow-up, transition other windows CI testing and references to 2026 (vc18).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
