### PR TITLE
Deselect flaky PCA XFAIL tests

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -77,6 +77,14 @@ deselected_tests:
   - tests/test_common.py::test_estimators[PCA()-check_array_api_input(array_namespace=array_api_strict,dtype_name=float32,device=array_api_strict.Device('device1'))] >=1.7,<1.9
   - tests/test_common.py::test_estimators[PCA()-check_array_api_input(array_namespace=array_api_strict,dtype_name=float64,device=array_api_strict.Device('CPU_DEVICE'))] >=1.7,<1.9
 
+  # PCA get_precision() inverts a rank-deficient covariance on the check's fixture; sklearn
+  # xfails these with "linalg.inv fails because input is singular" (gh-33205). The XPASS/XFAIL
+  # outcome is numerically unstable, so patched vs stock flip inconsistently.
+  - tests/test_common.py::test_estimators[PCA()-check_array_api_input(array_namespace=array_api_strict,device_name=CPU_DEVICE,dtype_name=float64)]
+  - tests/test_common.py::test_estimators[PCA()-check_array_api_input(array_namespace=array_api_strict,device_name=device1,dtype_name=float32)]
+  - tests/test_common.py::test_estimators[PCA()-check_array_api_input(array_namespace=numpy,device_name=None,dtype_name=None)]
+  - tests/test_common.py::test_estimators[PCA()-check_array_api_same_namespace(array_namespace=array_api_strict)]
+
   # sklearnex PCA always chooses "covariance_eigh" solver instead of "full" when solver="auto"
   # resulting in solver assignment check failure for sklearn version >= 1.5
   - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-400-full] >=1.5


### PR DESCRIPTION
## Description

Deselects four PCA array_api checks that intermittently trigger a false-positive warning in the nightly Python conformance job (with Scikit-learn 1.9.0, CPU, both Linux and Windows). The result of these tests was an inconsistent XPASS/XFAIL that occasionally led to the private CI conformance logic failing the test. Further analysis via Claude:

Root cause
----------
- sklearn upstream marks check_array_api_input for PCA as xfail with the reason
  "linalg.inv fails because input is singular" (gh-33205).
- The check's fixture is make_classification(n_samples=30, n_features=10,
  random_state=42). PCA keeps all 10 components -> noise_variance_ = 0 ->
  get_precision() inverts the covariance directly (decomposition/_base.py, via
  score -> score_samples). That covariance is numerically singular (det ~ 1.7e-15,
  one eigenvalue ~ -9.4e-8, cond ~ 3e8 in float32).
- Whether SciPy's inv trips its is_singular check and raises LinAlgError sits on a
  floating-point rounding edge, dependent on the BLAS/MKL backend - so the check
  XPASSes or XFAILs unpredictably.

Why it's sporadic
-----------------
The patched and stock suites run as separate processes, each flipping XPASS/XFAIL
independently on this edge case. The same three PCA tests actually mismatch on
nearly every build (the diff artifact is uploaded ~8/9 recent nightlies), but the
comparator only warns when the two independent flips leave sklearnex with strictly
fewer xpassed than stock. Confirmed identical on 7/14, 7/19, 7/21 (Linux), 7/27;
and confirmed green on 7/23, 7/25 where sklearnex happened to land on the
equal-or-better side.

Why deselect rather than fix
----------------------------
These parametrizations carry no conformance signal: they exercise a degenerate
rank-deficient input that upstream itself xfails, and healthy PCA array_api
coverage (test_pca_array_api_compliance, covariance_eigh) is unaffected.
Deselecting from both runs removes the case from the comparison so it can't churn.
Risk: a genuine sklearnex regression confined to this exact singular case would go
uncaught here - near-zero given the degenerate fixture and remaining coverage.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
