### PR TITLE
[maintenance] Drop use of `daal_check_version` in `onedal` module

### DIFF
--- a/doc/sources/contributor-reference.rst
+++ b/doc/sources/contributor-reference.rst
@@ -63,10 +63,16 @@ OneDAL
 
 The |sklearnex| is intended to be backwards-compatible with different versions of the |onedal|, but not forwards-compatible except within a major release series - meaning: it is meant to run with a version of the |onedal| that is lower or equal than the version of the |sklearnex|, such that ``onedal==2025.0`` + ``sklearnex==2025.0`` and ``onedal==2025.0`` + ``sklearnex==2025.2`` should both work correctly, even though the latter might not expose the same functionalities with ``onedal==2025.0`` as with ``onedal==2025.2``.
 
-This is achieved with conditional runtime checks of the library versions in order to determine whether some class or function or similar should be defined or not, through the provided function ``daal_check_version``, which accepts a tuple as argument containing the major version number, the ``"P"`` string (other possibilities for this parameter are not used anymore), and the minor version **multiplied by 100**. So for example, if a given piece of code requires ``onedal>=2025.2``, the function should be called as follows:
+This is achieved with conditional runtime checks of the library versions in order to determine whether some class or function or similar should be defined or not. This is provided through the provided function  ``onedal_check_version`` for ``onedal`` and ``daal_check_version`` for ``daal4py``. ``onedal_check_version`` accepts three integer inputs: major version, minor version, and update version. ``daal_check_version`` accepts a tuple as argument containing the major version number, the ``"P"`` string (other possibilities for this parameter are not used anymore), and the minor version **multiplied by 100**.  So for example, if a given piece of code requires ``onedal>=2025.2``, the function should be called as follows:
 
 .. code-block:: python
 
+    if onedal_check_version(2025, 2, 0):
+        # code branch for onedal>=2025.2
+    else:
+        # code branch for onedal<2025.2
+
+    # equivalent code for the daal4py module
     if daal_check_version((2025, "P", 200)):
         # code branch for onedal>=2025.2
     else:

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -200,7 +200,7 @@ def onedal_check_version(
         Minor version to compare against oneDAL's LibraryVersionInfo.minorVersion.
     update : int
         Update version to compare against oneDAL's LibraryVersionInfo.updateVersion.
-    _v: tuple(int, int, int), default=_default_backend.__version_tuple__
+    _v : tuple(int, int, int), default=_default_backend.__version_tuple__
         Version tuple defined by oneDAL (major, minor, update) to compare against.
 
     Returns

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -189,7 +189,27 @@ def _ensure_dpc_available(require_spmd: bool = False) -> None:
     )
 
 
