### PR TITLE
MAINT: Downgrade pandas due to yanked release

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ numpy>=2.0.0 ; python_version >= '3.12'
 scikit-learn==1.7.2 ; python_version <= '3.10'
 scikit-learn==1.9.0 ; python_version >= '3.11'
 pandas==2.1.3 ; python_version <= '3.10'
-pandas==3.0.4 ; python_version >= '3.11'
+pandas==3.0.3 ; python_version >= '3.11'
 xgboost==3.2.0 ; python_version <= '3.11'
 xgboost==3.3.0 ; python_version >= '3.12'
 lightgbm==4.6.0


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Pandas version 3.0.4 specified in the requirements is marked as yanked, which leads to observing warnings and errors in CI jobs:
https://pypi.org/project/pandas/3.0.4/

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
