### PR TITLE
DOC: Add reminder to inherit sklearn docstrings of methods

### DIFF
--- a/sklearnex/dummy/_dummy.py
+++ b/sklearnex/dummy/_dummy.py
@@ -89,6 +89,11 @@ from ..utils.validation import validate_data
 # parameters must extend the dictionary for checking.  This validation
 # normally occurs in the ``fit`` method.
 #
+# 11) All methods that are overridden from scikit-learn's base (e.g. 'fit')
+# or otherwise passed through some decorator must take the method docstrings
+# from scikit-learn's class, adding documentation for additional arguments
+# where appropriate, which might be accomplishable through programmatic
+# string replacements.
 
 ##########################
 # METHOD HIERARCHY NOTES #


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Adds a small comment in the instructions to inherit the docstrings from sklearn. This detail is already mentioned at the end of the same file, but somehow it got missed by LLMs when crafting the PR for MaxAbsScaler. Perhaps having it more clearly expressed in the instructions might help.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