-# Core modules to export
+def onedal_check_version(major: int, minor: int, update: int, _v=_default_backend.__version_tuple__) -> bool:
+    """Check if runtime onedal library version is greater than or equal to a required version.
+    
+    Parameters
+    ----------
+    major : int
+        major version to compare against oneDAL's LibraryVersionInfo.majorVersion
+    minor : int
+        minor version to compare against oneDAL's LibraryVersionInfo.minorVersion
+    update : int
+        update version to compare against oneDAL's LibraryVersionInfo.updateVersion
+
+    Returns
+    -------
+        bool
+            runtime oneDAL version is greater than or equal to the given required oneDAL version
+    """
+    return _v >= (major, minor, update)
+
+
+# Core modules and functions to export
 __all__ = [
     "_ensure_dpc_available",
     "_host_backend",
@@ -201,27 +221,28 @@ __all__ = [
     "dummy",
     "ensemble",
     "neighbors",
+    "onedal_check_version",
     "primitives",
     "svm",
 ]
 
 # Additional features based on version checks
-if daal_check_version((2023, "P", 100)):
+if onedal_check_version(2023, 1, 0):
     __all__ += ["basic_statistics", "linear_model"]
-if daal_check_version((2023, "P", 200)):
+if onedal_check_version(2023, 2, 0):
     __all__ += ["cluster"]
 
 # Exports if SPMD backend is available
 if _spmd_backend is not None:
     __all__ += ["spmd"]
-    if daal_check_version((2023, "P", 100)):
+    if onedal_check_version(2023, 1, 0):
         __all__ += [
             "spmd.basic_statistics",
             "spmd.decomposition",
             "spmd.linear_model",
             "spmd.neighbors",
         ]
-    if daal_check_version((2023, "P", 200)):
+    if onedal_check_version(2023, 2, 0):
         __all__ += ["spmd.cluster"]
 
 __version__ = "2199.9.9"

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -195,11 +195,13 @@ def onedal_check_version(
     Parameters
     ----------
     major : int
-        major version to compare against oneDAL's LibraryVersionInfo.majorVersion
+        Major version to compare against oneDAL's LibraryVersionInfo.majorVersion.
     minor : int
-        minor version to compare against oneDAL's LibraryVersionInfo.minorVersion
+        Minor version to compare against oneDAL's LibraryVersionInfo.minorVersion.
     update : int
-        update version to compare against oneDAL's LibraryVersionInfo.updateVersion
+        Update version to compare against oneDAL's LibraryVersionInfo.updateVersion.
+    _v: tuple(int, int, int), default=_default_backend.__version_tuple__
+        Version tuple defined by oneDAL (major, minor, update) to compare against.
 
     Returns
     -------

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import importlib
+import importlib.util
 import platform
 
 

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -189,9 +189,11 @@ def _ensure_dpc_available(require_spmd: bool = False) -> None:
     )
 
 
-def onedal_check_version(major: int, minor: int, update: int, _v=_default_backend.__version_tuple__) -> bool:
+def onedal_check_version(
+    major: int, minor: int, update: int, _v=_default_backend.__version_tuple__
+) -> bool:
     """Check if runtime onedal library version is greater than or equal to a required version.
-    
+
     Parameters
     ----------
     major : int

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -206,7 +206,7 @@ def onedal_check_version(
     Returns
     -------
         bool
-            runtime oneDAL version is greater than or equal to the given required oneDAL version
+        Runtime oneDAL version is greater than or equal to the given required oneDAL version.
     """
     return _v >= (major, minor, update)
 

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -82,6 +82,13 @@ if "Windows" in platform.system():
             if os.path.exists(dal_root_redist):
                 os.add_dll_directory(dal_root_redist)
 
+        # duplicates behavior in daal4py.__init__ to allow for independent
+        # loading of the onedal_core.dll without daal4py in onedal.__init__
+        if "TBBROOT" in os.environ:
+            tbb_root_dir = os.path.join(os.environ["TBBROOT"], "bin")
+            if os.path.exists(tbb_root_dir):
+                os.add_dll_directory(tbb_root_dir)
+
         if _backend_binary_present("_onedal_py_dpc"):
             for dep_root in ["CMPLR_ROOT", "MKLROOT"]:
                 if dep_root in os.environ:

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -18,8 +18,6 @@
 import importlib
 import platform
 
-from daal4py.sklearn._utils import daal_check_version
-
 
 class Backend:
 

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -206,7 +206,7 @@ def onedal_check_version(
     Returns
     -------
         bool
-        Runtime oneDAL version is greater than or equal to the given required oneDAL version.
+            Runtime oneDAL version is greater than or equal to the given required oneDAL version.
     """
     return _v >= (major, minor, update)
 

--- a/onedal/cluster/__init__.py
+++ b/onedal/cluster/__init__.py
@@ -14,14 +14,14 @@
 # limitations under the License.
 # ==============================================================================
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 
 from .dbscan import DBSCAN
 from .kmeans import KMeans
 
 __all__ = ["DBSCAN", "KMeans"]
 
-if daal_check_version((2023, "P", 200)):
+if onedal_check_version(2023, 2, 0):
     from .kmeans_init import KMeansInit, kmeans_plusplus
 
     __all__ += ["KMeansInit", "kmeans_plusplus"]

--- a/onedal/cluster/kmeans.py
+++ b/onedal/cluster/kmeans.py
@@ -19,13 +19,13 @@ from abc import ABC
 
 import numpy as np
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 from onedal._device_offload import supports_queue
 from onedal.basic_statistics import BasicStatistics
 from onedal.common._backend import bind_default_backend
 from onedal.utils import _sycl_queue_manager as QM
 
-if daal_check_version((2023, "P", 200)):
+if onedal_check_version(2023, 2, 0):
     from .kmeans_init import KMeansInit
 
 from sklearn.cluster._kmeans import _kmeans_plusplus
@@ -212,7 +212,7 @@ class KMeans(ABC):
         random_state = check_random_state(self.random_state)
 
         init = self.init
-        use_onedal_init = daal_check_version((2023, "P", 200)) and not callable(self.init)
+        use_onedal_init = onedal_check_version(2023, 2, 0) and not callable(self.init)
 
         # Resolve n_init from 'auto' to integer if not already resolved
         # by the sklearnex layer (_resolve_n_init).

--- a/onedal/cluster/kmeans_init.py
+++ b/onedal/cluster/kmeans_init.py
@@ -17,7 +17,7 @@
 import numpy as np
 from sklearn.utils import check_random_state
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 from onedal._device_offload import supports_queue
 from onedal.common._backend import bind_default_backend
 from onedal.utils import _sycl_queue_manager as QM
@@ -25,7 +25,7 @@ from sklearnex._config import config_context, get_config
 
 from ..datatypes import from_table, to_table
 
-if daal_check_version((2023, "P", 200)):
+if onedal_check_version(2023, 2, 0):
 
     def force_host_if_csr(func):
         """

--- a/onedal/common/hyperparameters.py
+++ b/onedal/common/hyperparameters.py
@@ -18,10 +18,10 @@ import logging
 from typing import Callable, Dict, Tuple
 from warnings import warn
 
-from daal4py.sklearn._utils import daal_check_version
 from onedal import _default_backend as backend
+from onedal import onedal_check_version
 
-if not daal_check_version((2024, "P", 0)):
+if not onedal_check_version(2024, 0, 0):
     warn("Hyperparameters are supported in oneDAL starting from 2024.0.0 version.")
     hyperparameters_map = {}
 else:
@@ -101,11 +101,11 @@ else:
         ): lambda: backend.linear_model.regression.train_hyperparameters(),
         ("covariance", "compute"): lambda: backend.covariance.compute_hyperparameters(),
     }
