### PR TITLE
[maintenance] remove unnecessary imports from PCA sklearnex estimators

### DIFF
--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ===============================================================================
 
-import logging
-
 from daal4py.sklearn._utils import daal_check_version, is_sparse
 
 if daal_check_version((2024, "P", 100)):
@@ -26,7 +24,6 @@ if daal_check_version((2024, "P", 100)):
     from sklearn.decomposition import PCA as _sklearn_PCA
     from sklearn.decomposition._pca import _infer_dimension
     from sklearn.utils._array_api import get_namespace
-    from sklearn.utils._param_validation import StrOptions
     from sklearn.utils.extmath import stable_cumsum
     from sklearn.utils.validation import check_is_fitted
 

--- a/sklearnex/preview/decomposition/incremental_pca.py
+++ b/sklearnex/preview/decomposition/incremental_pca.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 
 from sklearn.decomposition import IncrementalPCA as _sklearn_IncrementalPCA
-from sklearn.utils import check_array, gen_batches
+from sklearn.utils import gen_batches
 from sklearn.utils._array_api import get_namespace
 from sklearn.utils._param_validation import StrOptions
 from sklearn.utils.validation import check_is_fitted


### PR DESCRIPTION
## Description

Quick follow-on to #3276 where some imports were left dangling.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
