### PR TITLE
Fix deprecated Coverity scan keys usage

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -53,8 +53,7 @@ jobs:
       conda activate CB
       pip install -r dependencies-dev
       export DALROOT=$CONDA_PREFIX
-      $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int --no-command --fs-capture-search .
-      $(COVERITY_TOOL_HOME)/bin/cov-build --dir cov-int -- python setup.py build_ext --inplace
+      $(COVERITY_TOOL_HOME)/bin/coverity capture --project-dir . --dir cov-int --language python
       zip -r daal4py.zip cov-int
     displayName: 'Perform Coverity scan'
   - script: |


### PR DESCRIPTION
## Description

Fixed outdated Coverity scan options **--no-command** and **--fs-capture-search** usage, deprecated starting 2024.12.0 client version.

<!--

-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

</details>
