### PR TITLE
Cleanup from skl1.0 removal via coverity

### DIFF
--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -132,15 +132,8 @@ def _daal4py_fit_enet(self, X, y_, check_input):
     penalty_L1 = penalty_L1.reshape((1, -1))
     penalty_L2 = penalty_L2.reshape((1, -1))
 
-    # normalizing and centering
+    # centering
     X_offset = np.zeros(X.shape[1], dtype=X.dtype)
-    X_scale = np.ones(X.shape[1], dtype=X.dtype)
-    if y.ndim == 1:
-        y_offset = X.dtype.type(0)
-    else:
-        y_offset = np.zeros(y.shape[1], dtype=X.dtype)
-
-    _normalize = False
     if self.fit_intercept:
         X_offset = np.average(X, axis=0)
 
@@ -148,11 +141,7 @@ def _daal4py_fit_enet(self, X, y_, check_input):
     if (
         isinstance(self.precompute, np.ndarray)
         and self.fit_intercept
-        and (
-            not np.allclose(X_offset, np.zeros(X.shape[1]))
-            or _normalize
-            and not np.allclose(X_scale, np.ones(X.shape[1]))
-        )
+        and not np.allclose(X_offset, np.zeros(X.shape[1]))
     ):
         warnings.warn(
             "Gram matrix was provided but X was centered"
@@ -185,9 +174,7 @@ def _daal4py_fit_enet(self, X, y_, check_input):
             inputArgument[i][0] = self.intercept_ if (n_rows == 1) else self.intercept_[i]
             inputArgument[i][1:] = self.coef_[:] if (n_rows == 1) else self.coef_[i, :]
         cd_solver.setup(inputArgument)
-    doUse_condition = self.copy_X is False or (
-        self.fit_intercept and _normalize and self.copy_X
-    )
+    doUse_condition = self.copy_X is False
     elastic_net_alg = daal4py.elastic_net_training(
         fptype=_fptype,
         method="defaultDense",
@@ -210,13 +197,6 @@ def _daal4py_fit_enet(self, X, y_, check_input):
     # set coef_ and intersept_ results
     elastic_net_model = elastic_net_res.model
     self.daal_model_ = elastic_net_model
-
-    # update coefficients if normalizing and centering
-    if self.fit_intercept and _normalize:
-        elastic_net_model.Beta[:, 1:] = elastic_net_model.Beta[:, 1:] / X_scale
-        elastic_net_model.Beta[:, 0] = (
-            y_offset - np.dot(X_offset, elastic_net_model.Beta[:, 1:].T)
-        ).T
 
     coefs = elastic_net_model.Beta
 
@@ -283,15 +263,8 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
     self.n_features_in_ = X.shape[1]
     self._y = y
 
-    # normalizing and centering
+    # centering
     X_offset = np.zeros(X.shape[1], dtype=X.dtype)
-    X_scale = np.ones(X.shape[1], dtype=X.dtype)
-    if y.ndim == 1:
-        y_offset = X.dtype.type(0)
-    else:
-        y_offset = np.zeros(y.shape[1], dtype=X.dtype)
-
-    _normalize = False
     if self.fit_intercept:
         X_offset = np.average(X, axis=0)
 
@@ -299,16 +272,11 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
     if (
         isinstance(self.precompute, np.ndarray)
         and self.fit_intercept
-        and (
-            not np.allclose(X_offset, np.zeros(X.shape[1]))
-            or _normalize
-            and not np.allclose(X_scale, np.ones(X.shape[1]))
-        )
+        and not np.allclose(X_offset, np.zeros(X.shape[1]))
     ):
         warnings.warn(
             "Gram matrix was provided but X was centered"
-            " to fit intercept, "
-            "or X was normalized : recomputing Gram matrix.",
+            " to fit intercept: recomputing Gram matrix.",
             UserWarning,
         )
 
@@ -341,9 +309,7 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
                 else self.coef_[i, :].copy(order="C")
             )
         cd_solver.setup(inputArgument)
-    doUse_condition = self.copy_X is False or (
-        self.fit_intercept and _normalize and self.copy_X
-    )
+    doUse_condition = self.copy_X is False
     lasso_alg = daal4py.lasso_regression_training(
         fptype=_fptype,
         method="defaultDense",
@@ -365,13 +331,6 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
     # set coef_ and intersept_ results
     lasso_model = lasso_res.model
     self.daal_model_ = lasso_model
-
-    # update coefficients if normalizing and centering
-    if self.fit_intercept and _normalize:
-        lasso_model.Beta[:, 1:] = lasso_model.Beta[:, 1:] / X_scale
-        lasso_model.Beta[:, 0] = (
-            y_offset - np.dot(X_offset, lasso_model.Beta[:, 1:].T)
-        ).T
 
     coefs = lasso_model.Beta
 


### PR DESCRIPTION
## Description

Small follow-up to #3259, addresses coverity hit

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
