### PR TITLE
DOC: Document thread-safety issues in KNN

### DIFF
--- a/doc/sources/parallelism.rst
+++ b/doc/sources/parallelism.rst
@@ -51,6 +51,44 @@ When |sklearn|'s utilities with built-in parallelism are used
 If ``n_jobs`` is not specified for underlying estimator(s), |sklearnex| sets it to the number of available threads
 (usually the number of logical CPUs divided by `n_jobs` set for higher-level parallelized entities).
 
+Python threads and thread safety
+================================
+
+In general, accelerated computations offered by estimators from the |sklearnex|
+do not raise the Python GIL, thus they are not compatible with parallelization
+backends that rely on Python threads. Instead, process-based parallelism is
+recommended, which is the default mode in tools like :mod:`joblib` and by
+extension in metaestimators from |sklearn|. Note that builds of the |sklearnex| for
+free-threaded Python are not offered at this moment.
+
+Besides GIL usage in the |sklearnex|, there are other considerations with concurrent
+usage in Python threads, even if running under the Python GIL:
+
+- Internally, the number of threads for calls to estimator methods from
+  the |sklearnex| is managed through global variables - thus, if multiple
+  calls to estimators with different ``n_jobs`` are performed in parallel
+  through **Python threads**, there might be threading races that override
+  one another's configuration, potentially leading to process-wide crashes.
+- The patched classes :obj:`sklearn.linear_model.LogisticRegression` and
+  :obj:`sklearn.linear_model.LogisticRegressionCV` in particular are not
+  suitable for parallel calls in Python threads regardless of the ``n_jobs``
+  parameter due to usage of other Python-level global state variables.
+  Attempting to fit multiple logistic regression estimator objects in parallel
+  might result in crashes and incorrect estimations.
+- Patched classes that rely on K-nearest neighbors set their internal state
+  during calls to methods other than ``.fit()`` - hence, if calling methods
+  on the **same** estimator instance from multiple threads, they might override
+  one another when setting variables, leading to incorrect results and potential
+  crashes. These classes include:
+
+    - :obj:`sklearn.neighbors.NearestNeighbors`.
+    - :obj:`sklearn.neighbors.KNeighborsRegressor`.
+    - :obj:`sklearn.neighbors.KNeighborsClassifier`.
+    - :obj:`sklearn.neighbors.LocalOutlierFactor`.
+
+Other considerations
+====================
+
 .. note::
     Environment variables such as `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, and others used by
     low-level parallelism libraries do not affect |sklearnex|, nor does the 
@@ -60,39 +98,19 @@ If ``n_jobs`` is not specified for underlying estimator(s), |sklearnex| sets it 
     ``n_jobs`` has no effect if computations are performed on GPU.
 
 .. note::
-    `threadpoolctl` context has no effect on |sklearnex| threading if `n_jobs` is specified and non-negative.
-    If `n_jobs` is equal to `0` or not specified then the number from `threadpoolctl` is propagated to |sklearnex|.
-    If `n_jobs` is negative then the `threadpoolctl`'s number will be `max(1, n_threadpoolctl + n_jobs + 1)`.
+    ``threadpoolctl`` context has no effect on |sklearnex| threading if ``n_jobs`` is specified and non-negative.
+    If ``n_jobs`` is equal to `0` or not specified then the number from ``threadpoolctl`` is propagated to |sklearnex|.
+    If ``n_jobs`` is negative then the ``threadpoolctl``'s number will be ``max(1, n_threadpoolctl + n_jobs + 1)``.
 
 .. note::
-    |sklearnex| threading doesn't automatically avoid nested parallelism when used in conjunction with OpenMP and/or python threads.
+    |sklearnex| threading doesn't automatically avoid nested parallelism when used in conjunction with OpenMP and/or Python threads.
 
 .. warning::
     If several instances of |sklearnex| algorithms are run sequentially and the ``n_jobs`` parameter for the first run
     is significantly greater than for subsequent ones, it may result in performance degradation due to a known issue
     with `oneTBB <https://github.com/uxlfoundation/oneTBB>`__.
 
-.. warning::
-    In general, accelerated computations offered by estimators from the |sklearnex|
-    do not raise the Python GIL, thus they are not compatible with multi-threading
-    backends that rely on Python threads.
 
-.. warning::
-    Internally, the number of threads for calls to estimator methods from
-    the |sklearnex| is managed through global variables - thus, if multiple
-    calls to estimators with different ``n_jobs`` are performed in parallel
-    through **Python threads**, there might be threading races that override
-    one another's configuration, potentially leading to process-wide crashes.
-    If concurrent calls are to be performed, process-based parallelism should
-    be used instead.
-
-.. warning::
-    The patched classes :obj:`sklearn.linear_model.LogisticRegression` and
-    :obj:`sklearn.linear_model.LogisticRegressionCV` in particular are not
-    suitable for parallel calls in Python threads regardless of the ``n_jobs`` parameter.
-    Attempting to fit multiple logistic regression estimator objects in parallel
-    might result in crashes and incorrect estimations.
-
-Setting the `DEBUG` :ref:`verbosity setting <verbose>` will produce logs
+Setting the ``DEBUG`` :ref:`verbosity setting <verbose>` will produce logs
 indicating when the number of threads used is different from the default
 (number of logical threads in the machine).

--- a/doc/sources/parallelism.rst
+++ b/doc/sources/parallelism.rst
@@ -75,11 +75,14 @@ usage in Python threads, even if running under the Python GIL:
   parameter due to usage of other Python-level global state variables.
   Attempting to fit multiple logistic regression estimator objects in parallel
   might result in crashes and incorrect estimations.
-- Patched classes that rely on K-nearest neighbors set their internal state
-  during calls to methods other than ``.fit()`` - hence, if calling methods
-  on the **same** estimator instance from multiple threads, they might override
-  one another when setting variables, leading to incorrect results and potential
-  crashes. These classes include:
+- While most estimators only set their attributes and internal state during
+  calls to ``.fit()`` and then use them without modifications in ``.predict()``
+  and similar, estimators based on K-nearest neighbors instead set their
+  attributes / state also during calls to methods like ``.transform()`` - hence,
+  when it comes to KNN-based classes, if calling methods on the **same** estimator
+  instance from multiple threads, they might override one another when setting
+  variables, leading to incorrect results and potential crashes. These classes
+  include:
 
     - :obj:`sklearn.neighbors.NearestNeighbors`.
     - :obj:`sklearn.neighbors.KNeighborsRegressor`.


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Documents thread-safety issues in KNN estimators, and refactors a bit the doc page for Python threads to make the information clearer.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