-    if daal_check_version((2024, "P", 300)):
+    if onedal_check_version(2024, 3, 0):
         hyperparameters_backend[("decision_forest", "infer")] = (
             lambda: backend.decision_forest.infer_hyperparameters()
         )
-    if daal_check_version((2025, "P", 700)):
+    if onedal_check_version(2025, 7, 0):
         hyperparameters_backend[("pca", "train")] = (
             lambda: backend.decomposition.dim_reduction.train_hyperparameters()
         )

--- a/onedal/covariance/covariance.py
+++ b/onedal/covariance/covariance.py
@@ -17,7 +17,7 @@ from abc import ABCMeta
 
 import numpy as np
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 from onedal._device_offload import supports_queue
 from onedal.common._backend import bind_default_backend
 
@@ -41,9 +41,9 @@ class BaseEmpiricalCovariance(metaclass=ABCMeta):
             "fptype": dtype,
             "method": self.method,
         }
-        if daal_check_version((2024, "P", 1)):
+        if onedal_check_version(2024, 0, 1):
             params["bias"] = self.bias
-        if daal_check_version((2024, "P", 400)):
+        if onedal_check_version(2024, 4, 0):
             params["assumeCentered"] = self.assume_centered
 
         return params
@@ -108,7 +108,7 @@ class EmpiricalCovariance(BaseEmpiricalCovariance):
             result = self.compute(params, hparams.backend, X_table)
         else:
             result = self.compute(params, X_table)
