### PR TITLE
[fix] correct addition of of the `spmd` submodule to `onedal.__all__` to follow proper importing standards

### DIFF
--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -244,14 +244,5 @@ if onedal_check_version(2023, 2, 0):
 # Exports if SPMD backend is available
 if _spmd_backend is not None:
     __all__ += ["spmd"]
-    if onedal_check_version(2023, 1, 0):
-        __all__ += [
-            "spmd.basic_statistics",
-            "spmd.decomposition",
-            "spmd.linear_model",
-            "spmd.neighbors",
-        ]
-    if onedal_check_version(2023, 2, 0):
-        __all__ += ["spmd.cluster"]
 
 __version__ = "2199.9.9"

--- a/onedal/spmd/__init__.py
+++ b/onedal/spmd/__init__.py
@@ -21,12 +21,8 @@ from .. import onedal_check_version
 __all__ = ["covariance", "ensemble"]
 
 if onedal_check_version(2023, 1, 0):
-    from . import (
-        basic_statistics,
-        decomposition,
-        linear_model,
-        neighbors
-    )
+    from . import basic_statistics, decomposition, linear_model, neighbors
+ 
     __all__ += [
         "basic_statistics",
         "decomposition",
@@ -35,4 +31,5 @@ if onedal_check_version(2023, 1, 0):
     ]
 if onedal_check_version(2023, 2, 0):
     from . import cluster
+
     __all__ += ["cluster"]

--- a/onedal/spmd/__init__.py
+++ b/onedal/spmd/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 
-from . import covariance, ensemble
 from .. import onedal_check_version
+from . import covariance, ensemble
 
 
 __all__ = ["covariance", "ensemble"]

--- a/onedal/spmd/__init__.py
+++ b/onedal/spmd/__init__.py
@@ -22,7 +22,7 @@ __all__ = ["covariance", "ensemble"]
 
 if onedal_check_version(2023, 1, 0):
     from . import basic_statistics, decomposition, linear_model, neighbors
- 
+
     __all__ += [
         "basic_statistics",
         "decomposition",

--- a/onedal/spmd/__init__.py
+++ b/onedal/spmd/__init__.py
@@ -17,7 +17,6 @@
 from .. import onedal_check_version
 from . import covariance, ensemble
 
-
 __all__ = ["covariance", "ensemble"]
 
 if onedal_check_version(2023, 1, 0):

--- a/onedal/spmd/__init__.py
+++ b/onedal/spmd/__init__.py
@@ -14,22 +14,25 @@
 # limitations under the License.
 # ==============================================================================
 
-from . import (
-    basic_statistics,
-    cluster,
-    covariance,
-    decomposition,
-    ensemble,
-    linear_model,
-    neighbors,
-)
+from . import covariance, ensemble
+from .. import onedal_check_version
 
-__all__ = [
-    "basic_statistics",
-    "cluster",
-    "covariance",
-    "decomposition",
-    "ensemble",
-    "linear_model",
-    "neighbors",
-]
+
+__all__ = ["covariance", "ensemble"]
+
+if onedal_check_version(2023, 1, 0):
+    from . import (
+        basic_statistics,
+        decomposition,
+        linear_model,
+        neighbors
+    )
+    __all__ += [
+        "basic_statistics",
+        "decomposition",
+        "linear_model",
+        "neighbors",
+    ]
+if onedal_check_version(2023, 2, 0):
+    from . import cluster
+    __all__ += ["cluster"]


### PR DESCRIPTION
## Description

Should correct issues of importing using `from onedal import *` when an spmd backend is available and someone actually wants to use it that way. Doing sub sub modules in an all will mess with things. (https://docs.python.org/3/tutorial/modules.html#importing-from-a-package)

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
