### PR TITLE
FIX: Fix dtype of coefficients from LogisticRegression being hardcoded to float64

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -172,7 +172,9 @@ def logistic_regression_path_d4p(
         X = check_array(
             X,
             accept_sparse=False,
-            dtype=[np.float64, np.float32],
+            dtype=(
+                [np.float64, np.float32] if sklearn_check_version("1.9") else np.float64
+            ),
             accept_large_sparse=False,
         )
         y = check_array(y, ensure_2d=False, dtype=None)
@@ -382,7 +384,7 @@ def logistic_regression_path_d4p(
             w0, loss = opt_res.x, opt_res.fun
             if C_daal_multiplier == 2:
                 w0 /= 2
-            if w0.dtype != X.dtype:
+            if w0.dtype != X.dtype and sklearn_check_version("1.9"):
                 w0 = w0.astype(X.dtype)
         elif solver == "newton-cg":
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -172,7 +172,7 @@ def logistic_regression_path_d4p(
         X = check_array(
             X,
             accept_sparse=False,
-            dtype=np.float64,
+            dtype=[np.float64, np.float32],
             accept_large_sparse=False,
         )
         y = check_array(y, ensure_2d=False, dtype=None)
@@ -195,22 +195,24 @@ def logistic_regression_path_d4p(
 
     le = LabelEncoder().fit(classes)
 
+    # Note: the LBFGS solver from SciPy will always cast the input to float64
+    w0_dtype = X.dtype if solver != "lbfgs" else np.float64
     if sklearn_check_version("1.8"):
         if is_binary:
             y_bin = (y == pos_class).astype(X.dtype)
-            w0 = np.zeros(n_features + 1, dtype=X.dtype)
+            w0 = np.zeros(n_features + 1, dtype=w0_dtype)
         else:
             Y_multi = le.transform(y).astype(X.dtype, copy=False)
-            w0 = np.zeros((classes.size, n_features + 1), order="C", dtype=X.dtype)
+            w0 = np.zeros((classes.size, n_features + 1), order="C", dtype=w0_dtype)
     else:
         # For doing a ovr, we need to mask the labels first. for the
         # multinomial case this is not necessary.
         if multi_class == "ovr":
             y_bin = (y == pos_class).astype(X.dtype)
-            w0 = np.zeros(n_features + 1, dtype=X.dtype)
+            w0 = np.zeros(n_features + 1, dtype=w0_dtype)
         else:
             Y_multi = le.fit_transform(y).astype(X.dtype, copy=False)
-            w0 = np.zeros((classes.size, n_features + 1), order="C", dtype=X.dtype)
+            w0 = np.zeros((classes.size, n_features + 1), order="C", dtype=w0_dtype)
 
     # Adoption of https://github.com/scikit-learn/scikit-learn/pull/26721
     sw_sum = len(X)
@@ -380,6 +382,8 @@ def logistic_regression_path_d4p(
             w0, loss = opt_res.x, opt_res.fun
             if C_daal_multiplier == 2:
                 w0 /= 2
+            if w0.dtype != X.dtype:
+                w0 = w0.astype(X.dtype)
         elif solver == "newton-cg":
 
             def make_ncg_funcs(f, value=False, gradient=False, hessian=False):

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -830,3 +830,15 @@ def test_no_warning_for_n_jobs():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=FutureWarning)
         model.fit(X, y, w)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_dtype_is_preserved(dtype):
+    from sklearnex.linear_model import LogisticRegression
+
+    rng = np.random.default_rng(seed=123)
+    X = rng.random(size=(10, 3)).astype(dtype)
+    y = rng.integers(2, size=X.shape[0]).astype(np.int64)
+    model = LogisticRegression().fit(X, y)
+    assert model.coef_.dtype == X.dtype
+    assert model.intercept_.dtype == X.dtype

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -485,7 +485,7 @@ def test_custom_solvers_are_correct(multi_class, C, solver, n_classes):
     )
 
     params = {"C": C}
-    if not sklearn_check_version:
+    if multi_class is not None:
         params["multi_class"] = multi_class
 
     with warnings.catch_warnings():

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -832,6 +832,10 @@ def test_no_warning_for_n_jobs():
         model.fit(X, y, w)
 
 
+@pytest.mark.skipif(
+    not sklearn_check_version("1.9"),
+    reason="Functionality introduced in later sklearn versions",
+)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_dtype_is_preserved(dtype):
     from sklearnex.linear_model import LogisticRegression


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

In the newest versions of sklearn, the default solver for logistic regression can work with float32 inputs, but works by casting data in several places.

This PR updates the logic in sklearnex to follow sklearn, which would now match the dtype of the coefficients with the dtype of 'X' like it does for other linear model classes.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