-        if daal_check_version((2024, "P", 1)) or (not self.bias):
+        if onedal_check_version(2024, 0, 1) or (not self.bias):
             self.covariance_ = from_table(result.cov_matrix, like=X)
         else:
             self.covariance_ = (

--- a/onedal/covariance/incremental_covariance.py
+++ b/onedal/covariance/incremental_covariance.py
@@ -16,7 +16,7 @@
 
 import numpy as np
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 
 from .._device_offload import supports_queue
 from ..common._backend import bind_default_backend
@@ -136,7 +136,7 @@ class IncrementalEmpiricalCovariance(BaseEmpiricalCovariance):
 
             self.covariance_ = from_table(result.cov_matrix, like=self._outtype)
 
-            if self.bias and not daal_check_version((2024, "P", 1)):
+            if self.bias and not onedal_check_version(2024, 0, 1):
                 n_rows = self._partial_result.partial_n_rows
                 self.covariance_ *= (n_rows - 1) / n_rows
 

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -83,10 +83,7 @@ ONEDAL_PY_INIT_MODULE(dummy);
 
 // function placed here for use within the module generation functions
 bool check_version(const int major, const int minor, const int update){
-    return (major > MAJOR_VERSION ||
-        (major == MAJOR_VERSION &&
-        (minor > MINOR_VERSION ||
-        (minor == MINOR_VERSION && update >= UPDATE_VERSION))));
+    return (
 }
 
 #ifdef ONEDAL_DATA_PARALLEL_SPMD
@@ -155,7 +152,10 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     std::string ver = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." +
                       std::to_string(UPDATE_VERSION);
 
-    if (!check_version(li.majorVersion, li.minorVersion, li.updateVersion)) {
+    if (li.majorVersion < MAJOR_VERSION ||
+        (li.majorVersion == MAJOR_VERSION &&
+         (li.minorVersion < MINOR_VERSION ||
+          (li.minorVersion == MINOR_VERSION && li.updateVersion < UPDATE_VERSION)))) {
         throw py::import_error(
             "Loaded oneDAL library version is below that used to compile the pybind11 interface (" +
             ver + ")");
@@ -164,16 +164,12 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     m.attr("__version__") = std::to_string(li.majorVersion) + "." +
                             std::to_string(li.minorVersion) + "." +
                             std::to_string(li.updateVersion);
+    // fastest way (no lru_cache, no C++ conversion, direct python) is to do a tuple version comparison
+    // __version__ is exposed for users, __version_tuple__ is used within the onedal_check_version
+    // function
+    m.attr("__version_tuple__") = py::make_tuple(li.majorVersion, li.minorVersion, li.updateVersion);
     m.attr("__compiled_version__") = ver;
 
-    m.def("onedal_check_version", [](const std::string& version){
-        auto d1 = version.find(".");
-        auto d2 = version.find(".", d1 + 1);
-        int major = std::stoi(version.substr(0,d1));
-        int minor = std::stoi(version.substr(d1 + 1, d2 - d1 - 1));
-        int update = std::stoi(version.substr(d2 + 1));
-        return check_version(major, minor, update);
-    }, "simple interface for checking oneDAL compatability");
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -140,7 +140,18 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     init_finiteness_checker(m);
 #endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20240700
     init_dummy(m);
-    m.attr("__version__") = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." + std::to_string(UPDATE_VERSION);
+
+    // verify thath the proper version of oneDAL at runtime is used versus what was used for compilation
+    // must be done with daal as there is no oneDAL equivalent
+    daal::services::LibraryVersionInfo li;
+    std::string ver = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." + std::to_string(UPDATE_VERSION);
+
+    if (li.majorVersion < MAJOR_VERSION || (li.majorVersion == MAJOR_VERSION && (li.minorVersion < MINOR_VERSION || (li.minorVersion == MINOR_VERSION && li.updateVersion < UPDATE_VERSION )))){
+        throw py::import_error("Loaded oneDAL library version is below that used to compile the pybind11 interface (" + ver + ")");
+        }
+    
+    m.attr("__version__") = std::to_string(li.majorVersion) + "." + std::to_string(li.minorVersion) + "." + std::to_string(li.updateVersion);
+    m.attr("__compiled_version__") = ver;
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -140,6 +140,7 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     init_finiteness_checker(m);
 #endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20240700
     init_dummy(m);
+    m.attr("__version__") = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." + std::to_string(UPDATE_VERSION);
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -144,13 +144,21 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     // verify thath the proper version of oneDAL at runtime is used versus what was used for compilation
     // must be done with daal as there is no oneDAL equivalent
     daal::services::LibraryVersionInfo li;
-    std::string ver = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." + std::to_string(UPDATE_VERSION);
+    std::string ver = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." +
+                      std::to_string(UPDATE_VERSION);
 
-    if (li.majorVersion < MAJOR_VERSION || (li.majorVersion == MAJOR_VERSION && (li.minorVersion < MINOR_VERSION || (li.minorVersion == MINOR_VERSION && li.updateVersion < UPDATE_VERSION )))){
-        throw py::import_error("Loaded oneDAL library version is below that used to compile the pybind11 interface (" + ver + ")");
-        }
-    
-    m.attr("__version__") = std::to_string(li.majorVersion) + "." + std::to_string(li.minorVersion) + "." + std::to_string(li.updateVersion);
+    if (li.majorVersion < MAJOR_VERSION ||
+        (li.majorVersion == MAJOR_VERSION &&
+         (li.minorVersion < MINOR_VERSION ||
+          (li.minorVersion == MINOR_VERSION && li.updateVersion < UPDATE_VERSION)))) {
+        throw py::import_error(
+            "Loaded oneDAL library version is below that used to compile the pybind11 interface (" +
+            ver + ")");
+    }
+
+    m.attr("__version__") = std::to_string(li.majorVersion) + "." +
+                            std::to_string(li.minorVersion) + "." +
+                            std::to_string(li.updateVersion);
     m.attr("__compiled_version__") = ver;
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -162,7 +162,8 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     // fastest way (no lru_cache, no C++ conversion, direct python) is to do a tuple version comparison
     // __version__ is exposed for users, __version_tuple__ is used within the onedal_check_version
     // function
-    m.attr("__version_tuple__") = py::make_tuple(li.majorVersion, li.minorVersion, li.updateVersion);
+    m.attr("__version_tuple__") =
+        py::make_tuple(li.majorVersion, li.minorVersion, li.updateVersion);
     m.attr("__compiled_version__") = ver;
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -81,6 +81,14 @@ ONEDAL_PY_INIT_MODULE(finiteness_checker);
 ONEDAL_PY_INIT_MODULE(dummy);
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 
+// function placed here for use within the module generation functions
+bool check_version(const int major, const int minor, const int update){
+    return (major > MAJOR_VERSION ||
+        (major == MAJOR_VERSION &&
+        (minor > MINOR_VERSION ||
+        (minor == MINOR_VERSION && update >= UPDATE_VERSION))));
+}
+
 #ifdef ONEDAL_DATA_PARALLEL_SPMD
 PYBIND11_MODULE(_onedal_py_spmd_dpc, m) {
     init_policy(m);
@@ -141,16 +149,13 @@ PYBIND11_MODULE(_onedal_py_host, m) {
 #endif // defined(ONEDAL_VERSION) && ONEDAL_VERSION >= 20240700
     init_dummy(m);
 
-    // verify thath the proper version of oneDAL at runtime is used versus what was used for compilation
+    // verify that the proper version of oneDAL at runtime is used versus what was used for compilation
     // must be done with daal as there is no oneDAL equivalent
     daal::services::LibraryVersionInfo li;
     std::string ver = std::to_string(MAJOR_VERSION) + "." + std::to_string(MINOR_VERSION) + "." +
                       std::to_string(UPDATE_VERSION);
 
-    if (li.majorVersion < MAJOR_VERSION ||
-        (li.majorVersion == MAJOR_VERSION &&
-         (li.minorVersion < MINOR_VERSION ||
-          (li.minorVersion == MINOR_VERSION && li.updateVersion < UPDATE_VERSION)))) {
+    if (!check_version(li.majorVersion, li.minorVersion, li.updateVersion)) {
         throw py::import_error(
             "Loaded oneDAL library version is below that used to compile the pybind11 interface (" +
             ver + ")");
@@ -160,6 +165,15 @@ PYBIND11_MODULE(_onedal_py_host, m) {
                             std::to_string(li.minorVersion) + "." +
                             std::to_string(li.updateVersion);
     m.attr("__compiled_version__") = ver;
+
+    m.def("onedal_check_version", [](const std::string& version){
+        auto d1 = version.find(".");
+        auto d2 = version.find(".", d1 + 1);
+        int major = std::stoi(version.substr(0,d1));
+        int minor = std::stoi(version.substr(d1 + 1, d2 - d1 - 1));
+        int update = std::stoi(version.substr(d2 + 1));
+        return check_version(major, minor, update);
+    }, "simple interface for checking oneDAL compatability");
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 

--- a/onedal/dal.cpp
+++ b/onedal/dal.cpp
@@ -81,11 +81,6 @@ ONEDAL_PY_INIT_MODULE(finiteness_checker);
 ONEDAL_PY_INIT_MODULE(dummy);
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 
-// function placed here for use within the module generation functions
-bool check_version(const int major, const int minor, const int update){
-    return (
-}
-
 #ifdef ONEDAL_DATA_PARALLEL_SPMD
 PYBIND11_MODULE(_onedal_py_spmd_dpc, m) {
     init_policy(m);
@@ -169,7 +164,6 @@ PYBIND11_MODULE(_onedal_py_host, m) {
     // function
     m.attr("__version_tuple__") = py::make_tuple(li.majorVersion, li.minorVersion, li.updateVersion);
     m.attr("__compiled_version__") = ver;
-
 }
 #endif // ONEDAL_DATA_PARALLEL_SPMD
 

--- a/onedal/ensemble/forest.py
+++ b/onedal/ensemble/forest.py
@@ -18,7 +18,7 @@ import math
 import numbers
 from abc import ABC, abstractmethod
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 from onedal._device_offload import supports_queue
 from onedal.common._backend import bind_default_backend
 from onedal.utils import _sycl_queue_manager as QM
@@ -138,7 +138,7 @@ class BaseForest(ABC):
             "voting_mode": self.voting_mode,  # used in classification only
         }
 
-        if daal_check_version((2023, "P", 101)):
+        if onedal_check_version(2023, 1, 1):
             onedal_params["splitter_mode"] = self.splitter_mode
         return onedal_params
 

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -18,7 +18,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 
 from .._device_offload import supports_queue
 from ..common._backend import bind_default_backend
@@ -56,7 +56,7 @@ class BaseLinearRegression(metaclass=ABCMeta):
             "intercept": self.fit_intercept,
             "result_option": (intercept + "coefficients"),
         }
-        if daal_check_version((2024, "P", 600)):
+        if onedal_check_version(2024, 6, 0):
             params["alpha"] = self.alpha
 
         return params

--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -18,7 +18,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from daal4py.sklearn._utils import daal_check_version
+from onedal import onedal_check_version
 from onedal._device_offload import supports_queue
 from onedal.common._backend import bind_default_backend
 
@@ -80,7 +80,7 @@ class BaseLogisticRegression(metaclass=ABCMeta):
         self.n_iter_ = np.array([result.iterations_count])
 
         # _n_inner_iter is the total number of cg-solver iterations
-        if daal_check_version((2024, "P", 300)) and self.solver == "newton-cg":
+        if onedal_check_version(2024, 3, 0) and self.solver == "newton-cg":
             self._n_inner_iter = result.inner_iterations_count
 
         coeff = from_table(result.model.packed_coefficients, like=X)


### PR DESCRIPTION
## Description

This is necessary for removing sklearn dependency from the `onedal` module, which we currently rely on `daal4py` for (which imports sklearn). This will standardize use around python version checking for simplicity and reuse.

Just as a note: using a tuple comparison in Python is faster than lru_cache and faster than converting data to C++ for a similar comparison there (either by string etc.). We also simplify the interface to be different than `daal_check_version` which is easier to understand and use.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
