### PR TITLE
MAINT: Remove logic of falling back to scikit-learn after linear model fit failures

### DIFF
--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -290,30 +290,16 @@ class LinearRegression(oneDALEstimator, _sklearn_LinearRegression, _BaseLinearMo
 
         self._initialize_onedal_estimator()
 
-        try:
-            self._onedal_estimator.fit(X, y, queue=queue)
+        self._onedal_estimator.fit(X, y, queue=queue)
 
-            self.n_features_in_ = self._onedal_estimator.n_features_in_
-            self._sparse = False
-            self._coef_ = self._onedal_estimator.coef_
-            self._intercept_ = self._onedal_estimator.intercept_
+        self.n_features_in_ = self._onedal_estimator.n_features_in_
+        self._sparse = False
+        self._coef_ = self._onedal_estimator.coef_
+        self._intercept_ = self._onedal_estimator.intercept_
 
-            if self._coef_.shape[0] == 1 and y.ndim == 1:
-                self._coef_ = self._coef_[0, ...]  # set to 1d
-                self._intercept_ = self._intercept_[0]  # set 1d to scalar
-
-        except RuntimeError as e:
-            if get_config()["allow_sklearn_after_onedal"]:
-
-                logging.getLogger("sklearnex").info(
-                    f"{self.__class__.__name__}.fit "
-                    + get_patch_message("sklearn_after_onedal")
-                )
-
-                del self._onedal_estimator
-                super().fit(X, y)
-            else:
-                raise e
+        if self._coef_.shape[0] == 1 and y.ndim == 1:
+            self._coef_ = self._coef_[0, ...]  # set to 1d
+            self._intercept_ = self._intercept_[0]  # set 1d to scalar
 
     def _onedal_predict(self, X, queue=None):
         xp, _ = get_namespace(X)

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -442,22 +442,8 @@ if daal_check_version((2024, "P", 1)):
                 y_bin = xp.asarray(y == self.classes_[1], dtype=xp.int32)
 
             self._onedal_gpu_initialize_estimator()
-            try:
-                self._onedal_estimator.fit(X, y_bin, queue=queue)
-                self._onedal_gpu_save_attributes()
-            except RuntimeError as err:
-                if get_config()["allow_sklearn_after_onedal"]:
-
-                    logging.getLogger("sklearnex").info(
-                        f"{self.__class__.__name__}.fit "
-                        + get_patch_message("sklearn_after_onedal")
-                    )
-                    msg = f"Sklearnex LogisticRegression estimator failed with error: {err}, falling back to sklearn implementation."
-                    logging.warning(msg)
-                    del self._onedal_estimator
-                    super().fit(X, y)
-                else:
-                    raise err
+            self._onedal_estimator.fit(X, y_bin, queue=queue)
+            self._onedal_gpu_save_attributes()
 
         # This should only be called when 'X' is on CPU
         def _error_out_on_incompatible_devices(self, X, method_name: str) -> None:


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

There is some logic in some linear models to fall back to scikit-learn if oneDAL fitting procedures fail (introduced in https://github.com/uxlfoundation/scikit-learn-intelex/pull/1907), but:
* In the case of linear regression, both the CPU and GPU versions by now have C++ fallbacks to try more robust methods when the first one fails (e.g. data with linear dependencies).
* When the input is originally on GPU, it would trigger a fallback to CPU with scikit-learn, which is usually not desirable. Better would be to let it fail.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
